### PR TITLE
Fix flood map texture size

### DIFF
--- a/data/shader/color.inc.glsl
+++ b/data/shader/color.inc.glsl
@@ -6,7 +6,7 @@ uniform usampler1D t_Table;
 // corresponds to SDL palette
 uniform sampler1D t_Palette;
 // Flood map has the water level per Y.
-uniform sampler1D t_Flood;
+uniform sampler1DArray t_Flood;
 
 const float c_HorFactor = 0.5; //H_CORRECTION
 const float c_DiffuseScale = 8.0;
@@ -29,7 +29,7 @@ float evaluate_palette(uint type, float value, float ycoord) {
     if (type == 0U && value > 0.0) { // water
         //TODO: apparently, the flood map data isn't correct...
         //float flood = texture(t_Flood, ycoord).x;
-        float flood = texelFetch(t_Flood, int(0), 0).x;
+        float flood = texelFetch(t_Flood, ivec2(0, 0), 0).x;
         float d = c_HorFactor * (1.0 - flood);
         value = clamp(value * 1.25 / (1.0 - d) - 0.25, 0.0, 1.0);
     }

--- a/src/level/mod.rs
+++ b/src/level/mod.rs
@@ -25,6 +25,7 @@ pub const HEIGHT_SCALE: u32 = 255;
 pub struct Level {
     pub size: (i32, i32),
     pub flood_map: Vec<u8>,
+    pub flood_section_power: usize,
     pub height: Vec<u8>,
     pub meta: Vec<u8>,
     pub palette: [[u8; 4]; 0x100],
@@ -84,6 +85,7 @@ impl Level {
         Level {
             size: (2, 1),
             flood_map: vec![0],
+            flood_section_power: 0,
             height: vec![0, 0],
             meta: vec![0, 0],
             palette: [[0xFF; 4]; 0x100],
@@ -495,6 +497,7 @@ pub fn load(config: &LevelConfig) -> Level {
     Level {
         size,
         flood_map,
+        flood_section_power: config.section.as_power() as usize,
         height,
         meta,
         palette: read_palette(palette, Some(&config.terrains)),

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -285,13 +285,15 @@ pub fn init<R: gfx::Resources, F: gfx::Factory<R>>(
         num_layers as tex::Size,
         tex::AaMode::Single,
     );
-    let height_chunks: Vec<_> = level
-        .height
+    let height_chunks: Vec<_> = level.height
         .chunks((level.size.0 * real_height) as usize)
         .collect();
-    let meta_chunks: Vec<_> = level
-        .meta
+    let meta_chunks: Vec<_> = level.meta
         .chunks((level.size.0 * real_height) as usize)
+        .collect();
+    let flood_height = real_height >> level.flood_section_power;
+    let flood_chunks: Vec<_> = level.flood_map
+        .chunks(flood_height as usize)
         .collect();
 
     let (_, height) = factory
@@ -302,9 +304,9 @@ pub fn init<R: gfx::Resources, F: gfx::Factory<R>>(
         .unwrap();
     let (_, flood) = factory
         .create_texture_immutable::<(format::R8, format::Unorm)>(
-            tex::Kind::D1(level.size.1 as _),
+            tex::Kind::D1Array(flood_height as _, num_layers as _),
             tex::Mipmap::Provided,
-            &[&level.flood_map],
+            &flood_chunks,
         ).unwrap();
     let (_, table) = factory
         .create_texture_immutable::<(format::R8_G8_B8_A8, format::Uint)>(


### PR DESCRIPTION
Previously, we created wrong-size texture and didn't layer it.