### PR TITLE
Build configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ rust-ini = "0.10"
 serde = "1.0"
 serde_derive = "1.0"
 serde_scan = "0.1"
+stb_truetype = "=0.2.2"
 # binaries
 env_logger = "0.4"
 getopts = "0.2"

--- a/makefile
+++ b/makefile
@@ -1,0 +1,20 @@
+RUSTC_FLAGS=-C prefer-dynamic
+# May be --release
+CARGO_FLAGS=
+
+# Classic static build
+static: Cargo.toml
+	cargo build ${CARGO_FLAGS}
+
+# Use nightly- toolchain to build dependencies with Rust 2018 edition
+static-nightly:
+	cargo +nightly build ${CARGO_FLAGS}
+
+# Shared build to produce thin binaries
+shared:
+	env RUSTFLAGS="${RUSTC_FLAGS}" cargo build ${CARGO_FLAGS}
+
+# Shared build with nightly toolchain
+shared-nightly:
+	env RUSTFLAGS="${RUSTC_FLAGS}" cargo +nightly build ${CARGO_FLAGS}
+


### PR DESCRIPTION
This is a previously suggested fix for `stb_truetype` dependency using Rust 2018 edition and I also suggest using `makefile` to store cargo invocation options. :)