### PR TITLE
[WIP] Material filtering

### DIFF
--- a/data/shader/color.inc.glsl
+++ b/data/shader/color.inc.glsl
@@ -27,8 +27,7 @@ float evaluate_palette(uint type, float value, float ycoord) {
     value = clamp(value, 0.0, 1.0);
     vec4 terr = vec4(texelFetch(t_Table, int(type), 0));
     if (type == 0U && value > 0.0) { // water
-        //TODO: apparently, the flood map data isn't correct...
-        float flood = texture(t_Flood, 0.0*ycoord).x;
+        float flood = texture(t_Flood, ycoord).x;
         float d = c_HorFactor * (1.0 - flood);
         value = clamp(value * 1.25 / (1.0 - d) - 0.25, 0.0, 1.0);
     }

--- a/data/shader/color.inc.glsl
+++ b/data/shader/color.inc.glsl
@@ -12,6 +12,9 @@ const float c_HorFactor = 0.5; //H_CORRECTION
 const float c_DiffuseScale = 8.0;
 const float c_ShadowDepthScale = 2.0 / 3.0;
 
+const vec3 c_GroundMaterial = vec3(1.0);
+const vec3 c_WaterMaterial = vec3(5.0, 1.25, 0.5);
+
 // see `RenderPrepare` in `land.cpp` for the original game logic
 
 // material coefficients are called "dx", "sd" and "jj" in the original
@@ -25,12 +28,13 @@ float evaluate_light(vec3 mat, float height_diff) {
 
 float evaluate_palette(uint type, float value, float ycoord) {
     value = clamp(value, 0.0, 1.0);
-    vec4 terr = vec4(texelFetch(t_Table, int(type), 0));
     if (type == 0U && value > 0.0) { // water
         float flood = texture(t_Flood, ycoord).x;
         float d = c_HorFactor * (1.0 - flood);
         value = clamp(value * 1.25 / (1.0 - d) - 0.25, 0.0, 1.0);
     }
+
+    vec4 terr = texelFetch(t_Table, int(type), 0);
     return (mix(terr.z, terr.w, value) + 0.5) / 256.0;
 }
 
@@ -38,9 +42,48 @@ vec4 evaluate_color(uint type, vec3 tex_coord, float height_normalized, float li
     float diff =
         textureLodOffset(t_Height, tex_coord, 0.0, ivec2(1, 0)).x -
         textureLodOffset(t_Height, tex_coord, 0.0, ivec2(-1, 0)).x;
-    vec3 mat = type == 0U ? vec3(5.0, 1.25, 0.5) : vec3(1.0);
+    vec3 mat = type == 0U ? c_WaterMaterial : c_GroundMaterial;
     float light_clr = evaluate_light(mat, diff);
     float tmp = light_clr - c_HorFactor * (1.0 - height_normalized);
     float color_id = evaluate_palette(type, lit_factor * tmp, tex_coord.y);
     return texture(t_Palette, color_id);
+}
+
+// Versions of the same functions but for 2x2 quads, which is useful to do
+// bilinear filtering across different materials
+
+vec4 evaluate_palette4(uvec4 types, vec4 values, float ycoord) {
+    values = clamp(values, 0.0, 1.0);
+    if (dot(values, values) > 0.0) {
+        float flood = texture(t_Flood, ycoord).x;
+        float d = c_HorFactor * (1.0 - flood);
+        vec4 water_values = clamp(values * 1.25 / (1.0 - d) - 0.25, 0.0, 1.0);
+        values = mix(values, water_values, equal(types, uvec4(0U)));
+    }
+
+    vec4 t0 = texelFetch(t_Table, int(types.x), 0);
+    vec4 t1 = texelFetch(t_Table, int(types.y), 0);
+    vec4 t2 = texelFetch(t_Table, int(types.z), 0);
+    vec4 t3 = texelFetch(t_Table, int(types.w), 0);
+    vec4 terr_z = vec4(t0.z, t1.z, t2.z, t3.z);
+    vec4 terr_w = vec4(t0.w, t1.w, t2.w, t3.w);
+
+    return (mix(terr_z, terr_w, values) + 0.5) / 256.0;
+}
+
+mat4 evaluate_color4(uvec4 types, vec3 tex_coord, float height_normalized, vec4 lit_factors) {
+    float diff =
+        textureOffset(t_Height, tex_coord, ivec2(1, 0)).x -
+        textureOffset(t_Height, tex_coord, ivec2(-1, 0)).x;
+    float light_clr_ground = evaluate_light(c_GroundMaterial, diff);
+    float light_clr_water = evaluate_light(c_WaterMaterial, diff);
+    vec4 light_clr = mix(vec4(light_clr_ground), vec4(light_clr_water), equal(types, uvec4(0U)));
+    vec4 tmp = light_clr - c_HorFactor * vec4(1.0 - height_normalized);
+    vec4 color_ids = evaluate_palette4(types, lit_factors * tmp, tex_coord.y);
+    return mat4(
+        texture(t_Palette, color_ids.x),
+        texture(t_Palette, color_ids.y),
+        texture(t_Palette, color_ids.z),
+        texture(t_Palette, color_ids.w)
+    );
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -549,7 +549,7 @@ pub fn init<R: gfx::Resources, F: gfx::Factory<R>>(
     let (terrain, terrain_slice, terrain_data) = {
         let (terrain, vbuf, slice) = match settings.terrain {
             settings::Terrain::RayTracedOld => {
-                let pso = Render::create_terrain_ray_pso(factory, "terrain_ray_old");
+                let pso = Render::create_terrain_ray_pso(factory, "terrain_ray_old", &[]);
                 let vertices = [
                     TerrainVertex { pos: [0., 0., 0., 1.] },
                     TerrainVertex { pos: [-1., 0., 0., 0.] },
@@ -563,7 +563,7 @@ pub fn init<R: gfx::Resources, F: gfx::Factory<R>>(
                 (terr, vbuf, slice)
             }
             settings::Terrain::RayTraced { mip_count, max_jumps, max_steps, debug } => {
-                let pso = Render::create_terrain_ray_pso(factory, "terrain_ray");
+                let pso = Render::create_terrain_ray_pso(factory, "terrain_ray", &[]);
                 let vertices = [
                     TerrainVertex { pos: [0., 0., 0., 1.] },
                     TerrainVertex { pos: [-1., 0., 0., 0.] },
@@ -843,9 +843,9 @@ impl<R: gfx::Resources> Render<R> {
     }
 
     fn create_terrain_ray_pso<F: gfx::Factory<R>>(
-        factory: &mut F, name: &str,
+        factory: &mut F, name: &str, specialization: &[&str]
     ) -> gfx::PipelineState<R, terrain::Meta> {
-        let shaders = read_shaders(name, false, &[])
+        let shaders = read_shaders(name, false, specialization)
             .unwrap();
         let program = factory
             .link_program(&shaders.vs, &shaders.fs)
@@ -918,10 +918,10 @@ impl<R: gfx::Resources> Render<R> {
         info!("Reloading shaders");
         match self.terrain {
             Terrain::RayOld { ref mut pso } => {
-                *pso = Render::create_terrain_ray_pso(factory, "terrain_ray_old");
+                *pso = Render::create_terrain_ray_pso(factory, "terrain_ray_old", &[]);
             }
             Terrain::Ray { ref mut pso, ref mut mipper, .. } => {
-                *pso = Render::create_terrain_ray_pso(factory, "terrain_ray");
+                *pso = Render::create_terrain_ray_pso(factory, "terrain_ray", &[]);
                 mipper.pso = MaxMipper::create_pso(factory);
             }
             Terrain::Tess { ref mut pso_low, ref mut pso_high, screen_space } => {


### PR DESCRIPTION
Fixes #10 

It appears that filtering material alone without the height (see #8) is not producing a good result.
In the areas with no height variation it's more visible, but still not enough to justify the code complexity.
Before:
![vangers-ground-no-filter](https://user-images.githubusercontent.com/107301/50732214-497eb600-1144-11e9-838a-cd1ffa4cba2f.png)
After:
![vangers-ground-filtered](https://user-images.githubusercontent.com/107301/50732215-4b487980-1144-11e9-9466-43707530d387.png)