### PR TITLE
Convert module expansion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ path = "bin/level/main.rs"
 
 [[bin]]
 name = "convert"
-path = "bin/convert.rs"
+path = "bin/convert/main.rs"
 
 [dependencies]
 # internals

--- a/README.md
+++ b/README.md
@@ -69,41 +69,52 @@ Controls:
 
 Note: the destination path is always to a file that gets created or overwritten!
 
-#### Model (M3D) -> OBJ+RON
+#### Model (M3D) <-> OBJ+RON
 ```bash
-cargo run --bin convert -- resource/m3d/items/i21.m3d my_dir/model.ron
+cargo run --bin convert -- game/resource/m3d/items/i21.m3d my_dir/model.ron
 ```
 The body, wheels, and debris are saved as separate Wavefront OBJ files near the target [RON](https://github.com/ron-rs/ron), which contains model meta-data.
 
-#### OBJ+RON -> Model(M3D)
 You can change the OBJ files using popular mesh editors, save them, and even manually tweak RON, after which you may want to generate a new M3D file:
 ```bash
-cargo run --bin convert -- my_dir/model.ron resource/m3d/items/i21-new.m3d
+cargo run --bin convert -- my_dir/model.ron game/resource/m3d/items/i21-new.m3d
 ```
 
 <img alt="modified model" src="etc/shots/Road14-import-model.png" width="50%">
 
-#### Level(INI+VMC/VMP) -> Image(BMP/PNG/TGA)
+#### Level(INI+VMC/VMP) <-> PNG+RON
 ```bash
-cargo run --bin convert --release -- thechain/fostral/world.ini my_dir/fostral.png
+cargo run --bin convert --release -- game/thechain/fostral/world.ini my_dir/fostral.ron
 ```
 
-The output image contains the following info in the RGBA channels:
+The RON file contains the size and names of two images: heights and materials. The former conains the following data:
   - R stands for the bottom layer height
   - G stands for the top layer height
   - B stands for the delta between the bottom and the ground above
-  - low 4 bits of A contain the material index of the bottom layer
-  - high 4 bits of A contain the material index of the top layer
 
-#### Image(BMP/PNG/TGA)+INI -> Level(VMP/VMC)
-You can change the image in a photo editor, and then we can import it as a non-compressed level:
+The materials image only uses two channels:
+  - R contains the index of the bottom layer material in its higher 4 bits. The lower 4 bits are ignored.
+  - G contains the index of the top layer
+
+You can change the images in a photo editor, and then we can import it as a non-compressed level:
 ```bash
-cargo run --bin convert --release -- my_dir/fostral.png thechain/fostral/output.vmp
+cargo run --bin convert --release -- my_dir/fostral.ron game/thechain/fostral/output.vmp
 ```
 
 <img alt="modified level" src="etc/shots/Road15-import-level.png" width="50%">
 
 Note: one can easily turn a non-compressed level file (VMP) into a pseudo-compressed one (VMC) by prepending the unzipped `etc/vmc-header.zip` file.
+
+#### PAL <-> PNG
+
+Palette files are really simple one-dimensional arrays of 256 colors. They ca be converted to PNG with the following command:
+```bash
+cargo run --bin convert -- game/thechain/fostral/harmony.pal my_dir/harmony.png
+```
+The image can be edited and then converted back to a palette:
+```bash
+cargo run --bin convert -- my_dir/harmony.png my_dir/harmony-new.pal
+```
 
 ## Technonolgy
 

--- a/bin/convert/level_png.rs
+++ b/bin/convert/level_png.rs
@@ -13,7 +13,7 @@ struct MultiPng {
     material: String,
 }
 
-pub fn save_multi_png(path: &PathBuf, layers: LevelLayers) {
+pub fn save(path: &PathBuf, layers: LevelLayers) {
     use png::Parameter;
     use std::io::Write;
 
@@ -63,7 +63,7 @@ pub fn save_multi_png(path: &PathBuf, layers: LevelLayers) {
     }
 }
 
-pub fn load_multi_png(path: &PathBuf) -> LevelLayers {
+pub fn load(path: &PathBuf) -> LevelLayers {
     let level_file = File::open(path).unwrap();
     let mp = ron::de::from_reader::<_, MultiPng>(level_file).unwrap();
     let mut layers = LevelLayers::new(mp.size);

--- a/bin/convert/level_png.rs
+++ b/bin/convert/level_png.rs
@@ -1,0 +1,113 @@
+use vangers::level::LevelLayers;
+
+use ron;
+
+use std::fs::File;
+use std::path::PathBuf;
+
+
+#[derive(Serialize, Deserialize)]
+struct MultiPng {
+    size: (u32, u32),
+    height: String,
+    material: String,
+}
+
+pub fn save_multi_png(path: &PathBuf, layers: LevelLayers) {
+    use png::Parameter;
+    use std::io::Write;
+
+    let mp = MultiPng {
+        size: layers.size,
+        height: "height.png".to_string(),
+        material: "material.png".to_string(),
+    };
+    let string = ron::ser::to_string_pretty(&mp, ron::ser::PrettyConfig::default()).unwrap();
+    let mut level_file = File::create(path).unwrap();
+    write!(level_file, "{}", string).unwrap();
+    let mut data = Vec::with_capacity(3 * (layers.size.0 as usize) * layers.size.1 as usize);
+
+    {
+        println!("\t\t{}...", mp.height);
+        let file = File::create(path.with_file_name(mp.height)).unwrap();
+        let mut encoder = png::Encoder::new(file, layers.size.0 as u32, layers.size.1 as u32);
+        png::ColorType::RGB.set_param(&mut encoder);
+        data.clear();
+        for ((&h0, &h1), &delta) in layers.het0
+            .iter()
+            .zip(&layers.het1)
+            .zip(&layers.delta)
+        {
+            data.extend_from_slice(&[h0, h1, delta]);
+        }
+        encoder
+            .write_header()
+            .unwrap()
+            .write_image_data(&data)
+            .unwrap();
+    }
+    {
+        println!("\t\t{}...", mp.material);
+        let file = File::create(path.with_file_name(mp.material)).unwrap();
+        let mut encoder = png::Encoder::new(file, layers.size.0 as u32, layers.size.1 as u32);
+        png::ColorType::RGB.set_param(&mut encoder);
+        data.clear();
+        for (&m0, &m1) in layers.mat0.iter().zip(&layers.mat1) {
+            data.extend_from_slice(&[m0 << 4, m1 << 4, 0, m0 & 0xF0, m1 & 0xF0, 0]);
+        }
+        encoder
+            .write_header()
+            .unwrap()
+            .write_image_data(&data)
+            .unwrap();
+    }
+}
+
+pub fn load_multi_png(path: &PathBuf) -> LevelLayers {
+    let level_file = File::open(path).unwrap();
+    let mp = ron::de::from_reader::<_, MultiPng>(level_file).unwrap();
+    let mut layers = LevelLayers::new(mp.size);
+    {
+        println!("\t\t{}...", mp.height);
+        let file = File::open(path.with_file_name(mp.height)).unwrap();
+        let decoder = png::Decoder::new(file);
+        let (info, mut reader) = decoder.read_info().unwrap();
+        assert_eq!((info.width, info.height), mp.size);
+        let stride = match info.color_type {
+            png::ColorType::RGB => 3,
+            png::ColorType::RGBA => 4,
+            _ => panic!("non-RGB image provided"),
+        };
+        let mut data = vec![0u8; stride * (layers.size.0 as usize) * (layers.size.1 as usize)];
+        assert_eq!(info.bit_depth, png::BitDepth::Eight);
+        assert_eq!(info.buffer_size(), data.len());
+        reader.next_frame(&mut data).unwrap();
+        for chunk in data.chunks(stride) {
+            layers.het0.push(chunk[0]);
+            layers.het1.push(chunk[1]);
+            layers.delta.push(chunk[2]);
+        }
+    }
+    {
+        println!("\t\t{}...", mp.material);
+        let file = File::open(path.with_file_name(mp.material)).unwrap();
+        let decoder = png::Decoder::new(file);
+        let (info, mut reader) = decoder.read_info().unwrap();
+        assert_eq!((info.width, info.height), mp.size);
+        let stride = match info.color_type {
+            png::ColorType::RGB => 3,
+            png::ColorType::RGBA => 4,
+            _ => panic!("non-RGB image provided"),
+        };
+        let mut data = vec![0u8; stride * (layers.size.0 as usize) * (layers.size.1 as usize)];
+        assert_eq!(info.bit_depth, png::BitDepth::Eight);
+        assert_eq!(info.buffer_size(), data.len());
+        reader.next_frame(&mut data).unwrap();
+        for chunk in data.chunks(stride + stride) {
+            layers.mat0.push((chunk[0] >> 4) | chunk[0 + stride]);
+            layers.mat1.push((chunk[1] >> 4) | chunk[1 + stride]);
+        }
+    }
+
+    layers
+}

--- a/bin/convert/main.rs
+++ b/bin/convert/main.rs
@@ -10,6 +10,7 @@ extern crate tiff;
 extern crate vangers;
 
 mod level_png;
+mod model_obj;
 
 
 use std::io::BufWriter;
@@ -104,11 +105,11 @@ fn main() {
             println!("\tLoading M3D...");
             let raw = m3d::FullModel::load(file);
             println!("\tExporting OBJ data...");
-            raw.export_obj(&dst_path);
+            model_obj::export(raw, &dst_path);
         }
         ("ron", "md3") => {
             println!("\tImporting OBJ data...");
-            let model = m3d::FullModel::import_obj(&src_path);
+            let model = model_obj::import(&src_path);
             println!("\tSaving M3D...");
             model.save(File::create(&dst_path).unwrap());
         }
@@ -129,7 +130,7 @@ fn main() {
             let config = vangers::level::LevelConfig::load(&src_path);
             let layers = vangers::level::load_layers(&config);
             println!("\tSaving multiple PNGs...");
-            level_png::save_multi_png(&dst_path, layers);
+            level_png::save(&dst_path, layers);
         }
         ("ini", "tiff") => {
             println!("\tLoading the level...");
@@ -157,7 +158,7 @@ fn main() {
         }
         ("ron", "vmp") => {
             println!("\tLoading multiple PNGs...");
-            let layers = level_png::load_multi_png(&src_path);
+            let layers = level_png::load(&src_path);
             println!("\tSaving VMP...");
             let level = vangers::level::LevelData::import_layers(layers);
             level.save_vmp(&dst_path);

--- a/bin/convert/model_obj.rs
+++ b/bin/convert/model_obj.rs
@@ -1,0 +1,105 @@
+use m3d::{CollisionQuad, DrawTriangle, Geometry, FullModel, Mesh, Model, Slot, Debrie};
+
+use ron;
+
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+type RefModel = Model<Mesh<String>, Mesh<String>>;
+
+
+pub fn export(full: FullModel, model_path: &PathBuf) {
+    const BODY_PATH: &str = "body.obj";
+    const SHAPE_PATH: &str = "body-shape.obj";
+
+    let dir_path = model_path.parent().unwrap();
+
+    let model = RefModel {
+        body: full.body.map(|geom| {
+            geom.save_obj(dir_path.join(BODY_PATH))
+                .unwrap();
+            BODY_PATH.to_string()
+        }),
+        shape: full.shape.map(|geom| {
+            geom.save_obj(dir_path.join(SHAPE_PATH))
+                .unwrap();
+            SHAPE_PATH.to_string()
+        }),
+        dimensions: full.dimensions,
+        max_radius: full.max_radius,
+        color: full.color,
+        wheels: full.wheels
+            .into_iter()
+            .enumerate()
+            .map(|(i, wheel)| {
+                wheel.map(|mesh| {
+                    mesh.map(|geom| {
+                        let name = format!("wheel{}.obj", i);
+                        geom.save_obj(dir_path.join(&name)).unwrap();
+                        name
+                    })
+                })
+            })
+            .collect(),
+        debris: full.debris
+            .into_iter()
+            .enumerate()
+            .map(|(i, debrie)| Debrie {
+                mesh: debrie.mesh.map(|geom| {
+                    let name = format!("debrie{}.obj", i);
+                    geom.save_obj(dir_path.join(&name)).unwrap();
+                    name
+                }),
+                shape: debrie.shape.map(|geom| {
+                    let name = format!("debrie{}-shape.obj", i);
+                    geom.save_obj(dir_path.join(&name)).unwrap();
+                    name
+                }),
+            })
+            .collect(),
+        slots: Slot::map_all(full.slots, |mesh, i| {
+            mesh.map(|geom| {
+                let name = format!("slot{}.obj", i);
+                geom.save_obj(dir_path.join(&name)).unwrap();
+                name
+            })
+        }),
+    };
+
+    let string = ron::ser::to_string_pretty(&model, ron::ser::PrettyConfig::default()).unwrap();
+    let mut model_file = File::create(model_path).unwrap();
+    write!(model_file, "{}", string).unwrap();
+}
+
+pub fn import(model_path: &PathBuf) -> FullModel {
+    let dir_path = model_path.parent().unwrap();
+    let model_file = File::open(model_path).unwrap();
+    let model = ron::de::from_reader::<_, RefModel>(model_file).unwrap();
+
+    let resolve_geom_draw = |name| -> Geometry<DrawTriangle> { Geometry::load_obj(dir_path.join(name)) };
+    let resolve_geom_coll = |name| -> Geometry<CollisionQuad> { Geometry::load_obj(dir_path.join(name)) };
+    let resolve_mesh = |mesh: Mesh<String>| { mesh.map(&resolve_geom_draw) };
+
+    FullModel {
+        body: model.body.map(&resolve_geom_draw),
+        shape: model.shape.map(&resolve_geom_coll),
+        dimensions: model.dimensions,
+        max_radius: model.max_radius,
+        color: model.color,
+        wheels: model.wheels
+            .into_iter()
+            .map(|wheel| wheel.map(&resolve_mesh))
+            .collect(),
+        debris: model.debris
+            .into_iter()
+            .map(|debrie| Debrie {
+                mesh: debrie.mesh.map(&resolve_geom_draw),
+                shape: debrie.shape.map(&resolve_geom_coll),
+            })
+            .collect(),
+        slots: Slot::map_all(model.slots, |mesh, _| {
+            resolve_mesh(mesh)
+        }),
+    }
+}


### PR DESCRIPTION
Main purpose here is to grow the `convert` from a crude hack to a full-featured converter with its own submodules.

## Palette conversion

Palette files are really simple one-dimensional arrays of 256 colors. They ca be converted to PNG with the following command:
```bash
cargo run --bin convert -- game/thechain/fostral/harmony.pal my_dir/harmony.png
```
The image can be edited and then converted back to a palette:
```bash
cargo run --bin convert -- my_dir/harmony.png my_dir/harmony-new.pal
```
