### PR TITLE
Move config/settings.toml out of version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.cargo
+/config/settings.toml

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Note: leaving the `level=""` empty in the config would load a flat boring debug 
 ```bash
 git clone https://github.com/kvark/vange-rs
 cd vange-rs
+cp config/settings.template.toml config/settings.toml
 vi config/settings.toml # set the game path
 cargo run --bin road
 ```

--- a/config/settings.template.toml
+++ b/config/settings.template.toml
@@ -1,10 +1,12 @@
-data_path = "/opt/gog/Vangers/game" #Linux (example)
+#data_path = "/opt/gog/Vangers/game" #Linux (example)
 #data_path = "/Applications/GOG/Vangers.app/Contents/Resources/game" #OSX
 
 [game]
 level = "Fostral"
 cycle = "Plump-up"
-other_vangers = 10
+#level = "Xplo"
+#cycle = "" #Leave empty for bonus worlds
+other_vangers = 10 #Number of NPC vangers
 
 [car]
 id = "OxidizeMonk"


### PR DESCRIPTION
*[#31 reopened]*
As said in #28 i suppose to move `config/settings.toml` out of git, because local copy of repo may have different settings. Instead of settings.toml it would be nice to have `settings.template.toml` as a template settings file. User should copy template settings to actual one after cloning the repository - `cp config/settings.template.toml config/settings.toml`.
fixes #28