### PR TITLE
Don't create SRVs of the height for mipmapping

### DIFF
--- a/data/shader/color.inc.glsl
+++ b/data/shader/color.inc.glsl
@@ -37,8 +37,8 @@ float evaluate_palette(uint type, float value, float ycoord) {
 
 vec4 evaluate_color(uint type, vec3 tex_coord, float height_normalized, float lit_factor) {
     float diff =
-        textureOffset(t_Height, tex_coord, ivec2(1, 0)).x -
-        textureOffset(t_Height, tex_coord, ivec2(-1, 0)).x;
+        textureLodOffset(t_Height, tex_coord, 0.0, ivec2(1, 0)).x -
+        textureLodOffset(t_Height, tex_coord, 0.0, ivec2(-1, 0)).x;
     vec3 mat = type == 0U ? vec3(5.0, 1.25, 0.5) : vec3(1.0);
     float light_clr = evaluate_light(mat, diff);
     float tmp = light_clr - c_HorFactor * (1.0 - height_normalized);

--- a/data/shader/surface.inc.glsl
+++ b/data/shader/surface.inc.glsl
@@ -87,14 +87,14 @@ Surface get_surface(vec2 pos) {
         }
 
         suf.low_alt =
-            textureOffset(t_Height, suf.tex_coord, ivec2(-1, 0)).x
+            textureLodOffset(t_Height, suf.tex_coord, 0.0, ivec2(-1, 0)).x
             * u_TextureScale.z;
-        suf.high_alt = texture(t_Height, suf.tex_coord).x * u_TextureScale.z;
+        suf.high_alt = textureLod(t_Height, suf.tex_coord, 0.0).x * u_TextureScale.z;
         suf.delta = float(delta) * c_DeltaScale * u_TextureScale.z;
     } else {
         suf.high_type = suf.low_type;
 
-        suf.low_alt = texture(t_Height, tc).x * u_TextureScale.z;
+        suf.low_alt = textureLod(t_Height, tc, 0.0).x * u_TextureScale.z;
         suf.high_alt = suf.low_alt;
         suf.delta = 0.0;
     }

--- a/data/shader/terrain_ray.glsl
+++ b/data/shader/terrain_ray.glsl
@@ -89,11 +89,11 @@ vec3 cast_ray(vec3 point, vec3 dir) {
             float affinity;
             vec2 proximity = mod(cell_id, 2.0) - 0.5;
             if (units.x <= units.y) {
-                ipos.x = cell_tl.x + (dir.x < 0.0 ? -1 : 1 << lod);
+                ipos.x = dir.x < 0.0 ? cell_tl.x - 1 : cell_tl.x + (1 << lod);
                 affinity = dir.x * proximity.x;
             }
             if (units.y <= units.x) {
-                ipos.y = cell_tl.y + (dir.y < 0.0 ? -1 : 1 << lod);
+                ipos.y = dir.y < 0.0 ? cell_tl.y - 1 : cell_tl.y + (1 << lod);
                 affinity = dir.y * proximity.y;
             }
             if (lod < u_Params.x && affinity > 0.0) {


### PR DESCRIPTION
This is a follow-up to #62 that makes it friendly to Macs and older GLs.