### PR TITLE
Refactor input iteration in Splay

### DIFF
--- a/lib/splay/benches/level.rs
+++ b/lib/splay/benches/level.rs
@@ -4,35 +4,35 @@ extern crate byteorder;
 extern crate test;
 extern crate splay;
 
-use std::io::{Read, Seek, SeekFrom, Cursor};
+use std::io::{Read, Seek};
 use std::fs::File;
 use byteorder::{LittleEndian as E, ReadBytesExt};
 
-const VMC_PATH: &'static str = "/mnt/data/gog/Vangers/game/thechain/fostral/output.vmc";
+const VMC_PATH: &'static str = "/hub/gog/Vangers/game/thechain/fostral/output.vmc";
 const SIZE: [usize; 2] = [1<<11, 1<<14];
 
 
 #[bench]
 fn load_level(bench: &mut test::Bencher) {
     let mut file = File::open(VMC_PATH).unwrap();
-    let table: Vec<_> = (0 .. SIZE[1]).map(|_| {
-        let offset = file.read_i32::<E>().unwrap();
-        file.read_i16::<E>().unwrap();
-        offset
-    }).collect();
+    let table: Vec<_> = (0 .. SIZE[1])
+        .map(|_| {
+            let offset = file.read_i32::<E>().unwrap();
+            let size = file.read_i16::<E>().unwrap();
+            (offset, size)
+        }).collect();
 
     let splay = splay::Splay::new(&mut file);
     let mut height = vec![0u8; SIZE[0]];
     let mut meta = vec![0u8; SIZE[0]];
-    let base = file.seek(std::io::SeekFrom::Current(0)).unwrap();
+    let data_offset = file.seek(std::io::SeekFrom::Current(0)).unwrap();
     let mut buffer = Vec::new();
     file.read_to_end(&mut buffer).unwrap();
 
     bench.iter(|| {
-        let mut cursor = Cursor::new(&mut buffer);
-        for &offset in table[..0x100].iter() {
-            cursor.seek(SeekFrom::Start(offset as u64 - base)).unwrap();
-            splay.expand(&mut cursor, &mut height, &mut meta);
+        for &(offset, size) in table[..0x100].iter() {
+            let off = offset as usize - data_offset as usize;
+            splay.expand(&buffer[off .. off + size as usize], &mut height, &mut meta);
         }
     });
 }


### PR DESCRIPTION
Basically, work with `&[u8]` input instead of advancing through a (buffered) input file. This is an innocently looking change that has some interesting effect on the loading performance:

- Benchmark score: 10.880 iter/s -> 10.060 iter/s (slower by ~7%)
- Level app loading in debug: 8600ms -> 960ms (faster by ~9 times (!))
- Level app loading in release: 255ms -> 150ms (faster by > 40%)

TL;DR: be careful with benchmarks! the problem with it was that the benchmark loaded the whole file in memory before testing, since it needs to run multiple times. This aspect steered the actual results away from the main bottleneck of the use case: file I/O.

With this in, a sub-second loading is totally manageable during development, it's no longer a concern.

Fixes #17 