### PR TITLE
Total wgpu-rs conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
  "serde_scan 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "splay 0.1.0",
  "tiff 0.1.0",
- "wgpu 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wgpu 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1123,16 +1123,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-native 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wgpu-native 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wgpu-native"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1357,8 +1357,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wayland-protocols 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fd94211387fa8ff50df1e4ff7a5529b5a9aebe68ba88acc48e5b7f5fd98f6eef"
 "checksum wayland-scanner 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3611f231e675e15c2feb7623103e6449edc6f10b0598cafb3e16e590a0561355"
 "checksum wayland-sys 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2a69d729a1747a5bf40ae05b94c7904b64fbf2381e365c046d872ce4a34aa826"
-"checksum wgpu 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "faeef261f3ccc3d6524283299937489ab5f6906e01cfcf6fe5b6124af5e718b2"
-"checksum wgpu-native 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e17b66dac851097c5b27d05c9a77dd29b17d3a0f346fff8a471531f86b7c9d85"
+"checksum wgpu 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf01cc350ab760949d04e88d188ae8942fbe5eb9c6059cd029d8708e335838f3"
+"checksum wgpu-native 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "fcb7813e0e5dd1360829f35819be7c46f3a3a0cb34f30f1915b35c74eb93e312"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,20 +5,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "andrew"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "line_drawing 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusttype 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -31,32 +31,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "approx"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "approx"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "backtrace"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "base64"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -70,37 +106,42 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "block-buffer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "byte-tools"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byteorder"
-version = "1.2.6"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.25"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "cgl"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gleam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cgmath"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -109,6 +150,14 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -121,7 +170,7 @@ dependencies = [
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -131,7 +180,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -147,7 +196,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -164,12 +213,12 @@ name = "crossbeam-epoch"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -178,26 +227,24 @@ name = "crossbeam-utils"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "deflate"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "derivative"
-version = "1.0.0"
+name = "digest"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -214,26 +261,46 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "draw_state"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "either"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.4.3"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "failure"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "foreign-types"
@@ -249,18 +316,25 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
+name = "generic-array"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "getopts"
@@ -271,142 +345,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "gfx"
-version = "0.17.1"
+name = "gfx-backend-empty"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "draw_state 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "gfx_core"
-version = "0.8.3"
+name = "gfx-hal"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "draw_state 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "gfx_device_gl"
-version = "0.15.5"
+name = "glsl-to-spirv"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gfx_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_gl 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "gfx_gl"
-version = "0.5.0"
+name = "humantime"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gfx_window_glutin"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gfx_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_device_gl 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gl_generator"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gl_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "gleam"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "glutin"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "inflate"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "itertools"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "khronos_api"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "khronos_api"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "lazy_static"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
-version = "0.2.45"
+version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -414,7 +404,7 @@ name = "libloading"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -437,29 +427,21 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.3.9"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "log"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "m3d"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "ron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ron 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -467,23 +449,20 @@ name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.0.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memmap"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -494,31 +473,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nix"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nix"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nodrop"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -540,23 +519,15 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-traits"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -574,18 +545,10 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "osmesa-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -598,22 +561,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.6.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -633,99 +596,70 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "inflate 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deflate 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.19"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "quote"
-version = "0.3.15"
+name = "quick-error"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand"
-version = "0.3.22"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.2.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand_core"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -733,7 +667,7 @@ name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -741,24 +675,47 @@ name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_pcg"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -766,7 +723,7 @@ name = "rayon"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -776,44 +733,78 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.2.11"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.5.6"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ron"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rust-ini"
 version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -826,26 +817,21 @@ dependencies = [
 
 [[package]]
 name = "rusttype"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "stb_truetype 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stb_truetype 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "safemem"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "same-file"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -868,20 +854,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.79"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.79"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -889,48 +875,46 @@ name = "serde_scan"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "shared_library"
-version = "0.1.9"
+name = "sha2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "smallvec"
-version = "0.6.7"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "andrew 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "andrew 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-protocols 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-protocols 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "splay"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -940,29 +924,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stb_truetype"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.10.8"
+version = "0.15.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "syn"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -970,19 +987,24 @@ name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tiff"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "typenum"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ucd-util"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -992,57 +1014,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "utf8-ranges"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vangers"
 version = "0.1.0"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "cgmath 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cgmath 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_device_gl 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx_window_glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glsl-to-spirv 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "m3d 0.1.0",
  "obj 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "png 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ron 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-ini 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_scan 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "splay 0.1.0",
  "tiff 0.1.0",
+ "wgpu 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "version_check"
-version = "0.1.4"
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1057,59 +1064,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.21.7"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-commons"
-version = "0.21.7"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.21.7"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-commons 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-scanner 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-sys 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-scanner"
-version = "0.21.7"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wayland-sys"
-version = "0.21.7"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wgpu"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wgpu-native 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "wgpu-native"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-backend-empty 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1128,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1140,22 +1174,32 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winit"
-version = "0.18.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "smithay-client-toolkit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smithay-client-toolkit 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wayland-client 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1165,8 +1209,8 @@ name = "x11-dl"
 version = "2.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1177,34 +1221,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "xml-rs"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "xml-rs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
-"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
-"checksum andrew 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "62ea7024f6f4d203bede7c0c9cdafa3cbda3a9e0fa04d349008496cc95b8f11b"
+"checksum aho-corasick 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
+"checksum andrew 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48fb30d9ad567e58e97dfeedcb54c66a6fbdeae3fc869075f5c0a2739dc2d849"
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
-"checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
-"checksum approx 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c57ff1a5b00753647aebbbcf4ea67fa1e711a65ea7a30eb90dbf07de2485aee"
-"checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
-"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+"checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
+"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
-"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
-"checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
-"checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
-"checksum cgl 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "55e7ec0b74fe5897894cbc207092c577e87c52f8a59e8ca8d97ef37551f60a49"
-"checksum cgmath 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d2372c02a7cfabf871ec42ecc968406a7b5916bcfd51defc6a0498fcb19fa2e5"
+"checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
+"checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum cc 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "c9ce8bb087aacff865633f0bd5aeaed910fe2fe55b55f4739527f2e023a2e53d"
+"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+"checksum cgmath 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "283944cdecc44bf0b8dd010ec9af888d3b4f142844fdbe026c20ef68148d6fe7"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+"checksum cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "6ec65ee4f9c9d16f335091d23693457ed4928657ba4982289d7fafee03bc614a"
 "checksum cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf79daa4e11e5def06e55306aa3601b87de6b5149671529318da048f67cdd77b"
 "checksum core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2640d6d0bf22e82bed1b73c6aef8d5dd31e5abe6666c57e6d45e2649f4f887"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
@@ -1212,118 +1254,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
-"checksum deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)" = "32c8120d981901a9970a3a1c97cf8b630e0fa8c3ca31e75b6fd6fd5f9f427b31"
-"checksum derivative 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67b3d6d0e84e53a5bdc263cc59340541877bb541706a191d762bfac6a481bdde"
+"checksum deflate 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)" = "8a6abb26e16e8d419b5c78662aa9f82857c2386a073da266840e474d5055ec86"
+"checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
-"checksum draw_state 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33cf9537e2d06891448799b96d5a8c8083e0e90522a7fdabe6ebf4f41d79d651"
-"checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
-"checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
+"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
+"checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
+"checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+"checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
-"checksum gfx 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7d7ce0c1f747245342a73453fdb098ea0764c430421fbc4d98cdc8ef8ede4834"
-"checksum gfx_core 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c74932837e61f20956c3da1a47471513707dde300274812bba94373ab51830ae"
-"checksum gfx_device_gl 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)" = "def9cc76ab9ae3187a1ef5edb16c263fa7d713319ffa1d46e00c9d348081a982"
-"checksum gfx_gl 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3e8a920f8f6c1025a7ddf9dd25502bf059506fd3cd765dfbe8dba0b56b7eeecb"
-"checksum gfx_window_glutin 0.28.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9762740a3aa4d2c0dc61fca23a4271e4c26586d90d7e904c00e2dd97d775db7f"
-"checksum gl_generator 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0ffaf173cf76c73a73e080366bf556b4776ece104b06961766ff11449f38604"
-"checksum gl_generator 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a795170cbd85b5a7baa58d6d7525cae6a03e486859860c220f7ebbbdd379d0a"
-"checksum gleam 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0d41e7ac812597988fdae31c9baec3c6d35cadb8ad9ab88a9bf9c0f119ed66c2"
-"checksum glutin 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "535c6eda58adbb227604b2db10a022ffd6339d7ea3e970f338e7d98aeb24fcc3"
-"checksum inflate 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6f53b811ee8e2057ccf9643ca6b4277de90efaf5e61e55fd5254576926bb4245"
-"checksum itertools 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4833d6978da405305126af4ac88569b5d71ff758581ce5a987dbfa3755f694fc"
-"checksum khronos_api 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "037ab472c33f67b5fbd3e9163a2645319e5356fcd355efa6d4eb7fff4bbcb554"
-"checksum khronos_api 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "62237e6d326bd5871cd21469323bf096de81f1618cd82cbaf5d87825335aeb49"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
-"checksum libc 0.2.45 (registry+https://github.com/rust-lang/crates.io-index)" = "2d2857ec59fadc0773853c664d2d18e7198e83883e7060b63c924cb077bd5c74"
+"checksum gfx-backend-empty 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "590c15369f88b88e4ea748da52b27a521a758a947b4aee995539c9f0cc1beb4c"
+"checksum gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84c470bce77fcaaea6854858682a99026ff796b880b0ca30511593a6b2bc77c0"
+"checksum glsl-to-spirv 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "28caebc98746d507603a2d3df66dcbe04e41d4febad0320f3eec1ef72b6bbef1"
+"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum line_drawing 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cc7ad3d82c845bdb5dde34ffdcc7a5fb4d2996e1e1ee0f19c33bc80e15196b9"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
-"checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
-"checksum memchr 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3b4142ab8738a78c51896f704f83c11df047ff1bda9a92a661aa6361552d93d"
+"checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
-"checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nix 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "921f61dc817b379d0834e45d5ec45beaacfae97082090a49c2cf30dcbc30206f"
-"checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-iter 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "af3fdbbc3291a5464dc57b03860ec37ca6bf915ed6ee385e7c6c052c422b2124"
-"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
-"checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum obj 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0afb43d620f9ef0c5ca3687f644839eff37c70df6de0058c40986503407a5dc"
 "checksum objc 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "9833ab0efe5361b1e2122a0544a5d3359576911a42cb098c2e59be8650807367"
-"checksum ordered-float 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2f0015e9e8e28ee20c581cfbfe47c650cedeb9ed0721090e0b7ebb10b9cdbcc2"
-"checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
+"checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-"checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
-"checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum png 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "99c43e2159aafbfccf7b1e13f420d028a6b9384c72544ac3b829c14d48dcb002"
-"checksum proc-macro2 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)" = "ffe022fb8c8bd254524b0b3305906c1921fa37a84a644e29079a9e62200c3901"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
-"checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
-"checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
-"checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
-"checksum rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae9d223d52ae411a33cf7e54ec6034ec165df296ccd23533d671a28252b6f66a"
-"checksum rand_chacha 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "771b009e3a508cb67e8823dda454aaa5368c7bc1c16829fb77d3e980440dd34a"
-"checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
-"checksum rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0905b6b7079ec73b314d4c748701f6931eb79fd97c668caa3f1899b22b32c6db"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
+"checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+"checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+"checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+"checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-"checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
-"checksum rand_xorshift 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "effa3fcaa47e18db002bdde6060944b6d2f9cfd8db471c30e873448ad9187be3"
+"checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
+"checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+"checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+"checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rayon 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed02d09394c94ffbdfdc755ad62a132e94c3224a8354e78a1200ced34df12edf"
 "checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
-"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-"checksum ron 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c48677d8a9247a4e0d1f3f9cb4b0a8e29167fdc3c04f383a5e669cd7a960ae0f"
+"checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+"checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f"
+"checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum ron 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "17f52a24414403f81528b67488cf8edc4eda977d3af1646bb6b106a600ead78f"
 "checksum rust-ini 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a654c5bda722c699be6b0fe4c0d90de218928da5b724c3e467fc48865c37263"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rusttype 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "436c67ae0d0d24f14e1177c3ed96780ee16db82b405f0fba1bb80b46c9a30625"
-"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
+"checksum rusttype 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ce3926a2057b315b3e8bca6d1cec1e97f19436a8f9127621cd538cda9c96a38b"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "84257ccd054dc351472528c8587b4de2dbf0dc0fe2e634030c1a90bfdacebaa9"
-"checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
+"checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
+"checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_scan 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a46bde9df7cd825e0753a19b5454e9466d1c062b3b544a716ba032cfe8b5159"
-"checksum shared_library 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
-"checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
-"checksum smithay-client-toolkit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d858330eeed4efaf71c560555e2a6a0597d01b7d52685c3cc964ab1cc360f8c6"
+"checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum smithay-client-toolkit 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4899558362a65589b53313935099835acf999740915e134dff20cca7c6a28b"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum stb_truetype 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71a7d260b43b6129a22dc341be18a231044ca67a48b7e32625f380cc5ec9ad70"
-"checksum syn 0.10.8 (registry+https://github.com/rust-lang/crates.io-index)" = "58fd09df59565db3399efbba34ba8a2fec1307511ebd245d0061ff9d42691673"
-"checksum syn 0.15.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9056ebe7f2d6a38bc63171816fd1d3430da5a43896de21676dc5c0a4b8274a11"
+"checksum stb_truetype 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "69b7df505db8e81d54ff8be4693421e5b543e08214bd8d99eb761fcb4d5668ba"
+"checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
+"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
+"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
-"checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d9d7ed3431229a144296213105a390676cc49c9b6a72bd19f3176c98e129fa1"
-"checksum wayland-client 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "267d642a6e551e5af62a5e4fbfaab299221e6ddbd453b5985cfa84c835887679"
-"checksum wayland-commons 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "da95f98e6b8222cb0f248811ecd69ba6ebe243b737fd34020f7c73665bb4a3af"
-"checksum wayland-protocols 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1d20e951995113cdb8f32578c8402e619aa3d3e894f3ca334deb219abc1f6df"
-"checksum wayland-scanner 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4f17846a40a19f7917f11c18a6c8c3b3a34b3ba09cb200d3e03503ebdfcbf3a7"
-"checksum wayland-sys 0.21.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a0931c24c91e4e56c1119e4137e237df2ccc3696df94f64b1e2f61982d89cc32"
+"checksum wayland-client 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "96041810afa07e7953867d46f8f03c41cbca49ebd1e840eef6abefde8b458b30"
+"checksum wayland-commons 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "92af0c5dc724c049e9bd927f8563d9a6abaa94893c5305ef0a6d2805e661f3d3"
+"checksum wayland-protocols 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fd94211387fa8ff50df1e4ff7a5529b5a9aebe68ba88acc48e5b7f5fd98f6eef"
+"checksum wayland-scanner 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3611f231e675e15c2feb7623103e6449edc6f10b0598cafb3e16e590a0561355"
+"checksum wayland-sys 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2a69d729a1747a5bf40ae05b94c7904b64fbf2381e365c046d872ce4a34aa826"
+"checksum wgpu 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "faeef261f3ccc3d6524283299937489ab5f6906e01cfcf6fe5b6124af5e718b2"
+"checksum wgpu-native 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e17b66dac851097c5b27d05c9a77dd29b17d3a0f346fff8a471531f86b7c9d85"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "27aa86a5723951d6a08c2acb9f10e25cb39ceb5b1987d7daf74e181b21f8f50b"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
+"checksum winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c57c15bd4c0ef18dff33e263e452abe32d00e2e05771cacaa410a14cc1c0776"
 "checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
-"checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,6 @@ members = [
 
 [features]
 default = []
-gfx-vulkan = ["wgpu/vulkan"]
-gfx-dx12 = ["wgpu/dx12"]
-gfx-dx11 = ["wgpu/dx11"]
-gfx-metal = ["wgpu/metal"]
 
 [[bin]]
 name = "road"
@@ -58,6 +54,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_scan = "0.1"
 #wgpu = { github = "https://github.com/gfx-rs/wgpu", features = ["local"] }
+#wgpu = { path = "../wgpu/wgpu-rs" }
 wgpu = { version = "0.2" }
 # binaries
 env_logger = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ members = [
 
 [features]
 default = []
+gfx-vulkan = ["wgpu/vulkan"]
+gfx-dx12 = ["wgpu/dx12"]
+gfx-dx11 = ["wgpu/dx11"]
+gfx-metal = ["wgpu/metal"]
 
 [[bin]]
 name = "road"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vangers"
 version = "0.1.0"
 authors = ["kvark"]
+edition = "2018"
 
 [workspace]
 members = [
@@ -11,6 +12,9 @@ members = [
 ]
 
 [lib]
+
+[features]
+default = []
 
 [[bin]]
 name = "road"
@@ -39,8 +43,8 @@ splay = { path = "lib/splay" }
 tiff = { path = "lib/tiff" }
 # library
 byteorder = "1.0"
-cgmath = "0.15"
-gfx = "0.17"
+cgmath = "0.17"
+glsl-to-spirv = "0.1"
 log = "0.4"
 rand = "0.6"
 rayon = "0.9"
@@ -49,11 +53,10 @@ rust-ini = "0.10"
 serde = "1.0"
 serde_derive = "1.0"
 serde_scan = "0.1"
+#wgpu = { github = "https://github.com/gfx-rs/wgpu", features = ["local"] }
+wgpu = { version = "0.2" }
 # binaries
-env_logger = "0.4"
+env_logger = "0.5"
 getopts = "0.2"
-gfx_device_gl = "0.15.5"
-gfx_window_glutin = "0.28"
-glutin = "0.19"
 obj = "0.9"
 png = "0.13"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ git clone https://github.com/kvark/vange-rs
 cd vange-rs
 cp config/settings.template.ron config/settings.ron
 vi config/settings.ron # set the game path
-cargo run --bin road
+cargo run --bin road --features wgpu/<BACKEND> # where <BACKEND> is one of "vulkan", "metal", "dx12", or "dx11"
 ```
 Controls:
   - `WSAD`: movement in the game, rotating the camera around the car during the pause
@@ -117,6 +117,6 @@ cargo run --bin convert -- my_dir/harmony.png my_dir/harmony-new.pal
 
 ## Technonolgy
 
-The game uses [gfx-rs pre-LL](https://github.com/gfx-rs/gfx/tree/pre-ll) for graphics and [glutin](https://github.com/tomaka/glutin) for context creation.
+The game uses [wgpu-rs](https://github.com/gfx-rs/wgpu) for graphics and [winit](https://github.com/tomaka/winit) for windowing.
 
-The level is drawn in a single full-screen draw call with a bit of ray tracing magic. There is also an experimental tessellation-based renderer, but neither produce results of sufficient quality.
+The level is drawn in a single full-screen draw call with a bit of ray tracing magic. There is also an experimental tessellation-based renderer, but neither produce results of sufficient quality. See the [dedicated wiki page](https://github.com/kvark/vange-rs/wiki/Rendering-Techniques) for our rendering technologies.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ The idea of this project is to replicate the old look and behavior, but with nat
 
 You need the **original game** in order to try out `vange-rs`. The path to resources needs to be set in `config/settings.ron`.
 
+## Technonolgy
+
+The game uses [wgpu-rs](https://github.com/gfx-rs/wgpu) for graphics and [winit](https://github.com/tomaka/winit) for windowing.
+
+The level is drawn in a single full-screen draw call with a bit of ray tracing magic. There is also an experimental tessellation-based renderer, but neither produce results of sufficient quality. See the [dedicated wiki page](https://github.com/kvark/vange-rs/wiki/Rendering-Techniques) for our rendering technologies.
+
 ## Instructions
 
 The project is structured to provide multiple binaries. `road` binary is for the main game, which includes mechouses, items, and the level.
@@ -114,9 +120,3 @@ The image can be edited and then converted back to a palette:
 ```bash
 cargo run --bin convert -- my_dir/harmony.png my_dir/harmony-new.pal
 ```
-
-## Technonolgy
-
-The game uses [wgpu-rs](https://github.com/gfx-rs/wgpu) for graphics and [winit](https://github.com/tomaka/winit) for windowing.
-
-The level is drawn in a single full-screen draw call with a bit of ray tracing magic. There is also an experimental tessellation-based renderer, but neither produce results of sufficient quality. See the [dedicated wiki page](https://github.com/kvark/vange-rs/wiki/Rendering-Techniques) for our rendering technologies.

--- a/bin/boilerplate.rs
+++ b/bin/boilerplate.rs
@@ -1,6 +1,6 @@
 use vangers::{
     config,
-    render::{ScreenTargets, DEPTH_FORMAT},
+    render::{ScreenTargets, COLOR_FORMAT, DEPTH_FORMAT},
 };
 
 use env_logger;
@@ -8,7 +8,6 @@ use log::info;
 use wgpu;
 use wgpu::winit;
 
-const SWAP_CHAIN_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
 
 pub trait Application {
     fn on_key(&mut self, input: winit::KeyboardInput) -> bool;
@@ -68,13 +67,14 @@ impl Harness {
             .with_dimensions(
                 winit::dpi::LogicalSize::from_physical((extent.width, extent.height), dpi),
             )
+            .with_resizable(true)
             .build(&events_loop)
             .unwrap();
 
         let surface = instance.create_surface(&window);
         let sc_desc = wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
-            format: SWAP_CHAIN_FORMAT,
+            format: COLOR_FORMAT,
             width: extent.width,
             height: extent.height,
         };
@@ -159,7 +159,7 @@ impl Harness {
                 self.extent = extent;
                 let sc_desc = wgpu::SwapChainDescriptor {
                     usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
-                    format: SWAP_CHAIN_FORMAT,
+                    format: COLOR_FORMAT,
                     width: extent.width,
                     height: extent.height,
                 };

--- a/bin/boilerplate.rs
+++ b/bin/boilerplate.rs
@@ -1,121 +1,150 @@
-extern crate env_logger;
-extern crate gfx;
-extern crate gfx_device_gl;
-extern crate gfx_window_glutin;
-extern crate glutin;
-extern crate vangers;
+use vangers::{
+    config,
+    render::ScreenTargets,
+};
 
-use vangers::{config, render};
+use env_logger;
+use log::info;
+use wgpu;
+use wgpu::winit;
 
-pub use self::glutin::{ElementState, KeyboardInput, ModifiersState, VirtualKeyCode as Key, MouseScrollDelta, MouseButton};
+pub const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
+pub const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::D32Float;
 
-
-pub trait Application<R: gfx::Resources> {
-    fn on_key(&mut self, KeyboardInput) -> bool;
-    fn on_mouse_wheel(&mut self, _delta: MouseScrollDelta) {}
+pub trait Application {
+    fn on_key(&mut self, input: winit::KeyboardInput) -> bool;
+    fn on_mouse_wheel(&mut self, _delta: winit::MouseScrollDelta) {}
     fn on_cursor_move(&mut self, _position: (f64, f64)) {}
-    fn on_mouse_button(&mut self, _state: ElementState, _button: MouseButton) {}
-    fn gpu_update<F: gfx::Factory<R>>(
-        &mut self, &mut F, resize: Option<render::MainTargets<R>>, reload: bool
-    );
+    fn on_mouse_button(&mut self, _state: winit::ElementState, _button: winit::MouseButton) {}
+    fn resize(&mut self, _device: &wgpu::Device, _extent: wgpu::Extent3d) {}
+    fn reload(&mut self, _device: &wgpu::Device);
     fn update(&mut self, delta: f32);
-    fn draw<C: gfx::CommandBuffer<R>>(
-        &mut self, &mut gfx::Encoder<R, C>
-    );
+    fn draw(
+        &mut self,
+        device: &wgpu::Device,
+        targets: ScreenTargets,
+    ) -> Vec<wgpu::CommandBuffer>;
 }
 
-type MainTargets = render::MainTargets<gfx_device_gl::Resources>;
-
 pub struct Harness {
-    events_loop: glutin::EventsLoop,
-    window: glutin::GlWindow,
-    device: gfx_device_gl::Device,
-    pub factory: gfx_device_gl::Factory,
+    events_loop: winit::EventsLoop,
+    window: winit::Window,
+    pub device: wgpu::Device,
+    surface: wgpu::Surface,
+    swap_chain: wgpu::SwapChain,
+    extent: wgpu::Extent3d,
+    depth_target: wgpu::TextureView,
 }
 
 impl Harness {
-    pub fn init() -> (Self, config::Settings, MainTargets) {
-        env_logger::init().unwrap();
+    pub fn init(title: &str) -> (Self, config::Settings) {
+        info!("Initializing the device");
+        env_logger::init();
+
+        let instance = wgpu::Instance::new();
+        let adapter = instance.get_adapter(&wgpu::AdapterDescriptor {
+            power_preference: wgpu::PowerPreference::LowPower,
+        });
+        let device = adapter.create_device(&wgpu::DeviceDescriptor {
+            extensions: wgpu::Extensions {
+                anisotropic_filtering: false,
+            },
+        });
+
         info!("Loading the settings");
         let settings = config::Settings::load("config/settings.ron");
+        let extent = wgpu::Extent3d {
+            width: settings.window.size[0],
+            height: settings.window.size[1],
+            depth: 1,
+        };
 
-        info!("Creating the window with GL context");
-        #[cfg(target_os = "linux")]
-        let events_loop = <glutin::EventsLoop as glutin::os::unix::EventsLoopExt>::new_x11()
+        info!("Initializing the window...");
+        let events_loop = winit::EventsLoop::new();
+        let dpi = events_loop
+            .get_primary_monitor()
+            .get_hidpi_factor();
+        let window = winit::WindowBuilder::new()
+            .with_title(title)
+            .with_dimensions(
+                winit::dpi::LogicalSize::from_physical((extent.width, extent.height), dpi),
+            )
+            .build(&events_loop)
             .unwrap();
-        #[cfg(not(target_os = "linux"))]
-        let events_loop = glutin::EventsLoop::new();
 
-        let win_builder = glutin::WindowBuilder::new()
-            .with_title(settings.window.title.clone())
-            .with_dimensions(glutin::dpi::LogicalSize::from_physical(
-                (settings.window.size[0], settings.window.size[1]),
-                events_loop.get_primary_monitor().get_hidpi_factor(),
-            ));
-        let context_build = glutin::ContextBuilder::new()
-            .with_gl_profile(glutin::GlProfile::Core)
-            .with_vsync(true);
+        let surface = instance.create_surface(&window);
+        let sc_desc = wgpu::SwapChainDescriptor {
+            usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+            format: COLOR_FORMAT,
+            width: extent.width,
+            height: extent.height,
+        };
+        let swap_chain = device.create_swap_chain(&surface, &sc_desc);
+        let depth_target = device
+            .create_texture(&wgpu::TextureDescriptor {
+                size: extent,
+                array_size: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: DEPTH_FORMAT,
+                usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+            })
+            .create_default_view();
 
-        let (window, device, factory, color, depth) = gfx_window_glutin::init(
-            win_builder,
-            context_build,
-            &events_loop,
-        ).unwrap();
-
-        let targets = render::MainTargets { color, depth };
         let harness = Harness {
             events_loop,
             window,
             device,
-            factory,
+            surface,
+            swap_chain,
+            extent,
+            depth_target,
         };
 
-        (harness, settings, targets)
+        (harness, settings)
     }
 
-    pub fn main_loop<A>(&mut self, mut app: A)
-    where
-        A: Application<gfx_device_gl::Resources>,
-    {
+    pub fn main_loop<A: Application>(&mut self, mut app: A) {
         use std::time;
+        use wgpu::winit::{Event, WindowEvent};
 
-        let mut encoder = gfx::Encoder::from(self.factory.create_command_buffer());
         let mut last_time = time::Instant::now();
-        let mut running = true;
-
-        while running {
-            use gfx::Device;
-
+        loop {
             let win = &self.window;
-            let mut resized_targets = None;
+            let mut running = true;
+            let mut resized_extent = None;
             let mut reload_shaders = false;
             self.events_loop.poll_events(|event| match event {
-                glutin::Event::WindowEvent { window_id, ref event } if window_id == win.id() => {
+                Event::WindowEvent { window_id, ref event } if window_id == win.id() => {
                     match *event {
-                        glutin::WindowEvent::Resized(size) => {
-                            info!("Resizing to {:?}", size);
-                            let (color, depth) = gfx_window_glutin::new_views(win);
-                            resized_targets = Some(render::MainTargets { color, depth });
+                        WindowEvent::Resized(size) => {
+                            let physical = size.to_physical(win.get_hidpi_factor());
+                            info!("Resizing to {:?}", physical);
+                            resized_extent = Some(wgpu::Extent3d {
+                                width: physical.width as u32,
+                                height: physical.height as u32,
+                                depth: 1,
+                            });
                         }
-                        glutin::WindowEvent::Focused(true) => {
+                        WindowEvent::Focused(true) => {
                             info!("Reloading shaders");
                             reload_shaders = true;
                         }
-                        glutin::WindowEvent::CloseRequested => {
+                        WindowEvent::CloseRequested => {
                             running = false;
                         }
-                        glutin::WindowEvent::KeyboardInput { input, .. } => {
+                        WindowEvent::KeyboardInput { input, .. } => {
                             if !app.on_key(input) {
                                 running = false;
                             }
                         }
-                        glutin::WindowEvent::MouseWheel {delta, ..} => {
+                        WindowEvent::MouseWheel {delta, ..} => {
                             app.on_mouse_wheel(delta)
                         }
-                        glutin::WindowEvent::CursorMoved {position, ..} => {
-                            app.on_cursor_move(position.into())
+                        WindowEvent::CursorMoved {position, ..} => {
+                            let physical = position.to_physical(win.get_hidpi_factor());
+                            app.on_cursor_move(physical.into())
                         }
-                        glutin::WindowEvent::MouseInput {state, button, ..} => {
+                        WindowEvent::MouseInput {state, button, ..} => {
                             app.on_mouse_button(state, button)
                         }
                         _ => {}
@@ -124,7 +153,32 @@ impl Harness {
                 _ => {}
             });
 
-            app.gpu_update(&mut self.factory, resized_targets, reload_shaders);
+            if !running {
+                break;
+            }
+            if let Some(extent) = resized_extent {
+                self.extent = extent;
+                let sc_desc = wgpu::SwapChainDescriptor {
+                    usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+                    format: COLOR_FORMAT,
+                    width: extent.width,
+                    height: extent.height,
+                };
+                self.swap_chain = self.device.create_swap_chain(&self.surface, &sc_desc);
+                self.depth_target = self.device
+                    .create_texture(&wgpu::TextureDescriptor {
+                        size: extent,
+                        array_size: 1,
+                        dimension: wgpu::TextureDimension::D2,
+                        format: DEPTH_FORMAT,
+                        usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+                    })
+                    .create_default_view();
+                app.resize(&self.device, extent);
+            }
+            if reload_shaders {
+                app.reload(&self.device);
+            }
 
             let duration = time::Instant::now() - last_time;
             last_time += duration;
@@ -132,11 +186,18 @@ impl Harness {
                 duration.subsec_nanos() as f32 * 1.0e-9;
 
             app.update(delta);
-            app.draw(&mut encoder);
-
-            encoder.flush(&mut self.device);
-            self.window.swap_buffers().unwrap();
-            self.device.cleanup();
+            {
+                let frame = self.swap_chain.get_next_texture();
+                let targets = ScreenTargets {
+                    extent: self.extent,
+                    color: &frame.view,
+                    depth: &self.depth_target,
+                };
+                let command_buffers = app.draw(&self.device, targets);
+                self.device
+                    .get_queue()
+                    .submit(&command_buffers);
+            }
         }
     }
 }

--- a/bin/boilerplate.rs
+++ b/bin/boilerplate.rs
@@ -1,6 +1,6 @@
 use vangers::{
     config,
-    render::ScreenTargets,
+    render::{ScreenTargets, DEPTH_FORMAT},
 };
 
 use env_logger;
@@ -8,8 +8,7 @@ use log::info;
 use wgpu;
 use wgpu::winit;
 
-pub const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
-pub const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::D32Float;
+const SWAP_CHAIN_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
 
 pub trait Application {
     fn on_key(&mut self, input: winit::KeyboardInput) -> bool;
@@ -75,7 +74,7 @@ impl Harness {
         let surface = instance.create_surface(&window);
         let sc_desc = wgpu::SwapChainDescriptor {
             usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
-            format: COLOR_FORMAT,
+            format: SWAP_CHAIN_FORMAT,
             width: extent.width,
             height: extent.height,
         };
@@ -160,7 +159,7 @@ impl Harness {
                 self.extent = extent;
                 let sc_desc = wgpu::SwapChainDescriptor {
                     usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
-                    format: COLOR_FORMAT,
+                    format: SWAP_CHAIN_FORMAT,
                     width: extent.width,
                     height: extent.height,
                 };

--- a/bin/boilerplate.rs
+++ b/bin/boilerplate.rs
@@ -21,7 +21,7 @@ pub trait Application {
         &mut self,
         device: &wgpu::Device,
         targets: ScreenTargets,
-    ) -> Vec<wgpu::CommandBuffer>;
+    ) -> wgpu::CommandBuffer;
 }
 
 pub struct Harness {
@@ -192,10 +192,10 @@ impl Harness {
                     color: &frame.view,
                     depth: &self.depth_target,
                 };
-                let command_buffers = app.draw(&self.device, targets);
+                let command_buffer = app.draw(&self.device, targets);
                 self.device
                     .get_queue()
-                    .submit(&command_buffers);
+                    .submit(&[ command_buffer ]);
             }
         }
     }

--- a/bin/car/app.rs
+++ b/bin/car/app.rs
@@ -12,7 +12,7 @@ pub struct CarView {
     physics: config::car::CarPhysics,
     debug_render: render::DebugRender,
     global: render::GlobalContext,
-    object: render::ObjectContext,
+    object: render::object::Context,
     cam: space::Camera,
     rotation: (cgmath::Rad<f32>, cgmath::Rad<f32>),
     light_config: config::settings::Light,
@@ -46,7 +46,7 @@ impl CarView {
             todo: 0,
         });
         let global = render::GlobalContext::new(device);
-        let object = render::ObjectContext::new(&mut init_encoder, device, &pal_data, &global);
+        let object = render::object::Context::new(&mut init_encoder, device, &pal_data, &global);
         device.get_queue().submit(&[
             init_encoder.finish(),
         ]);

--- a/bin/car/app.rs
+++ b/bin/car/app.rs
@@ -1,10 +1,11 @@
+use crate::boilerplate::Application;
+use m3d::Mesh;
+use vangers::{config, level, model, render, space};
+
 use cgmath;
 use log::info;
 use wgpu;
 
-use crate::boilerplate::Application;
-use m3d::Mesh;
-use vangers::{config, level, model, render, space};
 
 pub struct CarView {
     model: model::RenderModel,

--- a/bin/car/app.rs
+++ b/bin/car/app.rs
@@ -1,33 +1,31 @@
 use cgmath;
-use gfx;
+use log::info;
+use wgpu;
 
-use boilerplate::{Application, KeyboardInput};
+use crate::boilerplate::Application;
 use m3d::Mesh;
 use vangers::{config, level, model, render, space};
 
-pub struct CarView<R: gfx::Resources> {
-    model: model::RenderModel<R>,
+pub struct CarView {
+    model: model::RenderModel,
     transform: space::Transform,
-    pso: gfx::PipelineState<R, render::object::Meta>,
-    debug_render: render::DebugRender<R>,
     physics: config::car::CarPhysics,
-    data: render::object::Data<R>,
+    debug_render: render::DebugRender,
+    global: render::GlobalContext,
+    object: render::ObjectContext,
     cam: space::Camera,
     rotation: (cgmath::Rad<f32>, cgmath::Rad<f32>),
     light_config: config::settings::Light,
 }
 
-impl<R: gfx::Resources> CarView<R> {
-    pub fn new<F: gfx::Factory<R>>(
+impl CarView {
+    pub fn new(
         settings: &config::Settings,
-        targets: render::MainTargets<R>,
-        factory: &mut F,
+        device: &mut wgpu::Device,
     ) -> Self {
-        use gfx::traits::FactoryExt;
-
         info!("Loading car registry");
         let game_reg = config::game::Registry::load(settings);
-        let car_reg = config::car::load_registry(settings, &game_reg, factory);
+        let car_reg = config::car::load_registry(settings, &game_reg, device);
         let cinfo = match car_reg.get(&settings.car.id) {
             Some(ci) => ci,
             None => {
@@ -39,21 +37,19 @@ impl<R: gfx::Resources> CarView<R> {
         for (ms, sid) in model.slots.iter_mut().zip(settings.car.slots.iter()) {
             let info = &game_reg.model_infos[sid];
             let raw = Mesh::load(&mut settings.open_relative(&info.path));
-            ms.mesh = Some(model::load_c3d(raw, factory));
+            ms.mesh = Some(model::load_c3d(raw, device));
             ms.scale = info.scale;
         }
 
         let pal_data = level::read_palette(settings.open_palette(), None);
-        let (width, height, _, _) = targets.color.get_dimensions();
-        let data = render::object::Data {
-            vbuf: model.body.buffer.clone(),
-            globals: factory.create_constant_buffer(1),
-            locals: factory.create_constant_buffer(1),
-            ctable: render::Render::create_color_table(factory),
-            palette: render::Render::create_palette(&pal_data, factory),
-            out_color: targets.color.clone(),
-            out_depth: targets.depth.clone(),
-        };
+        let mut init_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            todo: 0,
+        });
+        let global = render::GlobalContext::new(device);
+        let object = render::ObjectContext::new(&mut init_encoder, device, &pal_data, &global);
+        device.get_queue().submit(&[
+            init_encoder.finish(),
+        ]);
 
         CarView {
             model,
@@ -62,10 +58,10 @@ impl<R: gfx::Resources> CarView<R> {
                 disp: cgmath::Vector3::unit_z(),
                 rot: cgmath::One::one(),
             },
-            pso: render::Render::create_object_pso(factory),
-            debug_render: render::DebugRender::new(factory, targets, &settings.render.debug),
             physics: cinfo.physics.clone(),
-            data,
+            debug_render: render::DebugRender::new(device, &settings.render.debug),
+            global,
+            object,
             cam: space::Camera {
                 loc: cgmath::vec3(0.0, -64.0, 32.0),
                 rot: cgmath::Rotation3::from_angle_x::<cgmath::Rad<_>>(
@@ -73,7 +69,7 @@ impl<R: gfx::Resources> CarView<R> {
                 ),
                 proj: space::Projection::Perspective(cgmath::PerspectiveFov {
                     fovy: cgmath::Deg(45.0).into(),
-                    aspect: width as f32 / height as f32,
+                    aspect: settings.window.size[0] as f32 / settings.window.size[1] as f32,
                     near: 1.0,
                     far: 100.0,
                 }),
@@ -110,9 +106,9 @@ impl<R: gfx::Resources> CarView<R> {
     }
 }
 
-impl<R: gfx::Resources> Application<R> for CarView<R> {
-    fn on_key(&mut self, input: KeyboardInput) -> bool {
-        use boilerplate::{ElementState, Key};
+impl Application for CarView {
+    fn on_key(&mut self, input: wgpu::winit::KeyboardInput) -> bool {
+        use wgpu::winit::{ElementState, KeyboardInput, VirtualKeyCode as Key};
 
         let angle = cgmath::Rad(2.0);
         match input {
@@ -157,44 +153,68 @@ impl<R: gfx::Resources> Application<R> for CarView<R> {
         }
     }
 
-    fn draw<C: gfx::CommandBuffer<R>>(
-        &mut self,
-        enc: &mut gfx::Encoder<R, C>,
-    ) {
-        enc.clear(&self.data.out_color, [0.1, 0.2, 0.3, 1.0]);
-        enc.clear_depth(&self.data.out_depth, 1.0);
-
-        let mx_vp = render::Render::set_globals(
-            enc,
-            &self.cam,
-            &self.light_config,
-            &self.data.globals,
-        );
-
-        render::Render::draw_model(
-            enc,
-            &self.model,
-            self.transform,
-            &self.pso,
-            &mut self.data,
-            Some((&mut self.debug_render, self.physics.scale_bound, &mx_vp)),
-        );
+    fn resize(&mut self, _device: &wgpu::Device, extent: wgpu::Extent3d) {
+        self.cam.proj.update(extent.width as u16, extent.height as u16);
     }
 
-    fn gpu_update<F: gfx::Factory<R>>(
-        &mut self, factory: &mut F,
-        resized_targets: Option<render::MainTargets<R>>,
-        reload_shaders: bool,
-    ) {
-        if let Some(targets) = resized_targets {
-            let (w, h, _, _) = targets.color.get_dimensions();
-            self.cam.proj.update(w, h);
-            self.data.out_color = targets.color.clone();
-            self.data.out_depth = targets.depth.clone();
-            self.debug_render.resize(targets);
+    fn reload(&mut self, device: &wgpu::Device) {
+        self.object.reload(device);
+    }
+
+    fn draw(
+        &mut self,
+        device: &wgpu::Device,
+        targets: render::ScreenTargets,
+    ) -> Vec<wgpu::CommandBuffer> {
+        let mx_vp = self.cam.get_view_proj();
+
+        let mut updater = render::Updater::new(device);
+        updater.update(&self.global.uniform_buf, &[
+            render::GlobalConstants::new(&self.cam, &self.light_config),
+        ]);
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            todo: 0,
+        });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                color_attachments: &[
+                    wgpu::RenderPassColorAttachmentDescriptor {
+                        attachment: targets.color,
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_color: wgpu::Color {
+                            r: 0.1, g: 0.2, b: 0.3, a: 1.0,
+                        },
+                    },
+                ],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
+                    attachment: targets.depth,
+                    depth_load_op: wgpu::LoadOp::Clear,
+                    depth_store_op: wgpu::StoreOp::Store,
+                    clear_depth: 1.0,
+                    stencil_load_op: wgpu::LoadOp::Clear,
+                    stencil_store_op: wgpu::StoreOp::Store,
+                    clear_stencil: 0,
+                }),
+            });
+
+            pass.set_pipeline(&self.object.pipeline);
+            pass.set_bind_group(0, &self.global.bind_group);
+            pass.set_bind_group(1, &self.object.bind_group);
+            render::Render::draw_model(
+                &mut pass,
+                &mut updater,
+                &self.model,
+                self.transform,
+                &self.object.uniform_buf,
+                Some((&mut self.debug_render, self.physics.scale_bound, &mx_vp)),
+            );
         }
-        if reload_shaders {
-            self.pso = render::Render::create_object_pso(factory);
-        }
+
+        vec![
+            updater.finish(),
+            encoder.finish(),
+        ]
     }
 }

--- a/bin/car/app.rs
+++ b/bin/car/app.rs
@@ -12,7 +12,7 @@ pub struct CarView {
     transform: space::Transform,
     physics: config::car::CarPhysics,
     debug_render: render::DebugRender,
-    global: render::GlobalContext,
+    global: render::global::Context,
     object: render::object::Context,
     cam: space::Camera,
     rotation: (cgmath::Rad<f32>, cgmath::Rad<f32>),
@@ -46,7 +46,7 @@ impl CarView {
         let mut init_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             todo: 0,
         });
-        let global = render::GlobalContext::new(device);
+        let global = render::global::Context::new(device);
         let object = render::object::Context::new(&mut init_encoder, device, &pal_data, &global);
         device.get_queue().submit(&[
             init_encoder.finish(),
@@ -171,7 +171,7 @@ impl Application for CarView {
 
         let mut updater = render::Updater::new(device);
         updater.update(&self.global.uniform_buf, &[
-            render::GlobalConstants::new(&self.cam, &self.light_config),
+            render::global::Constants::new(&self.cam, &self.light_config),
         ]);
 
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {

--- a/bin/car/main.rs
+++ b/bin/car/main.rs
@@ -1,11 +1,3 @@
-extern crate cgmath;
-extern crate getopts;
-extern crate gfx;
-#[macro_use]
-extern crate log;
-extern crate m3d;
-extern crate vangers;
-
 mod app;
 #[path = "../boilerplate.rs"]
 mod boilerplate;
@@ -13,7 +5,7 @@ mod boilerplate;
 fn main() {
     use std::env;
 
-    let (mut harness, settings, main_targets) = boilerplate::Harness::init();
+    let (mut harness, settings) = boilerplate::Harness::init("car");
 
     let args: Vec<_> = env::args().collect();
     let mut options = getopts::Options::new();
@@ -32,7 +24,7 @@ fn main() {
         return;
     }
 
-    let app = app::CarView::new(&settings, main_targets, &mut harness.factory);
+    let app = app::CarView::new(&settings, &mut harness.device);
 
     harness.main_loop(app);
 }

--- a/bin/convert/level_png.rs
+++ b/bin/convert/level_png.rs
@@ -1,9 +1,12 @@
 use vangers::level::LevelLayers;
 
 use ron;
+use serde::{Serialize, Deserialize};
 
-use std::fs::File;
-use std::path::PathBuf;
+use std::{
+    fs::File,
+    path::PathBuf,
+};
 
 
 #[derive(Serialize, Deserialize)]

--- a/bin/convert/main.rs
+++ b/bin/convert/main.rs
@@ -1,21 +1,12 @@
-extern crate env_logger;
-extern crate getopts;
-extern crate m3d;
-extern crate obj;
-extern crate png;
-extern crate ron;
-#[macro_use]
-extern crate serde;
-extern crate tiff;
-extern crate vangers;
-
 mod level_png;
 mod model_obj;
 
 
-use std::io::BufWriter;
-use std::fs::{File, read as fs_read};
-use std::path::PathBuf;
+use std::{
+    io::BufWriter,
+    fs::{File, read as fs_read},
+    path::PathBuf,
+};
 
 pub fn save_tiff(path: &PathBuf, layers: vangers::level::LevelLayers) {
     let images = [
@@ -65,8 +56,6 @@ fn main() {
     use png::Parameter;
     use std::env;
     use std::io::Write;
-
-    env_logger::init().unwrap();
 
     let args: Vec<_> = env::args().collect();
     let mut options = getopts::Options::new();

--- a/bin/convert/model_obj.rs
+++ b/bin/convert/model_obj.rs
@@ -6,9 +6,11 @@ use m3d::{NORMALIZER, NUM_COLOR_IDS,
 use obj::{IndexTuple, Obj, SimplePolygon};
 use ron;
 
-use std::fs::File;
-use std::io::{Result as IoResult, Write};
-use std::path::PathBuf;
+use std::{
+    fs::File,
+    io::{Result as IoResult, Write},
+    path::PathBuf,
+};
 
 type RefModel = Model<Mesh<String>, Mesh<String>>;
 

--- a/bin/level/app.rs
+++ b/bin/level/app.rs
@@ -1,10 +1,15 @@
+use crate::boilerplate::Application;
+use vangers::{
+    config, level, space,
+    render::{
+        Render, ScreenTargets,
+    },
+};
+
 use cgmath;
 use log::info;
 use wgpu;
 use wgpu::winit;
-
-use crate::boilerplate::Application;
-use vangers::{config, level, render, space};
 
 
 #[derive(Debug)]
@@ -19,7 +24,7 @@ enum Input {
 }
 
 pub struct LevelView {
-    render: render::Render,
+    render: Render,
     _level: level::Level,
     cam: space::Camera,
     input: Input,
@@ -88,7 +93,7 @@ impl LevelView {
 
         let objects_palette = level::read_palette(settings.open_palette(), None);
         let depth = 10f32 .. 10000f32;
-        let render = render::init(device, &level, &objects_palette, &settings.render);
+        let render = Render::new(device, &level, &objects_palette, &settings.render);
 
         LevelView {
             render,
@@ -279,7 +284,7 @@ impl Application for LevelView {
     fn draw(
         &mut self,
         device: &wgpu::Device,
-        targets: render::ScreenTargets,
+        targets: ScreenTargets,
     ) -> Vec<wgpu::CommandBuffer> {
         self.render.draw_world(
             &[],

--- a/bin/level/app.rs
+++ b/bin/level/app.rs
@@ -285,7 +285,7 @@ impl Application for LevelView {
         &mut self,
         device: &wgpu::Device,
         targets: ScreenTargets,
-    ) -> Vec<wgpu::CommandBuffer> {
+    ) -> wgpu::CommandBuffer {
         self.render.draw_world(
             &[],
             &self.cam,

--- a/bin/level/main.rs
+++ b/bin/level/main.rs
@@ -1,18 +1,11 @@
-extern crate cgmath;
-extern crate getopts;
-extern crate gfx;
-#[macro_use]
-extern crate log;
-extern crate vangers;
-
 mod app;
 #[path = "../boilerplate.rs"]
 mod boilerplate;
 
 fn main() {
-    let (mut harness, settings, main_targets) = boilerplate::Harness::init();
+    let (mut harness, settings) = boilerplate::Harness::init("level");
 
-    let app = app::LevelView::new(&settings, main_targets, &mut harness.factory);
+    let app = app::LevelView::new(&settings, &mut harness.device);
 
     harness.main_loop(app);
 }

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -1,5 +1,5 @@
 use cgmath;
-use gfx;
+use wgpu;
 
 use boilerplate::{Application, KeyboardInput};
 use vangers::{config, level, model, render, space};

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -8,7 +8,7 @@ use vangers::{config, level, model, render, space};
 pub struct ResourceView {
     model: model::RenderModel,
     global: render::GlobalContext,
-    object: render::ObjectContext,
+    object: render::object::Context,
     transform: space::Transform,
     cam: space::Camera,
     rotation: cgmath::Rad<f32>,
@@ -30,7 +30,7 @@ impl ResourceView {
             todo: 0,
         });
         let global = render::GlobalContext::new(device);
-        let object = render::ObjectContext::new(&mut init_encoder, device, &pal_data, &global);
+        let object = render::object::Context::new(&mut init_encoder, device, &pal_data, &global);
         device.get_queue().submit(&[
             init_encoder.finish(),
         ]);

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -1,9 +1,10 @@
+use crate::boilerplate::Application;
+use vangers::{config, level, model, render, space};
+
 use cgmath;
 use log::info;
 use wgpu;
 
-use crate::boilerplate::Application;
-use vangers::{config, level, model, render, space};
 
 pub struct ResourceView {
     model: model::RenderModel,

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -8,7 +8,7 @@ use wgpu;
 
 pub struct ResourceView {
     model: model::RenderModel,
-    global: render::GlobalContext,
+    global: render::global::Context,
     object: render::object::Context,
     transform: space::Transform,
     cam: space::Camera,
@@ -30,7 +30,7 @@ impl ResourceView {
         let mut init_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             todo: 0,
         });
-        let global = render::GlobalContext::new(device);
+        let global = render::global::Context::new(device);
         let object = render::object::Context::new(&mut init_encoder, device, &pal_data, &global);
         device.get_queue().submit(&[
             init_encoder.finish(),
@@ -126,7 +126,7 @@ impl Application for ResourceView {
     ) -> Vec<wgpu::CommandBuffer> {
         let mut updater = render::Updater::new(device);
         updater.update(&self.global.uniform_buf, &[
-            render::GlobalConstants::new(&self.cam, &self.light_config),
+            render::global::Constants::new(&self.cam, &self.light_config),
         ]);
 
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {

--- a/bin/model/main.rs
+++ b/bin/model/main.rs
@@ -1,10 +1,3 @@
-extern crate cgmath;
-extern crate getopts;
-extern crate gfx;
-#[macro_use]
-extern crate log;
-extern crate vangers;
-
 mod app;
 #[path = "../boilerplate.rs"]
 mod boilerplate;
@@ -12,7 +5,7 @@ mod boilerplate;
 fn main() {
     use std::env;
 
-    let (mut harness, settings, main_targets) = boilerplate::Harness::init();
+    let (mut harness, settings) = boilerplate::Harness::init();
 
     let args: Vec<_> = env::args().collect();
     let mut options = getopts::Options::new();

--- a/bin/model/main.rs
+++ b/bin/model/main.rs
@@ -5,7 +5,7 @@ mod boilerplate;
 fn main() {
     use std::env;
 
-    let (mut harness, settings) = boilerplate::Harness::init();
+    let (mut harness, settings) = boilerplate::Harness::init("model");
 
     let args: Vec<_> = env::args().collect();
     let mut options = getopts::Options::new();
@@ -22,7 +22,7 @@ fn main() {
     }
 
     let path = &matches.free[0];
-    let app = app::ResourceView::new(path, &settings, main_targets, &mut harness.factory);
+    let app = app::ResourceView::new(path, &settings, &mut harness.device);
 
     harness.main_loop(app);
 }

--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -1,3 +1,14 @@
+use crate::{
+    boilerplate::Application,
+    physics,
+};
+use vangers::{
+    config, level, space,
+    render::{
+        LineBuffer, Render, RenderModel, ScreenTargets,
+    },
+};
+
 use cgmath::{
     self,
     Angle, Rotation3, Zero,
@@ -7,12 +18,6 @@ use rand;
 use wgpu;
 
 use std::collections::HashMap;
-
-use crate::{
-    boilerplate::Application,
-    physics,
-};
-use vangers::{config, level, render, space};
 
 
 #[derive(Eq, PartialEq)]
@@ -95,7 +100,7 @@ impl Agent {
         dt: f32,
         level: &level::Level,
         common: &config::common::Common,
-        line_buffer: Option<&mut render::LineBuffer>,
+        line_buffer: Option<&mut LineBuffer>,
     ) {
         physics::step(
             &mut self.dynamo,
@@ -126,11 +131,11 @@ struct DataBase {
 
 pub struct Game {
     db: DataBase,
-    render: render::Render,
+    render: Render,
     //collider: render::GpuCollider,
     //compute_gpu_collision: bool,
     //debug_collision_map: bool,
-    line_buffer: render::LineBuffer,
+    line_buffer: LineBuffer,
     level: level::Level,
     agents: Vec<Agent>,
     cam: space::Camera,
@@ -181,7 +186,7 @@ impl Game {
 
         let depth = 10f32 .. 10000f32;
         let pal_data = level::read_palette(settings.open_palette(), Some(&level.terrains));
-        let render = render::init(device, &level, &pal_data, &settings.render);
+        let render = Render::new(device, &level, &pal_data, &settings.render);
         /*
         let collider = render::GpuCollider::new(
             factory,
@@ -228,7 +233,7 @@ impl Game {
             db,
             render,
             //collider,
-            line_buffer: render::LineBuffer::new(),
+            line_buffer: LineBuffer::new(),
             level,
             agents,
             cam: space::Camera {
@@ -453,7 +458,7 @@ impl Application for Game {
     fn draw(
         &mut self,
         device: &wgpu::Device,
-        targets: render::ScreenTargets,
+        targets: ScreenTargets,
     ) -> Vec<wgpu::CommandBuffer> {
         /*
         if self.compute_gpu_collision {
@@ -472,7 +477,7 @@ impl Application for Game {
         }*/
         let models = self.agents
             .iter()
-            .map(|a| render::RenderModel {
+            .map(|a| RenderModel {
                 model: &a.car.model,
                 transform: a.transform.clone(),
                 debug_shape_scale: match a.spirit {

--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -2,8 +2,9 @@ use crate::{
     boilerplate::Application,
     physics,
 };
+use m3d::Mesh;
 use vangers::{
-    config, level, space,
+    config, level, model, space,
     render::{
         LineBuffer, Render, RenderModel, ScreenTargets,
     },
@@ -205,7 +206,7 @@ impl Game {
         for (ms, sid) in player_agent.car.model.slots.iter_mut().zip(settings.car.slots.iter()) {
             let info = &db.game.model_infos[sid];
             let raw = Mesh::load(&mut settings.open_relative(&info.path));
-            ms.mesh = Some(model::load_c3d(raw, factory));
+            ms.mesh = Some(model::load_c3d(raw, device));
             ms.scale = info.scale;
         }
 

--- a/bin/road/main.rs
+++ b/bin/road/main.rs
@@ -1,12 +1,4 @@
-extern crate cgmath;
-extern crate getopts;
-extern crate gfx;
-#[macro_use]
-extern crate log;
-extern crate rand;
-
-extern crate m3d;
-extern crate vangers;
+use log::info;
 
 mod game;
 mod physics;
@@ -16,7 +8,7 @@ mod boilerplate;
 fn main() {
     use std::env;
 
-    let (mut harness, settings, main_targets) = boilerplate::Harness::init();
+    let (mut harness, settings) = boilerplate::Harness::init("road");
 
     info!("Parsing command line");
     let args: Vec<_> = env::args().collect();
@@ -33,7 +25,7 @@ fn main() {
         return;
     }
 
-    let game = game::Game::new(&settings, main_targets, &mut harness.factory);
+    let game = game::Game::new(&settings, &mut harness.device);
 
     harness.main_loop(game);
 }

--- a/bin/road/physics.rs
+++ b/bin/road/physics.rs
@@ -1,14 +1,15 @@
+use vangers::{
+    config, level, model, space,
+    render::LineBuffer,
+};
+
 use cgmath::{
     self,
     prelude::*,
 };
 use log::debug;
-use std::f32::EPSILON;
 
-use vangers::{
-    config, level, model, space,
-    render::LineBuffer,
-};
+use std::f32::EPSILON;
 
 
 const MAX_TRACTION: config::common::Traction = 4.0;

--- a/bin/road/physics.rs
+++ b/bin/road/physics.rs
@@ -1,10 +1,14 @@
-use cgmath;
-use cgmath::prelude::*;
-use gfx;
+use cgmath::{
+    self,
+    prelude::*,
+};
+use log::debug;
 use std::f32::EPSILON;
 
-use vangers::{config, level, model, space};
-use vangers::render::LineBuffer;
+use vangers::{
+    config, level, model, space,
+    render::LineBuffer,
+};
 
 
 const MAX_TRACTION: config::common::Traction = 4.0;
@@ -121,7 +125,7 @@ fn collide_low(
 ) -> CollisionData {
     let (mut soft, mut hard) = (Accumulator::new(), Accumulator::new());
     for s in samples[poly.samples.clone()].iter() {
-        let sp = cgmath::Point3::from(*s).cast::<f32>();
+        let sp = cgmath::Point3::from(*s).cast::<f32>().unwrap();
         let pos = transform.transform_point(sp * scale).to_vec();
         let texel = level.get((pos.x as i32, pos.y as i32));
         let height = match texel {
@@ -188,11 +192,11 @@ fn calc_collision_matrix_inv(
 }
 
 
-pub fn step<R: gfx::Resources>(
+pub fn step(
     dynamo: &mut Dynamo,
     transform: &mut space::Transform,
     dt: f32,
-    car: &config::car::CarInfo<R>,
+    car: &config::car::CarInfo,
     level: &level::Level,
     common: &config::common::Common,
     f_turbo: f32,

--- a/data/shader/color.inc.glsl
+++ b/data/shader/color.inc.glsl
@@ -1,12 +1,15 @@
 // Common FS routines for evaluating terrain color.
 
-//uniform sampler2DArray t_Height;
-// Terrain parameters per type: shadow offset, height shift, palette start, palette end
-uniform usampler1D t_Table;
-// corresponds to SDL palette
-uniform sampler1D t_Palette;
+//uniform sampler2D t_Height;
 // Flood map has the water level per Y.
-uniform sampler1D t_Flood;
+layout(set = 1, binding = 4) uniform texture1D t_Flood;
+// Terrain parameters per type: shadow offset, height shift, palette start, palette end
+layout(set = 1, binding = 5) uniform utexture1D t_Table;
+// corresponds to SDL palette
+layout(set = 1, binding = 6) uniform texture1D t_Palette;
+layout(set = 1, binding = 8) uniform sampler s_FloodSampler;
+
+layout(set = 0, binding = 1) uniform sampler s_PaletteSampler;
 
 const float c_HorFactor = 0.5; //H_CORRECTION
 const float c_DiffuseScale = 8.0;
@@ -25,22 +28,22 @@ float evaluate_light(vec3 mat, float height_diff) {
 
 float evaluate_palette(uint type, float value, float ycoord) {
     value = clamp(value, 0.0, 1.0);
-    vec4 terr = vec4(texelFetch(t_Table, int(type), 0));
+    vec4 terr = vec4(texelFetch(usampler1D(t_Table, s_PaletteSampler), int(type), 0));
     if (type == 0U && value > 0.0) { // water
-        float flood = texture(t_Flood, ycoord).x;
+        float flood = texture(sampler1D(t_Flood, s_FloodSampler), ycoord).x;
         float d = c_HorFactor * (1.0 - flood);
         value = clamp(value * 1.25 / (1.0 - d) - 0.25, 0.0, 1.0);
     }
     return (mix(terr.z, terr.w, value) + 0.5) / 256.0;
 }
 
-vec4 evaluate_color(uint type, vec3 tex_coord, float height_normalized, float lit_factor) {
+vec4 evaluate_color(uint type, vec2 tex_coord, float height_normalized, float lit_factor) {
     float diff =
-        textureLodOffset(t_Height, tex_coord, 0.0, ivec2(1, 0)).x -
-        textureLodOffset(t_Height, tex_coord, 0.0, ivec2(-1, 0)).x;
+        textureLodOffset(sampler2D(t_Height, s_MainSampler), tex_coord, 0.0, ivec2(1, 0)).x -
+        textureLodOffset(sampler2D(t_Height, s_MainSampler), tex_coord, 0.0, ivec2(-1, 0)).x;
     vec3 mat = type == 0U ? vec3(5.0, 1.25, 0.5) : vec3(1.0);
     float light_clr = evaluate_light(mat, diff);
     float tmp = light_clr - c_HorFactor * (1.0 - height_normalized);
     float color_id = evaluate_palette(type, lit_factor * tmp, tex_coord.y);
-    return texture(t_Palette, color_id);
+    return texture(sampler1D(t_Palette, s_PaletteSampler), color_id);
 }

--- a/data/shader/object.glsl
+++ b/data/shader/object.glsl
@@ -24,12 +24,14 @@ layout(set = 1, binding = 3) uniform sampler s_ColorTableSampler;
 layout(set = 0, binding = 1) uniform sampler s_PaletteSampler;
 
 layout(location = 0) attribute ivec4 a_Pos;
-layout(location = 1) attribute vec4 a_Normal;
-layout(location = 2) attribute uint a_ColorIndex;
+layout(location = 1) attribute uint a_ColorIndex;
+layout(location = 2) attribute vec4 a_Normal;
 
 void main() {
     vec4 world = u_Model * a_Pos;
     gl_Position = u_ViewProj * world;
+    // convert from -1,1 Z to 0,1
+    gl_Position.z = 0.5 * (gl_Position.z + gl_Position.w);
 
     uvec2 color_params = texelFetch(usampler1D(t_ColorTable, s_ColorTableSampler), int(a_ColorIndex), 0).xy;
     v_Color = texelFetch(sampler1D(t_Palette, s_PaletteSampler), int(color_params[0]), 0);

--- a/data/shader/object.glsl
+++ b/data/shader/object.glsl
@@ -13,13 +13,13 @@ layout(location = 2) varying vec3 v_Light;
 
 #ifdef SHADER_VS
 
-layout(set = 1, binding = 0) uniform c_Locals {
+layout(set = 2, binding = 0) uniform c_Locals {
     mat4 u_Model;
 };
 
-layout(set = 1, binding = 1) uniform utexture1D t_ColorTable;
-layout(set = 1, binding = 2) uniform texture1D t_Palette;
-layout(set = 1, binding = 3) uniform sampler s_ColorTableSampler;
+layout(set = 1, binding = 0) uniform utexture1D t_ColorTable;
+layout(set = 1, binding = 1) uniform texture1D t_Palette;
+layout(set = 1, binding = 2) uniform sampler s_ColorTableSampler;
 
 layout(set = 0, binding = 1) uniform sampler s_PaletteSampler;
 

--- a/data/shader/object.glsl
+++ b/data/shader/object.glsl
@@ -30,8 +30,6 @@ layout(location = 2) attribute vec4 a_Normal;
 void main() {
     vec4 world = u_Model * a_Pos;
     gl_Position = u_ViewProj * world;
-    // convert from -1,1 Z to 0,1
-    gl_Position.z = 0.5 * (gl_Position.z + gl_Position.w);
 
     uvec2 color_params = texelFetch(usampler1D(t_ColorTable, s_ColorTableSampler), int(a_ColorIndex), 0).xy;
     v_Color = texelFetch(sampler1D(t_Palette, s_PaletteSampler), int(color_params[0]), 0);

--- a/data/shader/surface.inc.glsl
+++ b/data/shader/surface.inc.glsl
@@ -41,11 +41,8 @@ int modulo(int a, int b) {
 float get_lod_height(ivec2 ipos, int lod) {
     int x = modulo(ipos.x, int(u_TextureScale.x));
     int y = modulo(ipos.y, int(u_TextureScale.y));
-    ivec3 tc = ivec3(
-        x >> lod, y >> lod,
-        modulo((ipos.y - y) / int(u_TextureScale.y), int(u_TextureScale.w))
-    );
-    float alt = texelFetch(t_Height, tc, lod).x;
+    ivec2 tc = ivec2(x, y) >> lod;
+    float alt = texelFetch(sampler2D(t_Height, s_MainSampler), tc, lod).x;
     return alt * u_TextureScale.z;
 }
 
@@ -53,8 +50,7 @@ float get_lod_height(ivec2 ipos, int lod) {
 // integer operations or `texelFetch`.
 float get_lod_height_alt(ivec2 ipos, int lod) {
     vec2 xy = (vec2(ipos.xy) + 0.5) / u_TextureScale.xy;
-    float z = trunc(mod(float(ipos.y) / u_TextureScale.y, u_TextureScale.w));
-    float alt = textureLod(t_Height, vec3(xy, z), float(lod)).x;
+    float alt = textureLod(sampler2D(t_Height, s_MainSampler), xy, float(lod)).x;
     return alt * u_TextureScale.z;
 }
 

--- a/data/shader/surface.inc.glsl
+++ b/data/shader/surface.inc.glsl
@@ -58,8 +58,9 @@ Surface get_surface(vec2 pos) {
     Surface suf;
 
     vec2 tc = suf.tex_coord = pos / u_TextureScale.xy;
+    ivec2 tci = ivec2(mod(pos + 0.5, u_TextureScale.xy));
 
-    uint meta = texture(usampler2D(t_Meta, s_MainSampler), tc).x;
+    uint meta = texelFetch(usampler2D(t_Meta, s_MainSampler), tci, 0).x;
     suf.is_shadowed = (meta & c_ShadowMask) != 0U;
     suf.low_type = get_terrain_type(meta);
 
@@ -68,13 +69,13 @@ Surface get_surface(vec2 pos) {
         // so this can be more efficient with a boolean param
         uint delta;
         if (mod(pos.x, 2.0) >= 1.0) {
-            uint meta_low = textureOffset(usampler2D(t_Meta, s_MainSampler), tc, ivec2(-1, 0)).x;
+            uint meta_low = texelFetch(usampler2D(t_Meta, s_MainSampler), tci + ivec2(-1, 0), 0).x;
             suf.high_type = suf.low_type;
             suf.low_type = get_terrain_type(meta_low);
 
             delta = (get_delta(meta_low) << c_DeltaBits) + get_delta(meta);
         } else {
-            uint meta_high = textureOffset(usampler2D(t_Meta, s_MainSampler), tc, ivec2(1, 0)).x;
+            uint meta_high = texelFetch(usampler2D(t_Meta, s_MainSampler), tci + ivec2(1, 0), 0).x;
             suf.tex_coord.x += 1.0 / u_TextureScale.x;
             suf.high_type = get_terrain_type(meta_high);
 

--- a/data/shader/surface.inc.glsl
+++ b/data/shader/surface.inc.glsl
@@ -1,11 +1,12 @@
 // Common routines for fetching the level surface data.
 
-uniform c_Surface {
+layout(set = 1, binding = 0) uniform c_Surface {
     vec4 u_TextureScale;    // XY = size, Z = height scale, w = number of layers
 };
 
-uniform sampler2DArray t_Height;
-uniform usampler2DArray t_Meta;
+layout(set = 1, binding = 2) uniform texture2D t_Height;
+layout(set = 1, binding = 3) uniform utexture2D t_Meta;
+layout(set = 1, binding = 7) uniform sampler s_MainSampler;
 
 const uint
     c_DoubleLevelMask = 1U<<6,
@@ -21,7 +22,7 @@ const float c_DeltaScale = 8.0 / 255.0;
 struct Surface {
     float low_alt, high_alt, delta;
     uint low_type, high_type;
-    vec3 tex_coord;
+    vec2 tex_coord;
     bool is_shadowed;
 };
 
@@ -60,11 +61,9 @@ float get_lod_height_alt(ivec2 ipos, int lod) {
 Surface get_surface(vec2 pos) {
     Surface suf;
 
-    vec3 tc = vec3(pos / u_TextureScale.xy, 0.0);
-    tc.z = trunc(mod(tc.y, u_TextureScale.w));
-    suf.tex_coord = tc;
+    vec2 tc = suf.tex_coord = pos / u_TextureScale.xy;
 
-    uint meta = texture(t_Meta, tc).x;
+    uint meta = texture(usampler2D(t_Meta, s_MainSampler), tc).x;
     suf.is_shadowed = (meta & c_ShadowMask) != 0U;
     suf.low_type = get_terrain_type(meta);
 
@@ -73,13 +72,13 @@ Surface get_surface(vec2 pos) {
         // so this can be more efficient with a boolean param
         uint delta;
         if (mod(pos.x, 2.0) >= 1.0) {
-            uint meta_low = textureOffset(t_Meta, tc, ivec2(-1, 0)).x;
+            uint meta_low = textureOffset(usampler2D(t_Meta, s_MainSampler), tc, ivec2(-1, 0)).x;
             suf.high_type = suf.low_type;
             suf.low_type = get_terrain_type(meta_low);
 
             delta = (get_delta(meta_low) << c_DeltaBits) + get_delta(meta);
         } else {
-            uint meta_high = textureOffset(t_Meta, tc, ivec2(1, 0)).x;
+            uint meta_high = textureOffset(usampler2D(t_Meta, s_MainSampler), tc, ivec2(1, 0)).x;
             suf.tex_coord.x += 1.0 / u_TextureScale.x;
             suf.high_type = get_terrain_type(meta_high);
 
@@ -87,14 +86,14 @@ Surface get_surface(vec2 pos) {
         }
 
         suf.low_alt =
-            textureLodOffset(t_Height, suf.tex_coord, 0.0, ivec2(-1, 0)).x
+            textureLodOffset(sampler2D(t_Height, s_MainSampler), suf.tex_coord, 0.0, ivec2(-1, 0)).x
             * u_TextureScale.z;
-        suf.high_alt = textureLod(t_Height, suf.tex_coord, 0.0).x * u_TextureScale.z;
+        suf.high_alt = textureLod(sampler2D(t_Height, s_MainSampler), suf.tex_coord, 0.0).x * u_TextureScale.z;
         suf.delta = float(delta) * c_DeltaScale * u_TextureScale.z;
     } else {
         suf.high_type = suf.low_type;
 
-        suf.low_alt = textureLod(t_Height, tc, 0.0).x * u_TextureScale.z;
+        suf.low_alt = textureLod(sampler2D(t_Height, s_MainSampler), tc, 0.0).x * u_TextureScale.z;
         suf.high_alt = suf.low_alt;
         suf.delta = 0.0;
     }

--- a/data/shader/terrain_ray.glsl
+++ b/data/shader/terrain_ray.glsl
@@ -30,6 +30,8 @@ layout(set = 1, binding = 1) uniform Locals {
 
 #define TERRAIN_WATER   0U
 
+const float c_Step = 0.6;
+
 layout(location = 0) out vec4 o_Color;
 
 vec3 cast_ray_to_plane(float level, vec3 base, vec3 dir) {

--- a/data/shader/terrain_ray.glsl
+++ b/data/shader/terrain_ray.glsl
@@ -14,8 +14,6 @@ layout(location = 0) attribute ivec4 a_Pos;
 
 void main() {
     gl_Position = u_ViewProj * vec4(a_Pos);
-    // convert from -1,1 Z to 0,1
-    gl_Position.z = 0.5 * (gl_Position.z + gl_Position.w);
 }
 #endif //VS
 
@@ -132,7 +130,7 @@ CastPoint cast_ray_to_map(vec3 base, vec3 dir) {
 
 void main() {
     vec4 sp_ndc = vec4(
-        (gl_FragCoord.xy / u_ScreenSize.xy) * vec2(2.0, -2.0) + vec2(-1.0, 1.0),
+        gl_FragCoord.xy / u_ScreenSize.xy * 2.0 - 1.0,
         -1.0,
         1.0
     );
@@ -155,6 +153,6 @@ void main() {
     o_Color = frag_color;
 
     vec4 target_ndc = u_ViewProj * vec4(point, 1.0);
-    gl_FragDepth = target_ndc.z / target_ndc.w * 0.5 + 0.5;
+    gl_FragDepth = target_ndc.z / target_ndc.w;
 }
 #endif //FS

--- a/data/shader/terrain_ray.glsl
+++ b/data/shader/terrain_ray.glsl
@@ -13,7 +13,9 @@ layout(set = 0, binding = 0) uniform Globals {
 layout(location = 0) attribute ivec4 a_Pos;
 
 void main() {
-    gl_Position = u_ViewProj * a_Pos;
+    gl_Position = u_ViewProj * vec4(a_Pos);
+    // convert from -1,1 Z to 0,1
+    gl_Position.z = 0.5 * (gl_Position.z + gl_Position.w);
 }
 #endif //VS
 
@@ -128,7 +130,7 @@ CastPoint cast_ray_to_map(vec3 base, vec3 dir) {
 
 void main() {
     vec4 sp_ndc = vec4(
-        (gl_FragCoord.xy / u_ScreenSize.xy) * 2.0 - 1.0,
+        (gl_FragCoord.xy / u_ScreenSize.xy) * vec2(2.0, -2.0) + vec2(-1.0, 1.0),
         -1.0,
         1.0
     );

--- a/data/shader/terrain_ray_old.glsl
+++ b/data/shader/terrain_ray_old.glsl
@@ -11,10 +11,10 @@ layout(set = 0, binding = 0) uniform c_Globals {
 
 #ifdef SHADER_VS
 
-layout(location = 0) attribute vec4 a_Pos;
+layout(location = 0) attribute ivec4 a_Pos;
 
 void main() {
-    gl_Position = u_ViewProj * a_Pos;
+    gl_Position = u_ViewProj * vec4(a_Pos);
     // convert from -1,1 Z to 0,1
     gl_Position.z = 0.5 * (gl_Position.z + gl_Position.w);
 }

--- a/data/shader/terrain_ray_old.glsl
+++ b/data/shader/terrain_ray_old.glsl
@@ -15,8 +15,6 @@ layout(location = 0) attribute ivec4 a_Pos;
 
 void main() {
     gl_Position = u_ViewProj * vec4(a_Pos);
-    // convert from -1,1 Z to 0,1
-    gl_Position.z = 0.5 * (gl_Position.z + gl_Position.w);
 }
 #endif //VS
 
@@ -185,6 +183,6 @@ void main() {
     o_Color = frag_color;
 
     vec4 target_ndc = u_ViewProj * vec4(pt.pos, 1.0);
-    gl_FragDepth = target_ndc.z / target_ndc.w * 0.5 + 0.5;
+    gl_FragDepth = target_ndc.z / target_ndc.w;
 }
 #endif //FS

--- a/data/shader/terrain_ray_old.glsl
+++ b/data/shader/terrain_ray_old.glsl
@@ -1,6 +1,6 @@
 //!include fs:surface.inc fs:color.inc
 
-uniform c_Globals {
+layout(set = 0, binding = 0) uniform c_Globals {
     vec4 u_CameraPos;
     mat4 u_ViewProj;
     mat4 u_InvViewProj;
@@ -11,10 +11,12 @@ uniform c_Globals {
 
 #ifdef SHADER_VS
 
-attribute vec4 a_Pos;
+layout(location = 0) attribute vec4 a_Pos;
 
 void main() {
     gl_Position = u_ViewProj * a_Pos;
+    // convert from -1,1 Z to 0,1
+    gl_Position.z = 0.5 * (gl_Position.z + gl_Position.w);
 }
 #endif //VS
 
@@ -22,7 +24,7 @@ void main() {
 #ifdef SHADER_FS
 //imported: Surface, u_TextureScale, get_surface, evaluate_color
 
-uniform c_Locals {
+layout(set = 1, binding = 1) uniform c_Locals {
     vec4 u_ScreenSize;      // XY = size
 };
 
@@ -32,7 +34,7 @@ const float
 
 #define TERRAIN_WATER   0U
 
-out vec4 Target0;
+layout(location = 0) out vec4 o_Color;
 
 
 vec3 cast_ray_to_plane(float level, vec3 base, vec3 dir) {
@@ -85,7 +87,7 @@ Surface cast_ray_impl(
 struct CastPoint {
     vec3 pos;
     uint type;
-    vec3 tex_coord;
+    vec2 tex_coord;
     bool is_underground;
     //bool is_shadowed;
 };
@@ -180,7 +182,7 @@ void main() {
             frag_color += c_ReflectionPower * ref_color;
         }
     }
-    Target0 = frag_color;
+    o_Color = frag_color;
 
     vec4 target_ndc = u_ViewProj * vec4(pt.pos, 1.0);
     gl_FragDepth = target_ndc.z / target_ndc.w * 0.5 + 0.5;

--- a/lib/m3d/src/lib.rs
+++ b/lib/m3d/src/lib.rs
@@ -175,6 +175,11 @@ pub struct Model<M, S> {
     pub slots: [Slot<M>; MAX_SLOTS],
 }
 
+impl<M, S> Model<M, S> {
+    pub fn mesh_count(&self) -> usize {
+        1 + self.wheels.len() + self.debris.len() + MAX_SLOTS
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Bounds {

--- a/src/config/bunches.rs
+++ b/src/config/bunches.rs
@@ -1,7 +1,9 @@
-use config::text::Reader;
+use crate::config::text::Reader;
+
 use serde_scan;
 
 use std::fs::File;
+
 
 #[derive(Debug, Deserialize)]
 pub struct Cycle {

--- a/src/config/car.rs
+++ b/src/config/car.rs
@@ -1,9 +1,14 @@
-use config::Settings;
-use config::text::Reader;
-use gfx;
-use model;
+use crate::{
+    config::Settings,
+    config::text::Reader,
+    model,
+};
+
+use wgpu;
+
 use std::collections::HashMap;
 use std::fs::File;
+
 
 pub type BoxSize = u8;
 pub type Price = u32;
@@ -144,19 +149,19 @@ impl CarPhysics {
 }
 
 #[derive(Clone)]
-pub struct CarInfo<R: gfx::Resources> {
+pub struct CarInfo {
     pub kind: Kind,
     pub stats: CarStats,
     pub physics: CarPhysics,
-    pub model: model::RenderModel<R>,
+    pub model: model::RenderModel,
     pub scale: f32,
 }
 
-pub fn load_registry<R: gfx::Resources, F: gfx::Factory<R>>(
+pub fn load_registry(
     settings: &Settings,
     reg: &super::game::Registry,
-    factory: &mut F,
-) -> HashMap<String, CarInfo<R>> {
+    device: &wgpu::Device,
+) -> HashMap<String, CarInfo> {
     let mut map = HashMap::new();
     let mut fi = Reader::new(settings.open_relative("car.prm"));
     fi.advance();
@@ -198,7 +203,7 @@ pub fn load_registry<R: gfx::Resources, F: gfx::Factory<R>>(
                 },
                 stats: CarStats::new(&data),
                 physics,
-                model: model::load_m3d(file, factory),
+                model: model::load_m3d(file, device),
                 scale,
             },
         );

--- a/src/config/common.rs
+++ b/src/config/common.rs
@@ -1,5 +1,7 @@
-use config::text::Reader;
+use crate::config::text::Reader;
+
 use std::fs::File;
+
 
 // see `src/runtime.h` for original defines
 pub const MAIN_LOOP_TIME: f32 = 0.05;

--- a/src/config/escaves.rs
+++ b/src/config/escaves.rs
@@ -1,6 +1,7 @@
-use config::text::Reader;
+use crate::config::text::Reader;
 
 use std::fs::File;
+
 
 #[derive(Debug, Deserialize)]
 pub struct ItemSource {

--- a/src/config/game.rs
+++ b/src/config/game.rs
@@ -1,6 +1,10 @@
-use config::Settings;
-use config::text::Reader;
+use crate::{
+    config::Settings,
+    config::text::Reader,
+};
+
 use std::collections::HashMap;
+
 
 pub struct ModelInfo {
     pub path: String,

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::path::PathBuf;
 
+
 #[derive(Deserialize)]
 pub struct Car {
     pub id: String,

--- a/src/config/text.rs
+++ b/src/config/text.rs
@@ -5,6 +5,7 @@ use std::fmt::Debug;
 use std::io::{BufRead, BufReader, Read};
 use std::str::FromStr;
 
+
 pub struct Reader<I> {
     input: BufReader<I>,
     line: String,

--- a/src/config/worlds.rs
+++ b/src/config/worlds.rs
@@ -1,7 +1,8 @@
-use config::text::Reader;
+use crate::config::text::Reader;
 
 use std::collections::HashMap;
 use std::fs::File;
+
 
 pub type Worlds = HashMap<String, String>;
 

--- a/src/level/mod.rs
+++ b/src/level/mod.rs
@@ -130,7 +130,7 @@ impl Level {
             let base_y = (y * self.size.0) as usize * 4;
             for x in 0 .. self.size.0 {
                 let base_x = base_y + x as usize * 4;
-                let mut color = &mut data[base_x .. base_x + 4];
+                let color = &mut data[base_x .. base_x + 4];
                 match self.get((x, y)) {
                     Texel::Single(Point(alt, ty)) => {
                         color[0] = alt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,7 @@
-extern crate byteorder;
-extern crate cgmath;
-#[macro_use]
-extern crate gfx;
-extern crate ini;
 #[macro_use]
 extern crate log;
-extern crate m3d;
-extern crate rayon;
-extern crate ron;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde_scan;
-extern crate splay;
-
-//TODO: cleanup externs
 
 pub mod config;
 pub mod level;

--- a/src/model.rs
+++ b/src/model.rs
@@ -2,7 +2,8 @@ use wgpu;
 
 use m3d;
 use crate::render::{
-    DebugPos, ObjectVertex, ShapePolygon,
+    DebugPos, ShapePolygon,
+    object::Vertex as ObjectVertex,
 };
 
 use std::fs::File;

--- a/src/model.rs
+++ b/src/model.rs
@@ -128,8 +128,8 @@ pub fn load_c3d(
         num_vertices,
         wgpu::BufferUsageFlags::VERTEX,
     );
-    for (i, tri) in raw.geometry.polygons.iter().enumerate() {
-        for (vo, v) in mapping.data[i*3 .. i*3 + 3].iter_mut().zip(&tri.vertices) {
+    for (chunk, tri) in mapping.data.chunks_mut(3).zip(&raw.geometry.polygons) {
+        for (vo, v) in chunk.iter_mut().zip(&tri.vertices) {
             let p = raw.geometry.positions[v.pos as usize];
             let n = raw.geometry.normals[v.normal as usize];
             *vo = ObjectVertex {

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -56,10 +56,13 @@ enum ColorRate {
 type Selector = (Visibility, ColorRate);
 */
 
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DebugPos {
     pub pos: [f32; 4],
 }
+
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct DebugColor {
     pub color: [f32; 4],

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -1,18 +1,15 @@
-use std::collections::HashMap;
+use crate::{
+    config::settings,
+    model,
+    //render::{read_shaders, ShapePolygon},
+};
 
 use cgmath;
-use gfx;
-pub use gfx::pso::buffer::{InstanceRate, VertexBufferCommon};
-use gfx::traits::FactoryExt; // reduce the line width at use site
+use wgpu;
 
-use super::{
-    read_shaders,
-    ColorFormat, DepthFormat, MainTargets, ShapePolygon,
-};
-use config::settings;
-use model;
+//use std::collections::HashMap;
 
-
+/*
 const BLEND_FRONT: gfx::state::Blend = gfx::state::Blend {
     color: gfx::state::BlendChannel {
         equation: gfx::state::Equation::Add,
@@ -43,7 +40,9 @@ const DEPTH_BEHIND: gfx::state::Depth = gfx::state::Depth {
     fun: gfx::state::Comparison::Greater,
     write: false,
 };
+*/
 
+/*
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 enum Visibility {
     Front,
@@ -55,8 +54,18 @@ enum ColorRate {
     Instance,
 }
 type Selector = (Visibility, ColorRate);
+*/
 
-gfx_defines! {
+#[derive(Clone, Copy)]
+pub struct DebugPos {
+    pub pos: [f32; 4],
+}
+#[derive(Clone, Copy)]
+pub struct DebugColor {
+    pub color: [f32; 4],
+}
+
+/*gfx_defines! {
     vertex DebugPos {
         pos: [f32; 4] = "a_Pos",
     }
@@ -86,7 +95,7 @@ gfx_defines! {
         out_color: gfx::BlendTarget<ColorFormat> = ("Target0", gfx::state::ColorMask::all(), gfx::preset::blend::ALPHA),
         out_depth: gfx::DepthTarget<DepthFormat> = gfx::preset::depth::LESS_EQUAL_TEST,
     }
-}
+}*/
 
 pub struct LineBuffer {
     vertices: Vec<DebugPos>,
@@ -131,7 +140,8 @@ impl LineBuffer {
     }
 }
 
-pub struct DebugRender<R: gfx::Resources> {
+pub struct DebugRender {
+    /*
     settings: settings::DebugRender,
     buf_pos: gfx::handle::Buffer<R, DebugPos>,
     buf_col: gfx::handle::Buffer<R, DebugColor>,
@@ -139,14 +149,15 @@ pub struct DebugRender<R: gfx::Resources> {
     psos_line: HashMap<Selector, gfx::PipelineState<R, debug::Meta>>,
     pso_face: Option<gfx::PipelineState<R, shape::Meta>>,
     pso_edge: Option<gfx::PipelineState<R, shape::Meta>>,
+    */
 }
 
-impl<R: gfx::Resources> DebugRender<R> {
-    pub fn new<F: gfx::Factory<R>>(
-        factory: &mut F,
-        targets: MainTargets<R>,
-        settings: &settings::DebugRender,
+impl DebugRender {
+    pub fn new(
+        _device: &wgpu::Device,
+        _settings: &settings::DebugRender,
     ) -> Self {
+        /* TODO
         let data = debug::Data {
             buf_pos: factory
                 .create_buffer(
@@ -179,13 +190,12 @@ impl<R: gfx::Resources> DebugRender<R> {
             pso_edge: None,
         };
         result.reload(factory);
-        result
+        result*/
+        DebugRender {}
     }
 
-    pub fn reload<F: gfx::Factory<R>>(
-        &mut self,
-        factory: &mut F,
-    ) {
+    pub fn reload(&mut self, _device: &wgpu::Device) {
+        /* TODO
         let raster = gfx::state::Rasterizer::new_fill();
 
         if self.settings.collision_shapes {
@@ -252,22 +262,16 @@ impl<R: gfx::Resources> DebugRender<R> {
                     self.psos_line.insert((visibility, color_rate), pso);
                 }
             }
-        }
+        }*/
     }
 
-    pub fn resize(&mut self, targets: MainTargets<R>) {
-        self.data.out_color = targets.color;
-        self.data.out_depth = targets.depth;
-    }
-
-    fn draw_liner<C>(
+    fn _draw_liner(
         &mut self,
-        buf: gfx::handle::Buffer<R, DebugPos>,
-        num_verts: Option<usize>,
-        encoder: &mut gfx::Encoder<R, C>,
-    ) where
-        C: gfx::CommandBuffer<R>,
-    {
+        _buf: &wgpu::Buffer,
+        _num_verts: Option<usize>,
+        _pass: &mut wgpu::RenderPass,
+    ) {
+        /* TODO
         let (color_rate, slice) = match num_verts {
             Some(num) => (
                 ColorRate::Vertex,
@@ -286,17 +290,16 @@ impl<R: gfx::Resources> DebugRender<R> {
             if let Some(ref pso) = self.psos_line.get(&(vis, color_rate)) {
                 encoder.draw(&slice, pso, &self.data);
             }
-        }
+        }*/
     }
 
-    pub fn draw_shape<C>(
+    pub fn draw_shape(
         &mut self,
-        shape: &model::Shape<R>,
-        transform: cgmath::Matrix4<f32>,
-        encoder: &mut gfx::Encoder<R, C>,
-    ) where
-        C: gfx::CommandBuffer<R>,
-    {
+        _pass: &mut wgpu::RenderPass,
+        _shape: &model::Shape,
+        _transform: cgmath::Matrix4<f32>,
+    ) {
+        /* TODO
         let mut locals = DebugLocals {
             m_mvp: transform.into(),
             color: [0.0, 1.0, 0.0, 0.1],
@@ -340,17 +343,16 @@ impl<R: gfx::Resources> DebugRender<R> {
                 )
                 .unwrap();
             self.draw_liner(samples.clone(), None, encoder);
-        }
+        }*/
     }
 
-    pub fn draw_lines<C>(
+    pub fn draw_lines(
         &mut self,
-        linebuf: &LineBuffer,
-        transform: cgmath::Matrix4<f32>,
-        encoder: &mut gfx::Encoder<R, C>,
-    ) where
-        C: gfx::CommandBuffer<R>,
-    {
+        _linebuf: &LineBuffer,
+        _transform: cgmath::Matrix4<f32>,
+        _encoder: &mut wgpu::CommandEncoder,
+    ){
+        /* TODO
         let mut vertices = linebuf.vertices.as_slice();
         let mut colors = linebuf.colors.as_slice();
         if vertices.len() > self.settings.max_vertices {
@@ -386,5 +388,6 @@ impl<R: gfx::Resources> DebugRender<R> {
         encoder.update_buffer(&self.buf_col, colors, 0).unwrap();
         let buf = self.buf_pos.clone();
         self.draw_liner(buf, Some(vertices.len()), encoder);
+        */
     }
 }

--- a/src/render/global.rs
+++ b/src/render/global.rs
@@ -1,0 +1,98 @@
+use crate::{
+    config::settings,
+    space::Camera,
+};
+use wgpu;
+
+use std::mem;
+
+
+#[derive(Clone, Copy)]
+pub struct Constants {
+    _camera_pos: [f32; 4],
+    _m_vp: [[f32; 4]; 4],
+    _m_inv_vp: [[f32; 4]; 4],
+    _light_pos: [f32; 4],
+    _light_color: [f32; 4],
+}
+
+impl Constants {
+    pub fn new(cam: &Camera, light: &settings::Light) -> Self {
+        use cgmath::SquareMatrix;
+
+        let mx_vp = cam.get_view_proj();
+        Constants {
+            _camera_pos: cam.loc.extend(1.0).into(),
+            _m_vp: mx_vp.into(),
+            _m_inv_vp: mx_vp.invert().unwrap().into(),
+            _light_pos: light.pos,
+            _light_color: light.color,
+        }
+    }
+}
+
+pub struct Context {
+    pub uniform_buf: wgpu::Buffer,
+    pub palette_sampler: wgpu::Sampler,
+    pub bind_group: wgpu::BindGroup,
+    pub bind_group_layout: wgpu::BindGroupLayout,
+}
+
+impl Context {
+    pub fn new(device: &wgpu::Device) -> Self {
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            bindings: &[
+                wgpu::BindGroupLayoutBinding {
+                    binding: 0,
+                    visibility: wgpu::ShaderStageFlags::VERTEX | wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::UniformBuffer,
+                },
+                wgpu::BindGroupLayoutBinding { // palette sampler
+                    binding: 1,
+                    visibility: wgpu::ShaderStageFlags::VERTEX | wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler,
+                },
+            ],
+        });
+        let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            size: mem::size_of::<Constants>() as u32,
+            usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+        });
+        let palette_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            r_address_mode: wgpu::AddressMode::ClampToEdge,
+            s_address_mode: wgpu::AddressMode::ClampToEdge,
+            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            lod_min_clamp: 0.0,
+            lod_max_clamp: 0.0,
+            max_anisotropy: 0,
+            compare_function: wgpu::CompareFunction::Always,
+            border_color: wgpu::BorderColor::TransparentBlack,
+        });
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &bind_group_layout,
+            bindings: &[
+                wgpu::Binding {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &uniform_buf,
+                        range: 0 .. mem::size_of::<Constants>() as u32,
+                    },
+                },
+                wgpu::Binding {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&palette_sampler),
+                },
+            ],
+        });
+
+        Context {
+            uniform_buf,
+            palette_sampler,
+            bind_group_layout,
+            bind_group,
+        }
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -1,33 +1,31 @@
-use cgmath::{Decomposed, Matrix4};
-use gfx;
-use gfx::traits::FactoryExt;
+use crate::{
+    config::settings,
+    level,
+    model,
+    space::{Camera, Transform},
+};
 
-use {level, model};
 use m3d::NUM_COLOR_IDS;
-use config::settings;
-use space::{Camera, Transform};
+
+use cgmath::{Decomposed, Matrix4};
+use wgpu;
 
 use std::io::Error as IoError;
+use std::mem;
 
-mod collision;
+
+//mod collision; ../TODO
 mod debug;
 
-pub use self::collision::{DebugBlit, GpuCollider, ShapeId};
+//pub use self::collision::{DebugBlit, GpuCollider, ShapeId};
 pub use self::debug::{DebugPos, DebugRender, LineBuffer};
 
 
-pub struct MainTargets<R: gfx::Resources> {
-    pub color: gfx::handle::RenderTargetView<R, ColorFormat>,
-    pub depth: gfx::handle::DepthStencilView<R, DepthFormat>,
+pub struct SurfaceData {
+    pub constants: wgpu::Buffer,
+    pub height: (wgpu::TextureView, wgpu::Sampler),
+    pub meta: (wgpu::TextureView, wgpu::Sampler),
 }
-
-pub struct SurfaceData<R: gfx::Resources> {
-    pub constants: gfx::handle::Buffer<R, SurfaceConstants>,
-    pub height: (gfx::handle::ShaderResourceView<R, f32>, gfx::handle::Sampler<R>),
-    pub meta: (gfx::handle::ShaderResourceView<R, u32>, gfx::handle::Sampler<R>),
-}
-
-const MAX_TEX_HEIGHT: i32 = 4096;
 
 const COLOR_TABLE: [[u8; 2]; NUM_COLOR_IDS as usize] = [
     [0, 0],   // reserved
@@ -57,288 +55,120 @@ const COLOR_TABLE: [[u8; 2]; NUM_COLOR_IDS as usize] = [
     [224, 4], // rotten item
 ];
 
-pub type ColorFormat = gfx::format::Rgba8; //should be Srgba8
-pub type DepthFormat = gfx::format::DepthStencil;
-type HeightFormat = (gfx::format::R8, gfx::format::Unorm);
+pub const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8UnormSrgb;
+pub const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::D24UnormS8Uint;
 pub type ShapeVertex = [f32; 4];
 
-gfx_defines!{
-    vertex ShapePolygon {
-        indices: [u16; 4] = "a_Indices",
-        normal: [gfx::format::I8Norm; 4] = "a_Normal",
-        origin_square: [f32; 4] = "a_OriginSquare",
-    }
-
-    vertex TerrainVertex {
-        pos: [f32; 4] = "a_Pos",
-    }
-
-    constant SurfaceConstants {
-        tex_scale: [f32; 4] = "u_TextureScale",
-    }
-
-    constant TerrainConstants {
-        scr_size: [f32; 4] = "u_ScreenSize",
-        params: [u32; 4] = "u_Params",
-    }
-
-    constant Globals {
-        camera_pos: [f32; 4] = "u_CameraPos",
-        m_vp: [[f32; 4]; 4] = "u_ViewProj",
-        m_inv_vp: [[f32; 4]; 4] = "u_InvViewProj",
-        light_pos: [f32; 4] = "u_LightPos",
-        light_color: [f32; 4] = "u_LightColor",
-    }
-
-    pipeline terrain {
-        vbuf: gfx::VertexBuffer<TerrainVertex> = (),
-        globals: gfx::ConstantBuffer<Globals> = "c_Globals",
-        suf_constants: gfx::ConstantBuffer<SurfaceConstants> = "c_Surface",
-        terr_constants: gfx::ConstantBuffer<TerrainConstants> = "c_Locals",
-        height: gfx::TextureSampler<f32> = "t_Height",
-        meta: gfx::TextureSampler<u32> = "t_Meta",
-        flood: gfx::TextureSampler<f32> = "t_Flood",
-        palette: gfx::TextureSampler<[f32; 4]> = "t_Palette",
-        table: gfx::TextureSampler<[u32; 4]> = "t_Table",
-        out_color: gfx::RenderTarget<ColorFormat> = "Target0",
-        out_depth: gfx::DepthTarget<DepthFormat> = gfx::preset::depth::LESS_EQUAL_WRITE,
-    }
-
-    vertex ObjectVertex {
-        pos: [i8; 4] = "a_Pos",
-        color: u32 = "a_ColorIndex",
-        normal: [gfx::format::I8Norm; 4] = "a_Normal",
-    }
-
-    constant ObjectLocals {
-        m_model: [[f32; 4]; 4] = "u_Model",
-    }
-
-    pipeline object {
-        vbuf: gfx::VertexBuffer<ObjectVertex> = (),
-        globals: gfx::ConstantBuffer<Globals> = "c_Globals",
-        locals: gfx::ConstantBuffer<ObjectLocals> = "c_Locals",
-        ctable: gfx::TextureSampler<[u32; 2]> = "t_ColorTable",
-        palette: gfx::TextureSampler<[f32; 4]> = "t_Palette",
-        out_color: gfx::RenderTarget<ColorFormat> = "Target0",
-        out_depth: gfx::DepthTarget<DepthFormat> = gfx::preset::depth::LESS_EQUAL_WRITE,
-    }
-
-    pipeline terrain_mip {
-        vbuf: gfx::VertexBuffer<TerrainVertex> = (),
-        suf_constants: gfx::ConstantBuffer<SurfaceConstants> = "c_Surface",
-        height: gfx::TextureSampler<f32> = "t_Height",
-        out_color: gfx::RenderTarget<HeightFormat> = "Target0",
-    }
+#[derive(Clone, Copy)]
+pub struct ObjectVertex {
+    pub pos: [i8; 4],
+    pub color: u32,
+    pub normal: [i8; 4],
 }
 
-enum Terrain<R: gfx::Resources> {
-    RayOld {
-        pso: gfx::PipelineState<R, terrain::Meta>,
-    },
+#[derive(Clone, Copy)]
+struct ObjectLocals {
+    _matrix: [[f32; 4]; 4],
+}
+
+#[derive(Clone, Copy)]
+struct TerrainVertex {
+    _pos: [i8; 4],
+}
+
+#[derive(Clone, Copy)]
+pub struct ShapePolygon {
+    pub indices: [u16; 4],
+    pub normal: [i8; 4],
+    pub origin_square: [f32; 4],
+}
+
+#[derive(Clone, Copy)]
+struct SurfaceConstants {
+    _tex_scale: [f32; 4],
+}
+
+#[derive(Clone, Copy)]
+struct TerrainConstants {
+    _scr_size: [f32; 4],
+}
+
+#[derive(Clone, Copy)]
+struct Globals {
+    _camera_pos: [f32; 4],
+    _m_vp: [[f32; 4]; 4],
+    _m_inv_vp: [[f32; 4]; 4],
+    _light_pos: [f32; 4],
+    _light_color: [f32; 4],
+}
+
+enum Terrain {
     Ray {
-        pso: gfx::PipelineState<R, terrain::Meta>,
-        mipper: MaxMipper<R>,
-        params: [u32; 4],
+        pipeline: wgpu::RenderPipeline,
+        vertex_buf: wgpu::Buffer,
+        index_buf: wgpu::Buffer,
+        num_indices: usize,
     },
-    Tess {
-        pso_low: gfx::PipelineState<R, terrain::Meta>,
-        pso_high: gfx::PipelineState<R, terrain::Meta>,
+    /*Tess {
+        low: gfx::PipelineState<R, terrain::Meta>,
+        high: gfx::PipelineState<R, terrain::Meta>,
         screen_space: bool,
-    },
+    },*/
 }
 
-
-struct TerrainMip<R: gfx::Resources> {
-    target: gfx::handle::RenderTargetView<R, HeightFormat>,
+pub struct Updater<'a> {
+    command_encoder: wgpu::CommandEncoder,
+    device: &'a wgpu::Device,
 }
 
-struct MaxMipper<R: gfx::Resources> {
-    slice_size: (gfx::texture::Size, gfx::texture::Size),
-    pso: gfx::PipelineState<R, terrain_mip::Meta>,
-    data: terrain_mip::Data<R>,
-    mips: Vec<Vec<TerrainMip<R>>>,
-    vertex_capacity: usize,
-}
-
-impl<R: gfx::Resources> MaxMipper<R> {
-    fn create_pso<F: gfx::Factory<R>>(
-        factory: &mut F
-    ) -> gfx::PipelineState<R, terrain_mip::Meta> {
-         let shaders = read_shaders("terrain_mip", false, &[])
-            .unwrap();
-        let program = factory
-            .link_program(&shaders.vs, &shaders.fs)
-            .unwrap();
-        factory
-            .create_pipeline_from_program(
-                &program,
-                gfx::Primitive::TriangleList,
-                gfx::state::Rasterizer::new_fill(),
-                terrain_mip::new(),
-            )
-            .unwrap()
-    }
-
-    fn new<F: gfx::Factory<R>>(
-        factory: &mut F, texture: &gfx::handle::Texture<R, gfx::format::R8>
-    ) -> Self {
-        use gfx::{memory as mem, texture as tex};
-
-        let info = texture.get_info();
-        let num_slices = info.kind.get_num_slices().unwrap_or(1);
-        let mut mips = Vec::new();
-        for slice in 0 .. num_slices {
-            let mut slice_mips = Vec::with_capacity(info.levels as usize);
-            for level in 0 .. info.levels {
-                slice_mips.push(TerrainMip {
-                    target: factory
-                        .view_texture_as_render_target(texture, level, Some(slice))
-                        .unwrap(),
-                });
-            }
-            mips.push(slice_mips);
-        }
-
-        let srv = factory
-            .view_texture_as_shader_resource::<HeightFormat>(
-                texture, (0, info.levels - 1), gfx::format::Swizzle::new()
-            )
-            .unwrap();
-        let sampler = factory
-            .create_sampler(tex::SamplerInfo::new(
-                tex::FilterMethod::Mipmap,
-                tex::WrapMode::Tile,
-            ));
-
-        let vertex_capacity = 256;
-        let (wid, het, _, _) = info.kind.get_dimensions();
-
-        MaxMipper {
-            slice_size: (wid, het),
-            pso: Self::create_pso(factory),
-            data: terrain_mip::Data {
-                vbuf: factory
-                    .create_buffer(
-                        vertex_capacity,
-                        gfx::buffer::Role::Vertex,
-                        mem::Usage::Dynamic,
-                        mem::Bind::TRANSFER_DST,
-                    )
-                    .unwrap(),
-                suf_constants: factory.create_constant_buffer(1),
-                height: (srv, sampler),
-                out_color: mips[0][0].target.clone(),
-            },
-            mips,
-            vertex_capacity,
-        }
-    }
-
-    fn update<C: gfx::CommandBuffer<R>>(
-        &self,
-        encoder: &mut gfx::Encoder<R, C>,
-        base_rects: &[gfx::Rect],
-    ) {
-        let mut slice_rects = vec![Vec::new(); self.mips.len()];
-        for r in base_rects {
-            let mut base_slice = r.y / self.slice_size.1;
-            while (r.y + r.h) > base_slice * self.slice_size.1 {
-                let cut_bot = r.y.max(base_slice * self.slice_size.1);
-                let cut_top = (r.y + r.h).min((base_slice + 1) * self.slice_size.1);
-                slice_rects[base_slice as usize].push(gfx::Rect {
-                    y: cut_bot - base_slice * self.slice_size.1,
-                    h: cut_top - cut_bot,
-                    .. *r
-                });
-                base_slice += 1;
-            }
-        }
-
-        let mut vertices = Vec::with_capacity(base_rects.len() * 6);
-        for ((slice_id, slice_mips), rects) in self.mips.iter().enumerate().zip(slice_rects) {
-            if rects.is_empty() {
-                continue
-            }
-
-            for r in rects {
-                let v_abs = [
-                    (r.x, r.y),
-                    (r.x + r.w, r.y),
-                    (r.x, r.y + r.h),
-                    (r.x, r.y + r.h),
-                    (r.x + r.w, r.y),
-                    (r.x + r.w, r.y + r.h),
-                ];
-                for &(x, y) in &v_abs {
-                    vertices.push(TerrainVertex {
-                        pos: [
-                            x as f32 / self.slice_size.0 as f32,
-                            y as f32 / self.slice_size.1 as f32,
-                            slice_id as f32,
-                            1.0,
-                        ],
-                    });
-                }
-            }
-
-            assert!(vertices.len() <= self.vertex_capacity);
-            encoder.update_buffer(&self.data.vbuf, &vertices, 0).unwrap();
-            let slice = gfx::Slice {
-                end: vertices.len() as gfx::VertexCount,
-                .. gfx::Slice::new_match_vertex_buffer(&self.data.vbuf)
-            };
-
-            for mip in 0 .. slice_mips.len() - 1 {
-                vertices.clear();
-
-                let suf_constants = SurfaceConstants {
-                    tex_scale: [
-                        (self.slice_size.0 >> mip) as f32,
-                        (self.slice_size.1 >> mip) as f32,
-                        mip as f32,
-                        1.0,
-                    ],
-                };
-                encoder.update_constant_buffer(&self.data.suf_constants, &suf_constants);
-
-                encoder.draw(&slice, &self.pso, &terrain_mip::Data {
-                    out_color: slice_mips[mip + 1].target.clone(),
-                    .. self.data.clone()
-                });
-            }
-        }
+impl<'a> Updater<'a> {
+    pub fn update<T: 'static + Copy>(&mut self, buffer: &wgpu::Buffer, data: &[T]) {
+        let staging = self.device
+            .create_buffer_mapped(data.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(data);
+        self.command_encoder.copy_buffer_to_buffer(
+            &staging,
+            0,
+            buffer,
+            0,
+            mem::size_of::<T>() as u32,
+        );
     }
 }
 
-
-pub struct Render<R: gfx::Resources> {
-    terrain: Terrain<R>,
-    terrain_data: terrain::Data<R>,
-    terrain_slice: gfx::Slice<R>,
-    terrain_scale: [f32; 4],
-    terrain_dirty_rects: Vec<gfx::Rect>,
-    object_pso: gfx::PipelineState<R, object::Meta>,
-    object_data: object::Data<R>,
+pub struct Render {
+    global_bg: wgpu::BindGroup,
+    global_uni_buf: wgpu::Buffer,
+    terrain_bg: wgpu::BindGroup,
+    terrain_uni_buf: wgpu::Buffer,
+    terrain_pipeline_layout: wgpu::PipelineLayout,
+    terrain: Terrain,
+    object_bg: wgpu::BindGroup,
+    object_uni_buf: wgpu::Buffer,
+    object_pipeline_layout: wgpu::PipelineLayout,
+    object_pipeline: wgpu::RenderPipeline,
     pub light_config: settings::Light,
-    pub debug: debug::DebugRender<R>,
+    pub debug: debug::DebugRender,
 }
 
-pub struct RenderModel<'a, R: gfx::Resources> {
-    pub model: &'a model::RenderModel<R>,
+pub struct RenderModel<'a> {
+    pub model: &'a model::RenderModel,
     pub transform: Transform,
     pub debug_shape_scale: Option<f32>,
 }
 
 pub struct Shaders {
-    vs: Vec<u8>,
-    tec: Vec<u8>,
-    tev: Vec<u8>,
-    fs: Vec<u8>,
+    vs: wgpu::ShaderModule,
+    fs: wgpu::ShaderModule,
 }
 
 #[doc(hidden)]
-pub fn read_shaders(name: &str, tessellate: bool, specialization: &[&str]) -> Result<Shaders, IoError> {
+pub fn read_shaders(
+    name: &str,
+    specialization: &[&str],
+    device: &wgpu::Device,
+) -> Result<Shaders, IoError> {
+    use glsl_to_spirv;
     use std::fs::File;
     use std::io::{BufReader, Read, Write};
     use std::path::PathBuf;
@@ -351,19 +181,8 @@ pub fn read_shaders(name: &str, tessellate: bool, specialization: &[&str]) -> Re
         panic!("Shader not found: {:?}", path);
     }
 
-    let prelude = format!("#version 150 core\n// shader: {}\n", name);
     let mut buf_vs = Vec::new();
-    write!(buf_vs, "{}#define SHADER_VS\n", prelude)?;
     let mut buf_fs = Vec::new();
-    write!(buf_fs, "{}#define SHADER_FS\n", prelude)?;
-
-    let mut buf_tec = Vec::new();
-    let mut buf_tev = Vec::new();
-    if tessellate {
-        let ext = format!("#extension GL_ARB_tessellation_shader: require\n");
-        write!(buf_tec, "{}{}", prelude, ext)?;
-        write!(buf_tev, "{}{}", prelude, ext)?;
-    }
 
     let mut code = String::new();
     BufReader::new(File::open(&path)?)
@@ -377,8 +196,6 @@ pub fn read_shaders(name: &str, tessellate: bool, specialization: &[&str]) -> Re
                 let mut temp = include_pair.split(':');
                 let target = match temp.next().unwrap() {
                     "vs" => &mut buf_vs,
-                    "tec" => &mut buf_tec,
-                    "tev" => &mut buf_tev,
                     "fs" => &mut buf_fs,
                     other => panic!("Unknown target: {}", other),
                 };
@@ -400,10 +217,6 @@ pub fn read_shaders(name: &str, tessellate: bool, specialization: &[&str]) -> Re
                 };
                 write!(buf_vs, "#define {} {}\n", define, value)?;
                 write!(buf_fs, "#define {} {}\n", define, value)?;
-                if tessellate {
-                    write!(buf_tec, "#define {} {}\n", define, value)?;
-                    write!(buf_tev, "#define {} {}\n", define, value)?;
-                }
             }
         }
     }
@@ -416,32 +229,47 @@ pub fn read_shaders(name: &str, tessellate: bool, specialization: &[&str]) -> Re
         .replace("varying", "in")
     )?;
 
-    debug!("vs:\n{}", String::from_utf8_lossy(&buf_vs));
-    debug!("fs:\n{}", String::from_utf8_lossy(&buf_fs));
+    let str_vs = String::from_utf8_lossy(&buf_vs);
+    let str_fs = String::from_utf8_lossy(&buf_fs);
+    debug!("vs:\n{}", str_vs);
+    debug!("fs:\n{}", str_fs);
 
-    if tessellate {
-        write!(buf_tec, "\n#define SHADER_TEC\n{}", code)?;
-        write!(buf_tev, "\n#define SHADER_TEV\n{}", code)?;
-        debug!("tec:\n{}", String::from_utf8_lossy(&buf_tec));
-        debug!("tev:\n{}", String::from_utf8_lossy(&buf_tev));
-    }
+    let mut output_vs = glsl_to_spirv::compile(&str_vs, glsl_to_spirv::ShaderType::Vertex).unwrap();
+    let mut spv_vs = Vec::new();
+    output_vs.read_to_end(&mut spv_vs).unwrap();
+
+    let mut output_fs = glsl_to_spirv::compile(&str_fs, glsl_to_spirv::ShaderType::Fragment).unwrap();
+    let mut spv_fs = Vec::new();
+    output_fs.read_to_end(&mut spv_fs).unwrap();
 
     Ok(Shaders {
-        vs: buf_vs,
-        tec: buf_tec,
-        tev: buf_tev,
-        fs: buf_fs,
+        vs: device.create_shader_module(&spv_vs),
+        fs: device.create_shader_module(&spv_fs),
     })
 }
 
-pub fn init<R: gfx::Resources, F: gfx::Factory<R>>(
-    factory: &mut F,
-    targets: MainTargets<R>,
+pub fn init(
+    device: &mut wgpu::Device,
     level: &level::Level,
     object_palette: &[[u8; 4]],
     settings: &settings::Render,
-) -> Render<R> {
-    use gfx::{memory as mem, texture as tex};
+) -> Render {
+    let origin = wgpu::Origin3d { x: 0.0, y: 0.0, z: 0.0 };
+    let extent = wgpu::Extent3d {
+        width: level.size.0 as u32,
+        height: level.size.1 as u32,
+        depth: 1,
+    };
+    let flood_extent = wgpu::Extent3d {
+        width: level.size.1 as u32 >> level.flood_section_power,
+        height: 1,
+        depth: 1,
+    };
+    let table_extent = wgpu::Extent3d {
+        width: level::NUM_TERRAINS as u32,
+        height: 1,
+        depth: 1,
+    };
 
     let terrrain_table = level.terrains
         .iter()
@@ -453,262 +281,509 @@ pub fn init<R: gfx::Resources, F: gfx::Factory<R>>(
         ])
         .collect::<Vec<_>>();
 
-    let real_height = if level.size.1 >= MAX_TEX_HEIGHT {
-        assert_eq!(level.size.1 % MAX_TEX_HEIGHT, 0);
-        MAX_TEX_HEIGHT
-    } else {
-        level.size.1
-    };
-    let num_layers = level.size.1 / real_height;
-    let kind = tex::Kind::D2Array(
-        level.size.0 as tex::Size,
-        real_height as tex::Size,
-        num_layers as tex::Size,
-        tex::AaMode::Single,
+    let height_texture = device.create_texture(&wgpu::TextureDescriptor {
+        size: extent,
+        array_size: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::R8Unorm,
+        usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+    });
+    let meta_texture = device.create_texture(&wgpu::TextureDescriptor {
+        size: extent,
+        array_size: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::R8Uint,
+        usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+    });
+    let flood_texture = device.create_texture(&wgpu::TextureDescriptor {
+        size: flood_extent,
+        array_size: 1,
+        dimension: wgpu::TextureDimension::D1,
+        format: wgpu::TextureFormat::R8Unorm,
+        usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+    });
+    let table_texture = device.create_texture(&wgpu::TextureDescriptor {
+        size: table_extent,
+        array_size: 1,
+        dimension: wgpu::TextureDimension::D1,
+        format: wgpu::TextureFormat::Rgba8Uint,
+        usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+    });
+
+    let height_staging = device
+        .create_buffer_mapped(level.height.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+        .fill_from_slice(&level.height);
+    let meta_staging = device
+        .create_buffer_mapped(level.meta.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+        .fill_from_slice(&level.meta);
+    let flood_staging = device
+        .create_buffer_mapped(level.flood_map.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+        .fill_from_slice(&level.flood_map);
+    let table_staging = device
+        .create_buffer_mapped(terrrain_table.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+        .fill_from_slice(&terrrain_table);
+
+    let mut init_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        todo: 0,
+    });
+    init_encoder.copy_buffer_to_texture(
+        wgpu::BufferCopyView {
+            buffer: &height_staging,
+            offset: 0,
+            row_pitch: level.size.0 as u32,
+            image_height: level.size.1 as u32,
+        },
+        wgpu::TextureCopyView {
+            texture: &height_texture,
+            level: 0,
+            slice: 0,
+            origin,
+        },
+        extent,
     );
+    init_encoder.copy_buffer_to_texture(
+        wgpu::BufferCopyView {
+            buffer: &meta_staging,
+            offset: 0,
+            row_pitch: level.size.0 as u32,
+            image_height: level.size.1 as u32,
+        },
+        wgpu::TextureCopyView {
+            texture: &meta_texture,
+            level: 0,
+            slice: 0,
+            origin,
+        },
+        extent,
+    );
+    init_encoder.copy_buffer_to_texture(
+        wgpu::BufferCopyView {
+            buffer: &flood_staging,
+            offset: 0,
+            row_pitch: flood_extent.width,
+            image_height: 1,
+        },
+        wgpu::TextureCopyView {
+            texture: &flood_texture,
+            level: 0,
+            slice: 0,
+            origin,
+        },
+        flood_extent,
+    );
+    init_encoder.copy_buffer_to_texture(
+        wgpu::BufferCopyView {
+            buffer: &table_staging,
+            offset: 0,
+            row_pitch: table_extent.width,
+            image_height: 1,
+        },
+        wgpu::TextureCopyView {
+            texture: &table_texture,
+            level: 0,
+            slice: 0,
+            origin,
+        },
+        table_extent,
+    );
+    let (level_palette_view, palette_sampler) = Render::create_palette(
+        &mut init_encoder, &level.palette, device
+    );
+    let (object_palette_view, _) = Render::create_palette(
+        &mut init_encoder, object_palette, device
+    );
+    let (color_table_view, color_table_sampler) = Render::create_color_table(
+        &mut init_encoder, device
+    );
+    device.get_queue().submit(&[
+        init_encoder.finish(),
+    ]);
 
-    let terrain_mip_count = match settings.terrain {
-        settings::Terrain::RayTracedOld |
-        settings::Terrain::Tessellated { .. } => 1,
-        settings::Terrain::RayTraced { mip_count, .. } => mip_count,
-    };
-    let zero = vec![0; (level.size.0 * real_height) as usize / 4];
-    let mut height_data = Vec::new();
-    for chunk in level.height.chunks((level.size.0 * real_height) as usize) {
-        height_data.push(chunk);
-        for mip in 1 .. terrain_mip_count {
-            let w = level.size.0 as usize >> mip;
-            let h = real_height as usize >> mip;
-            height_data.push(&zero[.. w * h]);
-        }
-    }
+    let repeat_nearest_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        r_address_mode: wgpu::AddressMode::Repeat,
+        s_address_mode: wgpu::AddressMode::Repeat,
+        t_address_mode: wgpu::AddressMode::Repeat,
+        mag_filter: wgpu::FilterMode::Nearest,
+        min_filter: wgpu::FilterMode::Nearest,
+        mipmap_filter: wgpu::FilterMode::Nearest,
+        lod_min_clamp: 0.0,
+        lod_max_clamp: 0.0,
+        max_anisotropy: 0,
+        compare_function: wgpu::CompareFunction::Always,
+        border_color: wgpu::BorderColor::TransparentBlack,
+    });
+    let flood_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        r_address_mode: wgpu::AddressMode::Repeat,
+        s_address_mode: wgpu::AddressMode::ClampToEdge,
+        t_address_mode: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        mipmap_filter: wgpu::FilterMode::Nearest,
+        lod_min_clamp: 0.0,
+        lod_max_clamp: 0.0,
+        max_anisotropy: 0,
+        compare_function: wgpu::CompareFunction::Always,
+        border_color: wgpu::BorderColor::TransparentBlack,
+    });
+    let table_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        r_address_mode: wgpu::AddressMode::ClampToEdge,
+        s_address_mode: wgpu::AddressMode::ClampToEdge,
+        t_address_mode: wgpu::AddressMode::ClampToEdge,
+        mag_filter: wgpu::FilterMode::Nearest,
+        min_filter: wgpu::FilterMode::Nearest,
+        mipmap_filter: wgpu::FilterMode::Nearest,
+        lod_min_clamp: 0.0,
+        lod_max_clamp: 0.0,
+        max_anisotropy: 0,
+        compare_function: wgpu::CompareFunction::Always,
+        border_color: wgpu::BorderColor::TransparentBlack,
+    });
 
-    let meta_data: Vec<_> = level
-        .meta
-        .chunks((level.size.0 * real_height) as usize)
-        .collect();
-
-    let tex_height_raw = factory
-        .create_texture_raw(
-            tex::Info {
-                kind,
-                levels: terrain_mip_count as tex::Level,
-                format: gfx::format::SurfaceType::R8,
-                bind: mem::Bind::SHADER_RESOURCE | mem::Bind::RENDER_TARGET,
-                usage: mem::Usage::Data,
+    let global_bg_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        bindings: &[
+            wgpu::BindGroupLayoutBinding {
+                binding: 0,
+                visibility: wgpu::ShaderStageFlags::VERTEX | wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::UniformBuffer,
             },
-            Some(gfx::format::ChannelType::Unorm),
-            Some((&height_data, tex::Mipmap::Provided)),
+            wgpu::BindGroupLayoutBinding { // palette sampler
+                binding: 1,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::Sampler,
+            },
+        ],
+    });
+    let terrain_bg_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        bindings: &[
+            wgpu::BindGroupLayoutBinding { // surface uniforms
+                binding: 0,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::UniformBuffer,
+            },
+            wgpu::BindGroupLayoutBinding { // terrain locals
+                binding: 1,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::UniformBuffer,
+            },
+            wgpu::BindGroupLayoutBinding { // height map
+                binding: 2,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::SampledTexture,
+            },
+            wgpu::BindGroupLayoutBinding { // meta map
+                binding: 3,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::SampledTexture,
+            },
+            wgpu::BindGroupLayoutBinding { // flood map
+                binding: 4,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::SampledTexture,
+            },
+            wgpu::BindGroupLayoutBinding { // table map
+                binding: 5,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::SampledTexture,
+            },
+            wgpu::BindGroupLayoutBinding { // palette map
+                binding: 6,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::SampledTexture,
+            },
+            wgpu::BindGroupLayoutBinding { // main sampler
+                binding: 7,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::Sampler,
+            },
+            wgpu::BindGroupLayoutBinding { // flood sampler
+                binding: 8,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::Sampler,
+            },
+            wgpu::BindGroupLayoutBinding { // table sampler
+                binding: 9,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::Sampler,
+            },
+        ],
+    });
+    let object_bg_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        bindings: &[
+            wgpu::BindGroupLayoutBinding { // object locals
+                binding: 0,
+                visibility: wgpu::ShaderStageFlags::VERTEX,
+                ty: wgpu::BindingType::UniformBuffer,
+            },
+            wgpu::BindGroupLayoutBinding { // color map
+                binding: 1,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::SampledTexture,
+            },
+            wgpu::BindGroupLayoutBinding { // palette map
+                binding: 2,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::SampledTexture,
+            },
+            wgpu::BindGroupLayoutBinding { // main sampler
+                binding: 3,
+                visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                ty: wgpu::BindingType::Sampler,
+            },
+        ],
+    });
+
+    let global_uni_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        size: mem::size_of::<Globals>() as u32,
+        usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+    });
+    let global_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        layout: &global_bg_layout,
+        bindings: &[
+            wgpu::Binding {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer {
+                    buffer: &global_uni_buf,
+                    range: 0 .. mem::size_of::<Globals>() as u32,
+                },
+            },
+            wgpu::Binding {
+                binding: 1,
+                resource: wgpu::BindingResource::Sampler(&palette_sampler),
+            },
+        ],
+    });
+
+    let surface_uni_buf = device
+        .create_buffer_mapped(
+            mem::size_of::<SurfaceConstants>(),
+            wgpu::BufferUsageFlags::UNIFORM,
         )
-        .unwrap();
-    let tex_height = mem::Typed::new(tex_height_raw);
-    let height = factory
-        .view_texture_as_shader_resource::<HeightFormat>(
-            &tex_height,
-            (0, terrain_mip_count as tex::Level - 1),
-            gfx::format::Swizzle::new(),
-        )
-        .unwrap();
+        .fill_from_slice(&[SurfaceConstants {
+            _tex_scale: [
+                level.size.0 as f32,
+                level.size.1 as f32,
+                level::HEIGHT_SCALE as f32,
+                0.0,
+            ],
+        }]);
+    let terrain_uni_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        size: mem::size_of::<TerrainConstants>() as u32,
+        usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+    });
 
-    let (_, meta) = factory
-        .create_texture_immutable::<(gfx::format::R8, gfx::format::Uint)>(kind, tex::Mipmap::Provided, &meta_data)
-        .unwrap();
-    let (_, flood) = factory
-        .create_texture_immutable::<(gfx::format::R8, gfx::format::Unorm)>(
-            tex::Kind::D1((level.size.1 >> level.flood_section_power) as _),
-            tex::Mipmap::Provided,
-            &[&level.flood_map],
-        ).unwrap();
-    let (_, table) = factory
-        .create_texture_immutable::<(gfx::format::R8_G8_B8_A8, gfx::format::Uint)>(
-            tex::Kind::D1(level::NUM_TERRAINS as _),
-            tex::Mipmap::Provided,
-            &[&terrrain_table],
-        ).unwrap();
+    let terrain_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        layout: &terrain_bg_layout,
+        bindings: &[
+            wgpu::Binding {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer {
+                    buffer: &surface_uni_buf,
+                    range: 0 .. mem::size_of::<SurfaceConstants>() as u32,
+                },
+            },
+            wgpu::Binding {
+                binding: 1,
+                resource: wgpu::BindingResource::Buffer {
+                    buffer: &terrain_uni_buf,
+                    range: 0 .. mem::size_of::<TerrainConstants>() as u32,
+                },
+            },
+            wgpu::Binding {
+                binding: 2,
+                resource: wgpu::BindingResource::TextureView(
+                    &height_texture.create_default_view(),
+                ),
+            },
+            wgpu::Binding {
+                binding: 3,
+                resource: wgpu::BindingResource::TextureView(
+                    &meta_texture.create_default_view(),
+                ),
+            },
+            wgpu::Binding {
+                binding: 4,
+                resource: wgpu::BindingResource::TextureView(
+                    &flood_texture.create_default_view(),
+                ),
+            },
+            wgpu::Binding {
+                binding: 5,
+                resource: wgpu::BindingResource::TextureView(
+                    &table_texture.create_default_view(),
+                ),
+            },
+            wgpu::Binding {
+                binding: 6,
+                resource: wgpu::BindingResource::TextureView(&level_palette_view),
+            },
+            wgpu::Binding {
+                binding: 7,
+                resource: wgpu::BindingResource::Sampler(&repeat_nearest_sampler),
+            },
+            wgpu::Binding {
+                binding: 8,
+                resource: wgpu::BindingResource::Sampler(&flood_sampler),
+            },
+            wgpu::Binding {
+                binding: 9,
+                resource: wgpu::BindingResource::Sampler(&table_sampler),
+            },
+        ],
+    });
 
-    let sm_height = factory.create_sampler(tex::SamplerInfo::new(
-        if terrain_mip_count > 1 { tex::FilterMethod::Mipmap } else { tex::FilterMethod::Scale },
-        tex::WrapMode::Tile,
-    ));
-    let sm_meta = factory.create_sampler(tex::SamplerInfo::new(
-        tex::FilterMethod::Scale,
-        tex::WrapMode::Tile,
-    ));
-    let sm_flood = factory.create_sampler(tex::SamplerInfo::new(
-        tex::FilterMethod::Bilinear,
-        tex::WrapMode::Tile,
-    ));
-    let sm_table = factory.create_sampler(tex::SamplerInfo::new(
-        tex::FilterMethod::Scale,
-        tex::WrapMode::Clamp,
-    ));
+    let object_uni_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        size: mem::size_of::<ObjectLocals>() as u32,
+        usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+    });
+    let object_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        layout: &object_bg_layout,
+        bindings: &[
+            wgpu::Binding {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer {
+                    buffer: &object_uni_buf,
+                    range: 0 .. mem::size_of::<ObjectLocals>() as u32,
+                },
+            },
+            wgpu::Binding {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(&color_table_view),
+            },
+            wgpu::Binding {
+                binding: 2,
+                resource: wgpu::BindingResource::TextureView(&object_palette_view),
+            },
+            wgpu::Binding {
+                binding: 3,
+                resource: wgpu::BindingResource::Sampler(&color_table_sampler),
+            },
+        ],
+    });
 
-    let palette = Render::create_palette(&level.palette, factory);
-    let globals = factory.create_constant_buffer(1);
+    let terrain_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        bind_group_layouts: &[
+            &global_bg_layout,
+            &terrain_bg_layout,
+        ],
+    });
+    let object_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        bind_group_layouts: &[
+            &global_bg_layout,
+            &object_bg_layout,
+        ],
+    });
 
-    let (terrain, terrain_slice, terrain_data) = {
-        let (terrain, vbuf, slice) = match settings.terrain {
-            settings::Terrain::RayTracedOld => {
-                let pso = Render::create_terrain_ray_pso(factory, "terrain_ray_old");
-                let vertices = [
-                    TerrainVertex { pos: [0., 0., 0., 1.] },
-                    TerrainVertex { pos: [-1., 0., 0., 0.] },
-                    TerrainVertex { pos: [0., -1., 0., 0.] },
-                    TerrainVertex { pos: [1., 0., 0., 0.] },
-                    TerrainVertex { pos: [0., 1., 0., 0.] },
-                ];
-                let indices: &[u16] = &[0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1];
-                let (vbuf, slice) = factory.create_vertex_buffer_with_slice(&vertices, indices);
-                let terr = Terrain::RayOld { pso };
-                (terr, vbuf, slice)
-            }
-            settings::Terrain::RayTraced { mip_count, max_jumps, max_steps, debug } => {
-                let pso = Render::create_terrain_ray_pso(factory, "terrain_ray");
-                let vertices = [
-                    TerrainVertex { pos: [0., 0., 0., 1.] },
-                    TerrainVertex { pos: [-1., 0., 0., 0.] },
-                    TerrainVertex { pos: [0., -1., 0., 0.] },
-                    TerrainVertex { pos: [1., 0., 0., 0.] },
-                    TerrainVertex { pos: [0., 1., 0., 0.] },
-                ];
-                let indices: &[u16] = &[0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1];
-                let (vbuf, slice) = factory.create_vertex_buffer_with_slice(&vertices, indices);
-                let terr = Terrain::Ray {
-                    pso,
-                    mipper: MaxMipper::new(factory, &tex_height),
-                    params: [
-                        mip_count as u32 - 1,
-                        max_jumps as u32,
-                        max_steps as u32,
-                        if debug { 1 } else { 0 },
-                    ],
-                };
-                (terr, vbuf, slice)
-            }
-            settings::Terrain::Tessellated { screen_space } => {
-                let (pso_low, pso_high) = Render::create_terrain_tess_psos(factory, screen_space);
-                let vertices = [
-                    TerrainVertex { pos: [0., 0., 0., 1.] },
-                    TerrainVertex { pos: [1., 0., 0., 1.] },
-                    TerrainVertex { pos: [1., 1., 0., 1.] },
-                    TerrainVertex { pos: [0., 1., 0., 1.] },
-                ];
-                let (vbuf, mut slice) = factory.create_vertex_buffer_with_slice(&vertices, ());
-                let num_instances = if screen_space { 16 * 12 } else { 256 };
-                slice.instances = Some((num_instances, 0));
-                (Terrain::Tess { pso_low, pso_high, screen_space }, vbuf, slice)
-            }
-        };
-        let data = terrain::Data {
-            vbuf,
-            suf_constants: factory.create_constant_buffer(1),
-            terr_constants: factory.create_constant_buffer(1),
-            globals: globals.clone(),
-            height: (height, sm_height),
-            meta: (meta, sm_meta),
-            flood: (flood, sm_flood),
-            palette,
-            table: (table, sm_table),
-            out_color: targets.color.clone(),
-            out_depth: targets.depth.clone(),
-        };
-        (terrain, slice, data)
-    };
+    let vertices = [
+        TerrainVertex { _pos: [0, 0, 0, 1] },
+        TerrainVertex { _pos: [-1, 0, 0, 0] },
+        TerrainVertex { _pos: [0, -1, 0, 0] },
+        TerrainVertex { _pos: [1, 0, 0, 0] },
+        TerrainVertex { _pos: [0, 1, 0, 0] },
+    ];
+    let indices = [0u16, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1];
+
+    let terrain_vertex_buf = device
+        .create_buffer_mapped(vertices.len(), wgpu::BufferUsageFlags::VERTEX)
+        .fill_from_slice(&vertices);
+    let terrain_index_buf = device
+        .create_buffer_mapped(indices.len(), wgpu::BufferUsageFlags::INDEX)
+        .fill_from_slice(&indices);
+
+    let terrain_pipeline = Render::create_terrain_ray_pipeline(&terrain_pipeline_layout, device);
+    let object_pipeline = Render::create_object_pipeline(&object_pipeline_layout, device);
 
     Render {
-        terrain,
-        terrain_slice,
-        terrain_data,
-        terrain_scale: [
-            level.size.0 as f32,
-            real_height as f32,
-            level::HEIGHT_SCALE as f32,
-            num_layers as f32,
-        ],
-        terrain_dirty_rects: vec![gfx::Rect {
-            x: 0,
-            y: 0,
-            w: level.size.0 as u16,
-            h: level.size.1 as u16,
-        }],
-        object_pso: Render::create_object_pso(factory),
-        object_data: object::Data {
-            vbuf: factory.create_vertex_buffer(&[]), //dummy
-            locals: factory.create_constant_buffer(1),
-            globals,
-            palette: Render::create_palette(&object_palette, factory),
-            ctable: Render::create_color_table(factory),
-            out_color: targets.color.clone(),
-            out_depth: targets.depth.clone(),
+        global_bg,
+        global_uni_buf,
+        terrain_bg,
+        terrain_uni_buf,
+        terrain_pipeline_layout,
+        terrain: Terrain::Ray {
+            pipeline: terrain_pipeline,
+            vertex_buf: terrain_vertex_buf,
+            index_buf: terrain_index_buf,
+            num_indices: indices.len(),
         },
+        object_bg,
+        object_uni_buf,
+        object_pipeline_layout,
+        object_pipeline,
         light_config: settings.light.clone(),
-        debug: DebugRender::new(factory, targets, &settings.debug),
+        debug: DebugRender::new(device, &settings.debug),
     }
 }
 
-impl<R: gfx::Resources> Render<R> {
-    pub fn set_globals<C>(
-        encoder: &mut gfx::Encoder<R, C>,
+impl Render {
+    pub fn update_globals(
+        encoder: &mut wgpu::CommandEncoder,
         cam: &Camera,
         light: &settings::Light,
-        buffer: &gfx::handle::Buffer<R, Globals>,
-    ) -> Matrix4<f32>
-    where
-        C: gfx::CommandBuffer<R>,
-    {
+        buffer: &wgpu::Buffer,
+        device: &wgpu::Device,
+    ) -> Matrix4<f32> {
         use cgmath::SquareMatrix;
 
         let mx_vp = cam.get_view_proj();
+
         let globals = Globals {
-            camera_pos: cam.loc.extend(1.0).into(),
-            m_vp: mx_vp.into(),
-            m_inv_vp: mx_vp.invert().unwrap().into(),
-            light_pos: light.pos,
-            light_color: light.color,
+            _camera_pos: cam.loc.extend(1.0).into(),
+            _m_vp: mx_vp.into(),
+            _m_inv_vp: mx_vp.invert().unwrap().into(),
+            _light_pos: light.pos,
+            _light_color: light.color,
         };
 
-        encoder.update_constant_buffer(buffer, &globals);
+        let staging = device
+            .create_buffer_mapped(1, wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(&[globals]);
+
+        encoder.copy_buffer_to_buffer(
+            &staging,
+            0,
+            buffer,
+            0,
+            mem::size_of::<Globals>() as u32,
+        );
+
         mx_vp
     }
 
-    pub fn draw_mesh<C>(
-        encoder: &mut gfx::Encoder<R, C>,
-        mesh: &model::Mesh<R>,
+    pub fn draw_mesh(
+        pass: &mut wgpu::RenderPass,
+        updater: &mut Updater,
+        mesh: &model::Mesh,
         model2world: Transform,
-        pso: &gfx::PipelineState<R, object::Meta>,
-        data: &mut object::Data<R>,
-    ) where
-        C: gfx::CommandBuffer<R>,
-    {
+        locals_buf: &wgpu::Buffer,
+        pipeline: &wgpu::RenderPipeline,
+    ) {
         let mx_world = Matrix4::from(model2world);
-        let locals = ObjectLocals {
-            m_model: mx_world.into(),
-        };
-        data.vbuf = mesh.buffer.clone();
-        encoder.update_constant_buffer(&data.locals, &locals);
-        encoder.draw(&mesh.slice, pso, data);
+        updater.update(locals_buf, &[ObjectLocals {
+            _matrix: mx_world.into(),
+        }]);
+        pass.set_pipeline(pipeline);
+        pass.set_vertex_buffers(&[(&mesh.vertex_buf, 0)]);
+        pass.draw(0 .. mesh.num_vertices as u32, 0 .. 1);
     }
 
-    pub fn draw_model<C>(
-        encoder: &mut gfx::Encoder<R, C>,
-        model: &model::RenderModel<R>,
+    pub fn draw_model(
+        pass: &mut wgpu::RenderPass,
+        updater: &mut Updater,
+        model: &model::RenderModel,
         model2world: Transform,
-        pso: &gfx::PipelineState<R, object::Meta>,
-        data: &mut object::Data<R>,
-        debug_context: Option<(&mut DebugRender<R>, f32, &Matrix4<f32>)>,
-    ) where
-        C: gfx::CommandBuffer<R>,
-    {
+        locals_buf: &wgpu::Buffer,
+        pipeline: &wgpu::RenderPipeline,
+        debug_context: Option<(&mut DebugRender, f32, &Matrix4<f32>)>,
+    ) {
         use cgmath::{Deg, One, Quaternion, Rad, Rotation3, Transform, Vector3};
 
         // body
-        Render::draw_mesh(encoder, &model.body, model2world, pso, data);
+        Render::draw_mesh(pass, updater, &model.body, model2world.clone(), locals_buf, pipeline);
         // debug render
         if let Some((debug, scale, world2screen)) = debug_context {
-            let mut mx_shape = model2world;
+            let mut mx_shape =  model2world.clone();
             mx_shape.scale *= scale;
             let transform = world2screen * Matrix4::from(mx_shape);
-            debug.draw_shape(&model.shape, transform, encoder);
+            debug.draw_shape(pass, &model.shape, transform);
         }
         // wheels
         for w in model.wheels.iter() {
@@ -718,7 +793,7 @@ impl<R: gfx::Resources> Render<R> {
                     rot: Quaternion::one(),
                     scale: 1.0,
                 });
-                Render::draw_mesh(encoder, mesh, transform, pso, data);
+                Render::draw_mesh(pass, updater, mesh, transform, locals_buf, pipeline);
             }
         }
         // slots
@@ -731,225 +806,379 @@ impl<R: gfx::Resources> Render<R> {
                 };
                 local.disp -= local.transform_vector(Vector3::from(mesh.offset));
                 let transform = model2world.concat(&local);
-                Render::draw_mesh(encoder, mesh, transform, pso, data);
+                Render::draw_mesh(pass, updater, mesh, transform, locals_buf, pipeline);
             }
         }
     }
 
-    pub fn draw_world<'a, C>(
+    pub fn draw_world<'a>(
         &mut self,
-        encoder: &mut gfx::Encoder<R, C>,
-        render_models: &[RenderModel<'a, R>],
+        render_models: &[RenderModel<'a>],
         cam: &Camera,
-    ) where
-        C: gfx::CommandBuffer<R>,
-    {
-        // prepare the data
-        if !self.terrain_dirty_rects.is_empty() {
-            if let Terrain::Ray { ref mipper, .. } = self.terrain {
-                mipper.update(encoder, &self.terrain_dirty_rects);
-            }
-            self.terrain_dirty_rects.clear();
-        }
+        screen_extent: wgpu::Extent3d,
+        color_target: &wgpu::TextureView,
+        depth_target: &wgpu::TextureView, 
+        device: &wgpu::Device,
+    ) -> Vec<wgpu::CommandBuffer> {
+        let dummy_desc = wgpu::CommandEncoderDescriptor { todo: 0 };
+        let mut encoder = device.create_command_encoder(&dummy_desc);
+        let mut updater = Updater {
+            device,
+            command_encoder: device.create_command_encoder(&dummy_desc),
+        };
 
-        let mx_vp = Self::set_globals(
-            encoder,
+        let mx_vp = Self::update_globals(
+            &mut encoder,
             cam,
             &self.light_config,
-            &self.terrain_data.globals,
+            &self.global_uni_buf,
+            device,
         );
 
-        // clear buffers
-        encoder.clear(&self.terrain_data.out_color, [0.1, 0.2, 0.3, 1.0]);
-        encoder.clear_depth(&self.terrain_data.out_depth, 1.0);
+        updater.update(&self.terrain_uni_buf, &[TerrainConstants {
+            _scr_size: [screen_extent.width as f32, screen_extent.height as f32, 0.0, 0.0],
+        }]);
 
-        // draw terrain
-        let (wid, het, _, _) = self.terrain_data.out_color.get_dimensions();
-        let suf_constants = SurfaceConstants {
-            tex_scale: self.terrain_scale,
-        };
-        encoder.update_constant_buffer(&self.terrain_data.suf_constants, &suf_constants);
-        let terr_constants = TerrainConstants {
-            scr_size: [wid as f32, het as f32, 0.0, 0.0],
-            params: match self.terrain {
-                Terrain::RayOld { .. } |
-                Terrain::Tess { .. } => [0; 4],
-                Terrain::Ray { params, .. } => params,
-            },
-        };
-        encoder.update_constant_buffer(&self.terrain_data.terr_constants, &terr_constants);
-        match self.terrain {
-            Terrain::RayOld { ref pso } |
-            Terrain::Ray { ref pso, .. } => {
-                encoder.draw(&self.terrain_slice, pso, &self.terrain_data);
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                color_attachments: &[
+                    wgpu::RenderPassColorAttachmentDescriptor {
+                        attachment: color_target,
+                        load_op: wgpu::LoadOp::Clear,
+                        store_op: wgpu::StoreOp::Store,
+                        clear_color: wgpu::Color {
+                            r: 0.1, g: 0.2, b: 0.3, a: 1.0,
+                        },
+                    },
+                ],
+                depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachmentDescriptor {
+                    attachment: depth_target,
+                    depth_load_op: wgpu::LoadOp::Clear,
+                    depth_store_op: wgpu::StoreOp::Store,
+                    clear_depth: 1.0,
+                    stencil_load_op: wgpu::LoadOp::Clear,
+                    stencil_store_op: wgpu::StoreOp::Store,
+                    clear_stencil: 0,
+                }),
+            });
+
+            pass.set_bind_group(0, &self.global_bg);
+            pass.set_bind_group(1, &self.terrain_bg);
+            // draw terrain
+            match self.terrain {
+                Terrain::Ray { ref pipeline, ref index_buf, ref vertex_buf, num_indices } => {
+                    pass.set_pipeline(pipeline);
+                    pass.set_index_buffer(index_buf, 0);
+                    pass.set_vertex_buffers(&[(vertex_buf, 0)]);
+                    pass.draw_indexed(0 .. num_indices as u32, 0, 0 .. 1);
+                }
+                /*
+                Terrain::Tess { ref low, ref high, .. } => {
+                    encoder.draw(&self.terrain_slice, low, &self.terrain_data);
+                    encoder.draw(&self.terrain_slice, high, &self.terrain_data);
+                }*/
             }
-            Terrain::Tess { ref pso_low, ref pso_high, .. } => {
-                encoder.draw(&self.terrain_slice, pso_low, &self.terrain_data);
-                encoder.draw(&self.terrain_slice, pso_high, &self.terrain_data);
+
+            // draw vehicle models
+            pass.set_bind_group(1, &self.object_bg);
+            for rm in render_models {
+                Render::draw_model(
+                    &mut pass,
+                    &mut updater,
+                    &rm.model,
+                    rm.transform,
+                    &self.object_uni_buf,
+                    &self.object_pipeline,
+                    //&mut self.object_data,
+                    match rm.debug_shape_scale {
+                        Some(scale) => Some((&mut self.debug, scale, &mx_vp)),
+                        None => None,
+                    },
+                );
             }
         }
 
-        // draw vehicle models
-        for rm in render_models {
-            Render::draw_model(
-                encoder,
-                rm.model,
-                rm.transform,
-                &self.object_pso,
-                &mut self.object_data,
-                match rm.debug_shape_scale {
-                    Some(scale) => Some((&mut self.debug, scale, &mx_vp)),
-                    None => None,
-                },
-            );
-        }
+        vec![
+            updater.command_encoder.finish(),
+            encoder.finish(),
+        ]
     }
 
-    pub fn create_palette<F: gfx::Factory<R>>(
+    pub fn create_palette(
+        encoder: &mut wgpu::CommandEncoder,
         data: &[[u8; 4]],
-        factory: &mut F,
-    ) -> (
-        gfx::handle::ShaderResourceView<R, [f32; 4]>,
-        gfx::handle::Sampler<R>,
-    ) {
-        use gfx::texture as tex;
-        let (_, view) = factory
-            .create_texture_immutable::<gfx::format::Srgba8>(tex::Kind::D1(0x100), tex::Mipmap::Provided, &[data])
-            .unwrap();
-        let sampler = factory.create_sampler(tex::SamplerInfo::new(
-            tex::FilterMethod::Bilinear,
-            tex::WrapMode::Clamp,
-        ));
-        (view, sampler)
+        device: &wgpu::Device,
+    ) -> (wgpu::TextureView, wgpu::Sampler) {
+        let extent = wgpu::Extent3d {
+            width: 0x100,
+            height: 1,
+            depth: 1,
+        };
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: extent,
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D1,
+            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+        });
+
+        let staging = device
+            .create_buffer_mapped(data.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(data);
+        encoder.copy_buffer_to_texture(
+            wgpu::BufferCopyView {
+                buffer: &staging,
+                offset: 0,
+                row_pitch: 0x100 * 4,
+                image_height: 1,
+            },
+            wgpu::TextureCopyView {
+                texture: &texture,
+                level: 0,
+                slice: 0,
+                origin: wgpu::Origin3d {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            },
+            extent,
+        );
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            r_address_mode: wgpu::AddressMode::ClampToEdge,
+            s_address_mode: wgpu::AddressMode::ClampToEdge,
+            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            lod_min_clamp: 0.0,
+            lod_max_clamp: 0.0,
+            max_anisotropy: 0,
+            compare_function: wgpu::CompareFunction::Always,
+            border_color: wgpu::BorderColor::TransparentBlack,
+        });
+        (texture.create_default_view(), sampler)
     }
 
-    pub fn create_color_table<F: gfx::Factory<R>>(
-        factory: &mut F,
-    ) -> (
-        gfx::handle::ShaderResourceView<R, [u32; 2]>,
-        gfx::handle::Sampler<R>,
-    ) {
-        use gfx::texture as tex;
-        type Format = (gfx::format::R8_G8, gfx::format::Uint);
-        let kind = tex::Kind::D1(NUM_COLOR_IDS as tex::Size);
-        let (_, view) = factory
-            .create_texture_immutable::<Format>(kind, tex::Mipmap::Provided, &[&COLOR_TABLE])
-            .unwrap();
-        let sampler = factory.create_sampler(tex::SamplerInfo::new(
-            tex::FilterMethod::Scale,
-            tex::WrapMode::Clamp,
-        ));
-        (view, sampler)
+    pub fn create_color_table(
+        encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device
+    ) -> (wgpu::TextureView, wgpu::Sampler) {
+        let extent = wgpu::Extent3d {
+            width: NUM_COLOR_IDS as u32,
+            height: 1,
+            depth: 1,
+        };
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: extent,
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D1,
+            format: wgpu::TextureFormat::Rg8Uint,
+            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+        });
+
+        let staging = device
+            .create_buffer_mapped(NUM_COLOR_IDS as usize, wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(&COLOR_TABLE);
+        encoder.copy_buffer_to_texture(
+            wgpu::BufferCopyView {
+                buffer: &staging,
+                offset: 0,
+                row_pitch: NUM_COLOR_IDS as u32 * 2,
+                image_height: 1,
+            },
+            wgpu::TextureCopyView {
+                texture: &texture,
+                level: 0,
+                slice: 0,
+                origin: wgpu::Origin3d {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            },
+            extent,
+        );
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            r_address_mode: wgpu::AddressMode::ClampToEdge,
+            s_address_mode: wgpu::AddressMode::ClampToEdge,
+            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            lod_min_clamp: 0.0,
+            lod_max_clamp: 0.0,
+            max_anisotropy: 0,
+            compare_function: wgpu::CompareFunction::Always,
+            border_color: wgpu::BorderColor::TransparentBlack,
+        });
+        (texture.create_default_view(), sampler)
     }
 
-    fn create_terrain_ray_pso<F: gfx::Factory<R>>(
-        factory: &mut F, name: &str,
-    ) -> gfx::PipelineState<R, terrain::Meta> {
-        let shaders = read_shaders(name, false, &[])
+    fn create_terrain_ray_pipeline(
+        layout: &wgpu::PipelineLayout,
+        device: &wgpu::Device,
+    ) -> wgpu::RenderPipeline {
+        let shaders = read_shaders("terrain_ray", &[], device)
             .unwrap();
-        let program = factory
-            .link_program(&shaders.vs, &shaders.fs)
-            .unwrap();
-        factory
-            .create_pipeline_from_program(
-                &program,
-                gfx::Primitive::TriangleList,
-                gfx::state::Rasterizer::new_fill(),
-                terrain::new(),
-            )
-            .unwrap()
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            layout,
+            vertex_stage: wgpu::PipelineStageDescriptor {
+                module: &shaders.vs,
+                entry_point: "main",
+            },
+            fragment_stage: wgpu::PipelineStageDescriptor {
+                module: &shaders.fs,
+                entry_point: "main",
+            },
+            rasterization_state: wgpu::RasterizationStateDescriptor {
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: wgpu::CullMode::None,
+                depth_bias: 0,
+                depth_bias_slope_scale: 0.0,
+                depth_bias_clamp: 0.0,
+            },
+            primitive_topology: wgpu::PrimitiveTopology::TriangleList,
+            color_states: &[
+                wgpu::ColorStateDescriptor {
+                    format: COLOR_FORMAT,
+                    alpha: wgpu::BlendDescriptor::REPLACE,
+                    color: wgpu::BlendDescriptor::REPLACE,
+                    write_mask: wgpu::ColorWriteFlags::all(),
+                },
+            ],
+            depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
+                format: DEPTH_FORMAT,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::Always,
+                stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_read_mask: !0,
+                stencil_write_mask: !0,
+            }),
+            index_format: wgpu::IndexFormat::Uint16,
+            vertex_buffers: &[
+                wgpu::VertexBufferDescriptor {
+                    stride: mem::size_of::<TerrainVertex>() as u32,
+                    step_mode: wgpu::InputStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttributeDescriptor {
+                            offset: 0,
+                            format: wgpu::VertexFormat::Char4,
+                            attribute_index: 0,
+                        },
+                    ],
+                },
+            ],
+            sample_count: 1,
+        })
     }
 
-    fn create_terrain_tess_pso_impl<F: gfx::Factory<R>>(
-        factory: &mut F, specialization: &[&str]
-    ) -> gfx::PipelineState<R, terrain::Meta> {
-        let shaders = read_shaders("terrain_tess", true, specialization)
+    pub fn create_object_pipeline(
+        layout: &wgpu::PipelineLayout,
+        device: &wgpu::Device,
+    ) -> wgpu::RenderPipeline {
+        let shaders = read_shaders("object", &[], device)
             .unwrap();
-        let set = factory
-            .create_shader_set_tessellation(
-                &shaders.vs,
-                &shaders.tec,
-                &shaders.tev,
-                &shaders.fs
-            )
-            .unwrap();
-        factory
-            .create_pipeline_state(
-                &set,
-                gfx::Primitive::PatchList(4),
-                gfx::state::Rasterizer::new_fill(),
-                terrain::new(),
-            )
-            .unwrap()
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            layout,
+            vertex_stage: wgpu::PipelineStageDescriptor {
+                module: &shaders.vs,
+                entry_point: "main",
+            },
+            fragment_stage: wgpu::PipelineStageDescriptor {
+                module: &shaders.fs,
+                entry_point: "main",
+            },
+            rasterization_state: wgpu::RasterizationStateDescriptor {
+                front_face: wgpu::FrontFace::Ccw,
+                // original was not drawn with rasterizer, used no culling
+                cull_mode: wgpu::CullMode::None,
+                depth_bias: 0,
+                depth_bias_slope_scale: 0.0,
+                depth_bias_clamp: 0.0,
+            },
+            primitive_topology: wgpu::PrimitiveTopology::TriangleList,
+            color_states: &[
+                wgpu::ColorStateDescriptor {
+                    format: COLOR_FORMAT,
+                    alpha: wgpu::BlendDescriptor::REPLACE,
+                    color: wgpu::BlendDescriptor::REPLACE,
+                    write_mask: wgpu::ColorWriteFlags::all(),
+                },
+            ],
+            depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
+                format: DEPTH_FORMAT,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::LessEqual,
+                stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_read_mask: !0,
+                stencil_write_mask: !0,
+            }),
+            index_format: wgpu::IndexFormat::Uint16,
+            vertex_buffers: &[
+                wgpu::VertexBufferDescriptor {
+                    stride: mem::size_of::<ObjectVertex>() as u32,
+                    step_mode: wgpu::InputStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttributeDescriptor {
+                            offset: 0,
+                            format: wgpu::VertexFormat::Char4,
+                            attribute_index: 0,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            offset: 4,
+                            format: wgpu::VertexFormat::Uint,
+                            attribute_index: 1,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            offset: 8,
+                            format: wgpu::VertexFormat::Uchar4Norm,
+                            attribute_index: 2,
+                        },
+                    ],
+                },
+            ],
+            sample_count: 1,
+        })
     }
 
-    fn create_terrain_tess_psos<F: gfx::Factory<R>>(
-        factory: &mut F, screen_space: bool,
-    ) -> (gfx::PipelineState<R, terrain::Meta>, gfx::PipelineState<R, terrain::Meta>) {
-        let ss_spec = if screen_space { "SCREEN_SPACE" } else { "" };
-        let lo = Self::create_terrain_tess_pso_impl(factory, &[ss_spec]);
-        let hi = Self::create_terrain_tess_pso_impl(factory, &["HIGH_LEVEL", "USE_DISCARD", ss_spec]);
-        (lo, hi)
-    }
-
-    pub fn create_object_pso<F: gfx::Factory<R>>(
-        factory: &mut F,
-    ) -> gfx::PipelineState<R, object::Meta> {
-        let shaders = read_shaders("object", false, &[])
-            .unwrap();
-        let program = factory
-            .link_program(&shaders.vs, &shaders.fs)
-            .unwrap();
-        // no culling because the old rasterizer was not polygonal
-        factory
-            .create_pipeline_from_program(
-                &program,
-                gfx::Primitive::TriangleList,
-                gfx::state::Rasterizer::new_fill(),
-                object::new(),
-            )
-            .unwrap()
-    }
-
-    pub fn reload<F: gfx::Factory<R>>(
-        &mut self,
-        factory: &mut F,
-    ) {
+    pub fn reload(&mut self, device: &wgpu::Device) {
         info!("Reloading shaders");
         match self.terrain {
-            Terrain::RayOld { ref mut pso } => {
-                *pso = Render::create_terrain_ray_pso(factory, "terrain_ray_old");
+            Terrain::Ray { ref mut pipeline, .. } => {
+                *pipeline = Render::create_terrain_ray_pipeline(
+                    &self.terrain_pipeline_layout,
+                    device,
+                );
             }
-            Terrain::Ray { ref mut pso, ref mut mipper, .. } => {
-                *pso = Render::create_terrain_ray_pso(factory, "terrain_ray");
-                mipper.pso = MaxMipper::create_pso(factory);
-            }
-            Terrain::Tess { ref mut pso_low, ref mut pso_high, screen_space } => {
+            /*
+            Terrain::Tess { ref mut low, ref mut high, screen_space } => {
                 let (lo, hi) = Render::create_terrain_tess_psos(factory, screen_space);
-                *pso_low = lo;
-                *pso_high = hi;
-            }
+                *low = lo;
+                *high = hi;
+            }*/
         }
-        self.object_pso = Render::create_object_pso(factory);
+        self.object_pipeline = Render::create_object_pipeline(
+            &self.object_pipeline_layout,
+            device,
+        );
     }
 
-    pub fn resize(&mut self, targets: MainTargets<R>) {
-        self.terrain_data.out_color = targets.color.clone();
-        self.terrain_data.out_depth = targets.depth.clone();
-        self.object_data.out_color = targets.color.clone();
-        self.object_data.out_depth = targets.depth.clone();
-        self.debug.resize(targets);
-    }
-
-    pub fn surface_data(&self) -> SurfaceData<R> {
+    /*
+    pub fn surface_data(&self) -> SurfaceData {
         SurfaceData {
             constants: self.terrain_data.suf_constants.clone(),
             height: self.terrain_data.height.clone(),
             meta: self.terrain_data.meta.clone(),
         }
-    }
+    }*/
 
+    /*
     pub fn target_color(&self) -> gfx::handle::RenderTargetView<R, ColorFormat> {
         self.terrain_data.out_color.clone()
-    }
+    }*/
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5,8 +5,6 @@ use crate::{
     space::{Camera, Transform},
 };
 
-use m3d::NUM_COLOR_IDS;
-
 use cgmath::{Decomposed, Matrix4};
 use wgpu;
 
@@ -16,10 +14,14 @@ use std::mem;
 
 //mod collision; ../TODO
 mod debug;
+pub mod object;
 
 //pub use self::collision::{DebugBlit, GpuCollider, ShapeId};
 pub use self::debug::{DebugPos, DebugRender, LineBuffer};
 
+
+pub const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
+pub const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::D32Float;
 
 pub struct ScreenTargets<'a> {
     pub extent: wgpu::Extent3d,
@@ -33,50 +35,7 @@ pub struct SurfaceData {
     pub meta: (wgpu::TextureView, wgpu::Sampler),
 }
 
-const COLOR_TABLE: [[u8; 2]; NUM_COLOR_IDS as usize] = [
-    [0, 0],   // reserved
-    [128, 3], // body
-    [176, 4], // window
-    [224, 7], // wheel
-    [184, 4], // defence
-    [224, 3], // weapon
-    [224, 7], // tube
-    [128, 3], // body red
-    [144, 3], // body blue
-    [160, 3], // body yellow
-    [228, 4], // body gray
-    [112, 4], // yellow (charged)
-    [0, 2],   // material 0
-    [32, 2],  // material 1
-    [64, 4],  // material 2
-    [72, 3],  // material 3
-    [88, 3],  // material 4
-    [104, 4], // material 5
-    [112, 4], // material 6
-    [120, 4], // material 7
-    [184, 4], // black
-    [240, 3], // body green
-    [136, 4], // skyfarmer kenoboo
-    [128, 4], // skyfarmer pipetka
-    [224, 4], // rotten item
-];
-
-pub const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8UnormSrgb;
-pub const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::D32Float;
 pub type ShapeVertex = [f32; 4];
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct ObjectVertex {
-    pub pos: [i8; 4],
-    pub color: u32,
-    pub normal: [i8; 4],
-}
-
-#[derive(Clone, Copy)]
-struct ObjectLocals {
-    _matrix: [[f32; 4]; 4],
-}
 
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -238,229 +197,10 @@ impl GlobalContext {
     }
 }
 
-pub struct ObjectContext {
-    pub uniform_buf: wgpu::Buffer,
-    pub bind_group: wgpu::BindGroup,
-    pub pipeline_layout: wgpu::PipelineLayout,
-    pub pipeline: wgpu::RenderPipeline,
-}
-
-impl ObjectContext {
-    fn create_pipeline(
-        layout: &wgpu::PipelineLayout,
-        device: &wgpu::Device,
-    ) -> wgpu::RenderPipeline {
-        let shaders = read_shaders("object", &[], device)
-            .unwrap();
-        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            layout,
-            vertex_stage: wgpu::PipelineStageDescriptor {
-                module: &shaders.vs,
-                entry_point: "main",
-            },
-            fragment_stage: wgpu::PipelineStageDescriptor {
-                module: &shaders.fs,
-                entry_point: "main",
-            },
-            rasterization_state: wgpu::RasterizationStateDescriptor {
-                front_face: wgpu::FrontFace::Ccw,
-                // original was not drawn with rasterizer, used no culling
-                cull_mode: wgpu::CullMode::None,
-                depth_bias: 0,
-                depth_bias_slope_scale: 0.0,
-                depth_bias_clamp: 0.0,
-            },
-            primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-            color_states: &[
-                wgpu::ColorStateDescriptor {
-                    format: COLOR_FORMAT,
-                    alpha: wgpu::BlendDescriptor::REPLACE,
-                    color: wgpu::BlendDescriptor::REPLACE,
-                    write_mask: wgpu::ColorWriteFlags::all(),
-                },
-            ],
-            depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
-                format: DEPTH_FORMAT,
-                depth_write_enabled: true,
-                depth_compare: wgpu::CompareFunction::LessEqual,
-                stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
-                stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
-                stencil_read_mask: !0,
-                stencil_write_mask: !0,
-            }),
-            index_format: wgpu::IndexFormat::Uint16,
-            vertex_buffers: &[
-                wgpu::VertexBufferDescriptor {
-                    stride: mem::size_of::<ObjectVertex>() as u32,
-                    step_mode: wgpu::InputStepMode::Vertex,
-                    attributes: &[
-                        wgpu::VertexAttributeDescriptor {
-                            offset: 0,
-                            format: wgpu::VertexFormat::Char4,
-                            attribute_index: 0,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            offset: 4,
-                            format: wgpu::VertexFormat::Uint,
-                            attribute_index: 1,
-                        },
-                        wgpu::VertexAttributeDescriptor {
-                            offset: 8,
-                            format: wgpu::VertexFormat::Uchar4Norm,
-                            attribute_index: 2,
-                        },
-                    ],
-                },
-            ],
-            sample_count: 1,
-        })
-    }
-
-    fn create_color_table(
-        encoder: &mut wgpu::CommandEncoder,
-        device: &wgpu::Device
-    ) -> (wgpu::TextureView, wgpu::Sampler) {
-        let extent = wgpu::Extent3d {
-            width: NUM_COLOR_IDS as u32,
-            height: 1,
-            depth: 1,
-        };
-        let texture = device.create_texture(&wgpu::TextureDescriptor {
-            size: extent,
-            array_size: 1,
-            dimension: wgpu::TextureDimension::D1,
-            format: wgpu::TextureFormat::Rg8Uint,
-            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
-        });
-
-        let staging = device
-            .create_buffer_mapped(NUM_COLOR_IDS as usize, wgpu::BufferUsageFlags::TRANSFER_SRC)
-            .fill_from_slice(&COLOR_TABLE);
-        encoder.copy_buffer_to_texture(
-            wgpu::BufferCopyView {
-                buffer: &staging,
-                offset: 0,
-                row_pitch: NUM_COLOR_IDS as u32 * 2,
-                image_height: 1,
-            },
-            wgpu::TextureCopyView {
-                texture: &texture,
-                level: 0,
-                slice: 0,
-                origin: wgpu::Origin3d {
-                    x: 0.0,
-                    y: 0.0,
-                    z: 0.0,
-                },
-            },
-            extent,
-        );
-
-        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            r_address_mode: wgpu::AddressMode::ClampToEdge,
-            s_address_mode: wgpu::AddressMode::ClampToEdge,
-            t_address_mode: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Nearest,
-            min_filter: wgpu::FilterMode::Nearest,
-            mipmap_filter: wgpu::FilterMode::Nearest,
-            lod_min_clamp: 0.0,
-            lod_max_clamp: 0.0,
-            max_anisotropy: 0,
-            compare_function: wgpu::CompareFunction::Always,
-            border_color: wgpu::BorderColor::TransparentBlack,
-        });
-        (texture.create_default_view(), sampler)
-    }
-
-    pub fn new(
-        init_encoder: &mut wgpu::CommandEncoder,
-        device: &wgpu::Device,
-        palette: &[[u8; 4]],
-        global: &GlobalContext,
-    ) -> Self {
-        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-            bindings: &[
-                wgpu::BindGroupLayoutBinding { // object locals
-                    binding: 0,
-                    visibility: wgpu::ShaderStageFlags::VERTEX,
-                    ty: wgpu::BindingType::UniformBuffer,
-                },
-                wgpu::BindGroupLayoutBinding { // color map
-                    binding: 1,
-                    visibility: wgpu::ShaderStageFlags::VERTEX,
-                    ty: wgpu::BindingType::SampledTexture,
-                },
-                wgpu::BindGroupLayoutBinding { // palette map
-                    binding: 2,
-                    visibility: wgpu::ShaderStageFlags::VERTEX,
-                    ty: wgpu::BindingType::SampledTexture,
-                },
-                wgpu::BindGroupLayoutBinding { // main sampler
-                    binding: 3,
-                    visibility: wgpu::ShaderStageFlags::VERTEX,
-                    ty: wgpu::BindingType::Sampler,
-                },
-            ],
-        });
-        let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            size: mem::size_of::<ObjectLocals>() as u32,
-            usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
-        });
-        let palette_view = Render::create_palette(
-            init_encoder, palette, device
-        );
-        let (color_table_view, color_table_sampler) = Self::create_color_table(
-            init_encoder, device
-        );
-        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            layout: &bind_group_layout,
-            bindings: &[
-                wgpu::Binding {
-                    binding: 0,
-                    resource: wgpu::BindingResource::Buffer {
-                        buffer: &uniform_buf,
-                        range: 0 .. mem::size_of::<ObjectLocals>() as u32,
-                    },
-                },
-                wgpu::Binding {
-                    binding: 1,
-                    resource: wgpu::BindingResource::TextureView(&color_table_view),
-                },
-                wgpu::Binding {
-                    binding: 2,
-                    resource: wgpu::BindingResource::TextureView(&palette_view),
-                },
-                wgpu::Binding {
-                    binding: 3,
-                    resource: wgpu::BindingResource::Sampler(&color_table_sampler),
-                },
-            ],
-        });
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            bind_group_layouts: &[
-                &global.bind_group_layout,
-                &bind_group_layout,
-            ],
-        });
-        let pipeline = Self::create_pipeline(&pipeline_layout, device);
-
-        ObjectContext {
-            uniform_buf,
-            bind_group,
-            pipeline_layout,
-            pipeline,
-        }
-    }
-
-    pub fn reload(&mut self, device: &wgpu::Device) {
-        self.pipeline = Self::create_pipeline(&self.pipeline_layout, device);
-    }
-}
-
 
 pub struct Render {
     global: GlobalContext,
-    object: ObjectContext,
+    object: object::Context,
     terrain_bg: wgpu::BindGroup,
     terrain_uni_buf: wgpu::Buffer,
     terrain_pipeline_layout: wgpu::PipelineLayout,
@@ -480,7 +220,6 @@ pub struct Shaders {
     fs: wgpu::ShaderModule,
 }
 
-#[doc(hidden)]
 pub fn read_shaders(
     name: &str,
     specialization: &[&str],
@@ -721,7 +460,7 @@ pub fn init(
     );
 
     let global = GlobalContext::new(device);
-    let object = ObjectContext::new(&mut init_encoder, device, object_palette, &global);
+    let object = object::Context::new(&mut init_encoder, device, object_palette, &global);
 
     device.get_queue().submit(&[
         init_encoder.finish(),
@@ -948,8 +687,8 @@ impl Render {
         locals_buf: &wgpu::Buffer,
     ) {
         let mx_world = Matrix4::from(model2world);
-        updater.update(locals_buf, &[ObjectLocals {
-            _matrix: mx_world.into(),
+        updater.update(locals_buf, &[object::Locals {
+            matrix: mx_world.into(),
         }]);
         pass.set_vertex_buffers(&[(&mesh.vertex_buf, 0)]);
         pass.draw(0 .. mesh.num_vertices as u32, 0 .. 1);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -15,6 +15,7 @@ use std::mem;
 //mod collision; ../TODO
 mod debug;
 pub mod object;
+pub mod terrain;
 
 //pub use self::collision::{DebugBlit, GpuCollider, ShapeId};
 pub use self::debug::{DebugPos, DebugRender, LineBuffer};
@@ -37,27 +38,11 @@ pub struct SurfaceData {
 
 pub type ShapeVertex = [f32; 4];
 
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct TerrainVertex {
-    _pos: [i8; 4],
-}
-
 #[derive(Clone, Copy)]
 pub struct ShapePolygon {
     pub indices: [u16; 4],
     pub normal: [i8; 4],
     pub origin_square: [f32; 4],
-}
-
-#[derive(Clone, Copy)]
-struct SurfaceConstants {
-    _tex_scale: [f32; 4],
-}
-
-#[derive(Clone, Copy)]
-struct TerrainConstants {
-    _scr_size: [f32; 4],
 }
 
 #[derive(Clone, Copy)]
@@ -82,20 +67,6 @@ impl GlobalConstants {
             _light_color: light.color,
         }
     }
-}
-
-enum Terrain {
-    Ray {
-        pipeline: wgpu::RenderPipeline,
-        vertex_buf: wgpu::Buffer,
-        index_buf: wgpu::Buffer,
-        num_indices: usize,
-    },
-    /*Tess {
-        low: gfx::PipelineState<R, terrain::Meta>,
-        high: gfx::PipelineState<R, terrain::Meta>,
-        screen_space: bool,
-    },*/
 }
 
 pub struct Updater<'a> {
@@ -130,6 +101,7 @@ impl<'a> Updater<'a> {
         self.command_encoder.finish()
     }
 }
+
 
 pub struct GlobalContext {
     pub uniform_buf: wgpu::Buffer,
@@ -198,13 +170,168 @@ impl GlobalContext {
 }
 
 
+pub struct Shaders {
+    vs: wgpu::ShaderModule,
+    fs: wgpu::ShaderModule,
+}
+
+impl Shaders {
+    pub fn new(
+        name: &str,
+        specialization: &[&str],
+        device: &wgpu::Device,
+    ) -> Result<Self, IoError> {
+        use glsl_to_spirv;
+        use std::fs::File;
+        use std::io::{BufReader, Read, Write};
+        use std::path::PathBuf;
+
+        let path = PathBuf::from("data")
+            .join("shader")
+            .join(name)
+            .with_extension("glsl");
+        if !path.is_file() {
+            panic!("Shader not found: {:?}", path);
+        }
+
+        let mut buf_vs = b"#version 450\n#define SHADER_VS\n".to_vec();
+        let mut buf_fs = b"#version 450\n#define SHADER_FS\n".to_vec();
+
+        let mut code = String::new();
+        BufReader::new(File::open(&path)?)
+            .read_to_string(&mut code)?;
+        // parse meta-data
+        {
+            let mut lines = code.lines();
+            let first = lines.next().unwrap();
+            if first.starts_with("//!include") {
+                for include_pair in first.split_whitespace().skip(1) {
+                    let mut temp = include_pair.split(':');
+                    let target = match temp.next().unwrap() {
+                        "vs" => &mut buf_vs,
+                        "fs" => &mut buf_fs,
+                        other => panic!("Unknown target: {}", other),
+                    };
+                    let include = temp.next().unwrap();
+                    let inc_path = path
+                        .with_file_name(include)
+                        .with_extension("inc.glsl");
+                    BufReader::new(File::open(inc_path)?)
+                        .read_to_end(target)?;
+                }
+            }
+            let second = lines.next().unwrap();
+            if second.starts_with("//!specialization") {
+                for define in second.split_whitespace().skip(1) {
+                    let value = if specialization.contains(&define) {
+                        1
+                    } else {
+                        0
+                    };
+                    write!(buf_vs, "#define {} {}\n", define, value)?;
+                    write!(buf_fs, "#define {} {}\n", define, value)?;
+                }
+            }
+        }
+
+        write!(buf_vs, "\n{}", code
+            .replace("attribute", "in")
+            .replace("varying", "out")
+        )?;
+        write!(buf_fs, "\n{}", code
+            .replace("varying", "in")
+        )?;
+
+        let str_vs = String::from_utf8_lossy(&buf_vs);
+        let str_fs = String::from_utf8_lossy(&buf_fs);
+        debug!("vs:\n{}", str_vs);
+        debug!("fs:\n{}", str_fs);
+
+        let mut output_vs = match glsl_to_spirv::compile(&str_vs, glsl_to_spirv::ShaderType::Vertex) {
+            Ok(file) => file,
+            Err(e) => {
+                println!("Generated VS shader:\n{}", str_vs);
+                panic!("\nUnable to compile '{}': {:?}", name, e);
+            }
+        };
+        let mut spv_vs = Vec::new();
+        output_vs.read_to_end(&mut spv_vs).unwrap();
+
+        let mut output_fs = match glsl_to_spirv::compile(&str_fs, glsl_to_spirv::ShaderType::Fragment) {
+            Ok(file) => file,
+            Err(e) => {
+                println!("Generated FS shader:\n{}", str_fs);
+                panic!("\nUnable to compile '{}': {:?}", name, e);
+            }
+        };
+        let mut spv_fs = Vec::new();
+        output_fs.read_to_end(&mut spv_fs).unwrap();
+
+        Ok(Shaders {
+            vs: device.create_shader_module(&spv_vs),
+            fs: device.create_shader_module(&spv_fs),
+        })
+    }
+}
+
+
+pub struct Palette {
+    pub view: wgpu::TextureView,
+}
+
+impl Palette {
+    pub fn new(
+        encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device,
+        data: &[[u8; 4]],
+    ) -> Self {
+        let extent = wgpu::Extent3d {
+            width: 0x100,
+            height: 1,
+            depth: 1,
+        };
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: extent,
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D1,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+        });
+
+        let staging = device
+            .create_buffer_mapped(data.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(data);
+        encoder.copy_buffer_to_texture(
+            wgpu::BufferCopyView {
+                buffer: &staging,
+                offset: 0,
+                row_pitch: 0x100 * 4,
+                image_height: 1,
+            },
+            wgpu::TextureCopyView {
+                texture: &texture,
+                level: 0,
+                slice: 0,
+                origin: wgpu::Origin3d {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            },
+            extent,
+        );
+
+        Palette {
+            view: texture.create_default_view(),
+        }
+    }
+}
+
+
 pub struct Render {
     global: GlobalContext,
     object: object::Context,
-    terrain_bg: wgpu::BindGroup,
-    terrain_uni_buf: wgpu::Buffer,
-    terrain_pipeline_layout: wgpu::PipelineLayout,
-    terrain: Terrain,
+    terrain: terrain::Context,
     pub light_config: settings::Light,
     pub debug: debug::DebugRender,
 }
@@ -215,470 +342,32 @@ pub struct RenderModel<'a> {
     pub debug_shape_scale: Option<f32>,
 }
 
-pub struct Shaders {
-    vs: wgpu::ShaderModule,
-    fs: wgpu::ShaderModule,
-}
-
-pub fn read_shaders(
-    name: &str,
-    specialization: &[&str],
-    device: &wgpu::Device,
-) -> Result<Shaders, IoError> {
-    use glsl_to_spirv;
-    use std::fs::File;
-    use std::io::{BufReader, Read, Write};
-    use std::path::PathBuf;
-
-    let path = PathBuf::from("data")
-        .join("shader")
-        .join(name)
-        .with_extension("glsl");
-    if !path.is_file() {
-        panic!("Shader not found: {:?}", path);
-    }
-
-    let mut buf_vs = b"#version 450\n#define SHADER_VS\n".to_vec();
-    let mut buf_fs = b"#version 450\n#define SHADER_FS\n".to_vec();
-
-    let mut code = String::new();
-    BufReader::new(File::open(&path)?)
-        .read_to_string(&mut code)?;
-    // parse meta-data
-    {
-        let mut lines = code.lines();
-        let first = lines.next().unwrap();
-        if first.starts_with("//!include") {
-            for include_pair in first.split_whitespace().skip(1) {
-                let mut temp = include_pair.split(':');
-                let target = match temp.next().unwrap() {
-                    "vs" => &mut buf_vs,
-                    "fs" => &mut buf_fs,
-                    other => panic!("Unknown target: {}", other),
-                };
-                let include = temp.next().unwrap();
-                let inc_path = path
-                    .with_file_name(include)
-                    .with_extension("inc.glsl");
-                BufReader::new(File::open(inc_path)?)
-                    .read_to_end(target)?;
-            }
-        }
-        let second = lines.next().unwrap();
-        if second.starts_with("//!specialization") {
-            for define in second.split_whitespace().skip(1) {
-                let value = if specialization.contains(&define) {
-                    1
-                } else {
-                    0
-                };
-                write!(buf_vs, "#define {} {}\n", define, value)?;
-                write!(buf_fs, "#define {} {}\n", define, value)?;
-            }
-        }
-    }
-
-    write!(buf_vs, "\n{}", code
-        .replace("attribute", "in")
-        .replace("varying", "out")
-    )?;
-    write!(buf_fs, "\n{}", code
-        .replace("varying", "in")
-    )?;
-
-    let str_vs = String::from_utf8_lossy(&buf_vs);
-    let str_fs = String::from_utf8_lossy(&buf_fs);
-    debug!("vs:\n{}", str_vs);
-    debug!("fs:\n{}", str_fs);
-
-    let mut output_vs = match glsl_to_spirv::compile(&str_vs, glsl_to_spirv::ShaderType::Vertex) {
-        Ok(file) => file,
-        Err(e) => {
-            println!("Generated VS shader:\n{}", str_vs);
-            panic!("\nUnable to compile '{}': {:?}", name, e);
-        }
-    };
-    let mut spv_vs = Vec::new();
-    output_vs.read_to_end(&mut spv_vs).unwrap();
-
-    let mut output_fs = match glsl_to_spirv::compile(&str_fs, glsl_to_spirv::ShaderType::Fragment) {
-        Ok(file) => file,
-        Err(e) => {
-            println!("Generated FS shader:\n{}", str_fs);
-            panic!("\nUnable to compile '{}': {:?}", name, e);
-        }
-    };
-    let mut spv_fs = Vec::new();
-    output_fs.read_to_end(&mut spv_fs).unwrap();
-
-    Ok(Shaders {
-        vs: device.create_shader_module(&spv_vs),
-        fs: device.create_shader_module(&spv_fs),
-    })
-}
-
-pub fn init(
-    device: &mut wgpu::Device,
-    level: &level::Level,
-    object_palette: &[[u8; 4]],
-    settings: &settings::Render,
-) -> Render {
-    let origin = wgpu::Origin3d { x: 0.0, y: 0.0, z: 0.0 };
-    let extent = wgpu::Extent3d {
-        width: level.size.0 as u32,
-        height: level.size.1 as u32,
-        depth: 1,
-    };
-    let flood_extent = wgpu::Extent3d {
-        width: level.size.1 as u32 >> level.flood_section_power,
-        height: 1,
-        depth: 1,
-    };
-    let table_extent = wgpu::Extent3d {
-        width: level::NUM_TERRAINS as u32,
-        height: 1,
-        depth: 1,
-    };
-
-    let terrrain_table = level.terrains
-        .iter()
-        .map(|terr| [
-            terr.shadow_offset,
-            terr.height_shift,
-            terr.colors.start,
-            terr.colors.end,
-        ])
-        .collect::<Vec<_>>();
-
-    let height_texture = device.create_texture(&wgpu::TextureDescriptor {
-        size: extent,
-        array_size: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::R8Unorm,
-        usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
-    });
-    let meta_texture = device.create_texture(&wgpu::TextureDescriptor {
-        size: extent,
-        array_size: 1,
-        dimension: wgpu::TextureDimension::D2,
-        format: wgpu::TextureFormat::R8Uint,
-        usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
-    });
-    let flood_texture = device.create_texture(&wgpu::TextureDescriptor {
-        size: flood_extent,
-        array_size: 1,
-        dimension: wgpu::TextureDimension::D1,
-        format: wgpu::TextureFormat::R8Unorm,
-        usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
-    });
-    let table_texture = device.create_texture(&wgpu::TextureDescriptor {
-        size: table_extent,
-        array_size: 1,
-        dimension: wgpu::TextureDimension::D1,
-        format: wgpu::TextureFormat::Rgba8Uint,
-        usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
-    });
-
-    let height_staging = device
-        .create_buffer_mapped(level.height.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
-        .fill_from_slice(&level.height);
-    let meta_staging = device
-        .create_buffer_mapped(level.meta.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
-        .fill_from_slice(&level.meta);
-    let flood_staging = device
-        .create_buffer_mapped(level.flood_map.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
-        .fill_from_slice(&level.flood_map);
-    let table_staging = device
-        .create_buffer_mapped(terrrain_table.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
-        .fill_from_slice(&terrrain_table);
-
-    let mut init_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-        todo: 0,
-    });
-    init_encoder.copy_buffer_to_texture(
-        wgpu::BufferCopyView {
-            buffer: &height_staging,
-            offset: 0,
-            row_pitch: level.size.0 as u32,
-            image_height: level.size.1 as u32,
-        },
-        wgpu::TextureCopyView {
-            texture: &height_texture,
-            level: 0,
-            slice: 0,
-            origin,
-        },
-        extent,
-    );
-    init_encoder.copy_buffer_to_texture(
-        wgpu::BufferCopyView {
-            buffer: &meta_staging,
-            offset: 0,
-            row_pitch: level.size.0 as u32,
-            image_height: level.size.1 as u32,
-        },
-        wgpu::TextureCopyView {
-            texture: &meta_texture,
-            level: 0,
-            slice: 0,
-            origin,
-        },
-        extent,
-    );
-    init_encoder.copy_buffer_to_texture(
-        wgpu::BufferCopyView {
-            buffer: &flood_staging,
-            offset: 0,
-            row_pitch: flood_extent.width,
-            image_height: 1,
-        },
-        wgpu::TextureCopyView {
-            texture: &flood_texture,
-            level: 0,
-            slice: 0,
-            origin,
-        },
-        flood_extent,
-    );
-    init_encoder.copy_buffer_to_texture(
-        wgpu::BufferCopyView {
-            buffer: &table_staging,
-            offset: 0,
-            row_pitch: table_extent.width * 4,
-            image_height: 1,
-        },
-        wgpu::TextureCopyView {
-            texture: &table_texture,
-            level: 0,
-            slice: 0,
-            origin,
-        },
-        table_extent,
-    );
-    let level_palette_view = Render::create_palette(
-        &mut init_encoder, &level.palette, device
-    );
-
-    let global = GlobalContext::new(device);
-    let object = object::Context::new(&mut init_encoder, device, object_palette, &global);
-
-    device.get_queue().submit(&[
-        init_encoder.finish(),
-    ]);
-
-    let repeat_nearest_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-        r_address_mode: wgpu::AddressMode::Repeat,
-        s_address_mode: wgpu::AddressMode::Repeat,
-        t_address_mode: wgpu::AddressMode::Repeat,
-        mag_filter: wgpu::FilterMode::Nearest,
-        min_filter: wgpu::FilterMode::Nearest,
-        mipmap_filter: wgpu::FilterMode::Nearest,
-        lod_min_clamp: 0.0,
-        lod_max_clamp: 0.0,
-        max_anisotropy: 0,
-        compare_function: wgpu::CompareFunction::Always,
-        border_color: wgpu::BorderColor::TransparentBlack,
-    });
-    let flood_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-        r_address_mode: wgpu::AddressMode::Repeat,
-        s_address_mode: wgpu::AddressMode::ClampToEdge,
-        t_address_mode: wgpu::AddressMode::ClampToEdge,
-        mag_filter: wgpu::FilterMode::Linear,
-        min_filter: wgpu::FilterMode::Linear,
-        mipmap_filter: wgpu::FilterMode::Nearest,
-        lod_min_clamp: 0.0,
-        lod_max_clamp: 0.0,
-        max_anisotropy: 0,
-        compare_function: wgpu::CompareFunction::Always,
-        border_color: wgpu::BorderColor::TransparentBlack,
-    });
-    let table_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-        r_address_mode: wgpu::AddressMode::ClampToEdge,
-        s_address_mode: wgpu::AddressMode::ClampToEdge,
-        t_address_mode: wgpu::AddressMode::ClampToEdge,
-        mag_filter: wgpu::FilterMode::Nearest,
-        min_filter: wgpu::FilterMode::Nearest,
-        mipmap_filter: wgpu::FilterMode::Nearest,
-        lod_min_clamp: 0.0,
-        lod_max_clamp: 0.0,
-        max_anisotropy: 0,
-        compare_function: wgpu::CompareFunction::Always,
-        border_color: wgpu::BorderColor::TransparentBlack,
-    });
-
-    let terrain_bg_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
-        bindings: &[
-            wgpu::BindGroupLayoutBinding { // surface uniforms
-                binding: 0,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::UniformBuffer,
-            },
-            wgpu::BindGroupLayoutBinding { // terrain locals
-                binding: 1,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::UniformBuffer,
-            },
-            wgpu::BindGroupLayoutBinding { // height map
-                binding: 2,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::SampledTexture,
-            },
-            wgpu::BindGroupLayoutBinding { // meta map
-                binding: 3,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::SampledTexture,
-            },
-            wgpu::BindGroupLayoutBinding { // flood map
-                binding: 4,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::SampledTexture,
-            },
-            wgpu::BindGroupLayoutBinding { // table map
-                binding: 5,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::SampledTexture,
-            },
-            wgpu::BindGroupLayoutBinding { // palette map
-                binding: 6,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::SampledTexture,
-            },
-            wgpu::BindGroupLayoutBinding { // main sampler
-                binding: 7,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::Sampler,
-            },
-            wgpu::BindGroupLayoutBinding { // flood sampler
-                binding: 8,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::Sampler,
-            },
-            wgpu::BindGroupLayoutBinding { // table sampler
-                binding: 9,
-                visibility: wgpu::ShaderStageFlags::FRAGMENT,
-                ty: wgpu::BindingType::Sampler,
-            },
-        ],
-    });
-
-    let surface_uni_buf = device
-        .create_buffer_mapped(1, wgpu::BufferUsageFlags::UNIFORM)
-        .fill_from_slice(&[SurfaceConstants {
-            _tex_scale: [
-                level.size.0 as f32,
-                level.size.1 as f32,
-                level::HEIGHT_SCALE as f32,
-                0.0,
-            ],
-        }]);
-    let terrain_uni_buf = device.create_buffer(&wgpu::BufferDescriptor {
-        size: mem::size_of::<TerrainConstants>() as u32,
-        usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
-    });
-
-    let terrain_bg = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        layout: &terrain_bg_layout,
-        bindings: &[
-            wgpu::Binding {
-                binding: 0,
-                resource: wgpu::BindingResource::Buffer {
-                    buffer: &surface_uni_buf,
-                    range: 0 .. mem::size_of::<SurfaceConstants>() as u32,
-                },
-            },
-            wgpu::Binding {
-                binding: 1,
-                resource: wgpu::BindingResource::Buffer {
-                    buffer: &terrain_uni_buf,
-                    range: 0 .. mem::size_of::<TerrainConstants>() as u32,
-                },
-            },
-            wgpu::Binding {
-                binding: 2,
-                resource: wgpu::BindingResource::TextureView(
-                    &height_texture.create_default_view(),
-                ),
-            },
-            wgpu::Binding {
-                binding: 3,
-                resource: wgpu::BindingResource::TextureView(
-                    &meta_texture.create_default_view(),
-                ),
-            },
-            wgpu::Binding {
-                binding: 4,
-                resource: wgpu::BindingResource::TextureView(
-                    &flood_texture.create_default_view(),
-                ),
-            },
-            wgpu::Binding {
-                binding: 5,
-                resource: wgpu::BindingResource::TextureView(
-                    &table_texture.create_default_view(),
-                ),
-            },
-            wgpu::Binding {
-                binding: 6,
-                resource: wgpu::BindingResource::TextureView(&level_palette_view),
-            },
-            wgpu::Binding {
-                binding: 7,
-                resource: wgpu::BindingResource::Sampler(&repeat_nearest_sampler),
-            },
-            wgpu::Binding {
-                binding: 8,
-                resource: wgpu::BindingResource::Sampler(&flood_sampler),
-            },
-            wgpu::Binding {
-                binding: 9,
-                resource: wgpu::BindingResource::Sampler(&table_sampler),
-            },
-        ],
-    });
-
-    let terrain_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-        bind_group_layouts: &[
-            &global.bind_group_layout,
-            &terrain_bg_layout,
-        ],
-    });
-
-    let vertices = [
-        TerrainVertex { _pos: [0, 0, 0, 1] },
-        TerrainVertex { _pos: [-1, 0, 0, 0] },
-        TerrainVertex { _pos: [0, -1, 0, 0] },
-        TerrainVertex { _pos: [1, 0, 0, 0] },
-        TerrainVertex { _pos: [0, 1, 0, 0] },
-    ];
-    let indices = [0u16, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1];
-
-    let terrain_vertex_buf = device
-        .create_buffer_mapped(vertices.len(), wgpu::BufferUsageFlags::VERTEX)
-        .fill_from_slice(&vertices);
-    let terrain_index_buf = device
-        .create_buffer_mapped(indices.len(), wgpu::BufferUsageFlags::INDEX)
-        .fill_from_slice(&indices);
-
-    let terrain_pipeline = Render::create_terrain_ray_pipeline(&terrain_pipeline_layout, device);
-
-    Render {
-        global,
-        object,
-        terrain_bg,
-        terrain_uni_buf,
-        terrain_pipeline_layout,
-        terrain: Terrain::Ray {
-            pipeline: terrain_pipeline,
-            vertex_buf: terrain_vertex_buf,
-            index_buf: terrain_index_buf,
-            num_indices: indices.len(),
-        },
-        light_config: settings.light.clone(),
-        debug: DebugRender::new(device, &settings.debug),
-    }
-}
-
 impl Render {
+    pub fn new(
+        device: &mut wgpu::Device,
+        level: &level::Level,
+        object_palette: &[[u8; 4]],
+        settings: &settings::Render,
+    ) -> Self {
+        let mut init_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            todo: 0,
+        });
+        let global = GlobalContext::new(device);
+        let object = object::Context::new(&mut init_encoder, device, object_palette, &global);
+        let terrain = terrain::Context::new(&mut init_encoder, device, level, &global);
+        device.get_queue().submit(&[
+            init_encoder.finish(),
+        ]);
+
+        Render {
+            global,
+            object,
+            terrain,
+            light_config: settings.light.clone(),
+            debug: DebugRender::new(device, &settings.debug),
+        }
+    }
+
     pub fn draw_mesh(
         pass: &mut wgpu::RenderPass,
         updater: &mut Updater,
@@ -752,9 +441,9 @@ impl Render {
         updater.update(&self.global.uniform_buf, &[
             GlobalConstants::new(cam, &self.light_config),
         ]);
-        updater.update(&self.terrain_uni_buf, &[TerrainConstants {
-            _scr_size: [targets.extent.width as f32, targets.extent.height as f32, 0.0, 0.0],
-        }]);
+        updater.update(&self.terrain.uniform_buf, &[
+            terrain::Constants::new(&targets.extent)
+        ]);
 
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             todo: 0,
@@ -783,10 +472,10 @@ impl Render {
             });
 
             pass.set_bind_group(0, &self.global.bind_group);
-            pass.set_bind_group(1, &self.terrain_bg);
+            pass.set_bind_group(1, &self.terrain.bind_group);
             // draw terrain
-            match self.terrain {
-                Terrain::Ray { ref pipeline, ref index_buf, ref vertex_buf, num_indices } => {
+            match self.terrain.kind {
+                terrain::Kind::Ray { ref pipeline, ref index_buf, ref vertex_buf, num_indices } => {
                     pass.set_pipeline(pipeline);
                     pass.set_index_buffer(index_buf, 0);
                     pass.set_vertex_buffers(&[(vertex_buf, 0)]);
@@ -824,126 +513,10 @@ impl Render {
         ]
     }
 
-    pub fn create_palette(
-        encoder: &mut wgpu::CommandEncoder,
-        data: &[[u8; 4]],
-        device: &wgpu::Device,
-    ) -> wgpu::TextureView {
-        let extent = wgpu::Extent3d {
-            width: 0x100,
-            height: 1,
-            depth: 1,
-        };
-        let texture = device.create_texture(&wgpu::TextureDescriptor {
-            size: extent,
-            array_size: 1,
-            dimension: wgpu::TextureDimension::D1,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
-        });
-
-        let staging = device
-            .create_buffer_mapped(data.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
-            .fill_from_slice(data);
-        encoder.copy_buffer_to_texture(
-            wgpu::BufferCopyView {
-                buffer: &staging,
-                offset: 0,
-                row_pitch: 0x100 * 4,
-                image_height: 1,
-            },
-            wgpu::TextureCopyView {
-                texture: &texture,
-                level: 0,
-                slice: 0,
-                origin: wgpu::Origin3d {
-                    x: 0.0,
-                    y: 0.0,
-                    z: 0.0,
-                },
-            },
-            extent,
-        );
-
-        texture.create_default_view()
-    }
-
-    fn create_terrain_ray_pipeline(
-        layout: &wgpu::PipelineLayout,
-        device: &wgpu::Device,
-    ) -> wgpu::RenderPipeline {
-        let shaders = read_shaders("terrain_ray", &[], device)
-            .unwrap();
-        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            layout,
-            vertex_stage: wgpu::PipelineStageDescriptor {
-                module: &shaders.vs,
-                entry_point: "main",
-            },
-            fragment_stage: wgpu::PipelineStageDescriptor {
-                module: &shaders.fs,
-                entry_point: "main",
-            },
-            rasterization_state: wgpu::RasterizationStateDescriptor {
-                front_face: wgpu::FrontFace::Ccw,
-                cull_mode: wgpu::CullMode::None,
-                depth_bias: 0,
-                depth_bias_slope_scale: 0.0,
-                depth_bias_clamp: 0.0,
-            },
-            primitive_topology: wgpu::PrimitiveTopology::TriangleList,
-            color_states: &[
-                wgpu::ColorStateDescriptor {
-                    format: COLOR_FORMAT,
-                    alpha: wgpu::BlendDescriptor::REPLACE,
-                    color: wgpu::BlendDescriptor::REPLACE,
-                    write_mask: wgpu::ColorWriteFlags::all(),
-                },
-            ],
-            depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
-                format: DEPTH_FORMAT,
-                depth_write_enabled: true,
-                depth_compare: wgpu::CompareFunction::Always,
-                stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
-                stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
-                stencil_read_mask: !0,
-                stencil_write_mask: !0,
-            }),
-            index_format: wgpu::IndexFormat::Uint16,
-            vertex_buffers: &[
-                wgpu::VertexBufferDescriptor {
-                    stride: mem::size_of::<TerrainVertex>() as u32,
-                    step_mode: wgpu::InputStepMode::Vertex,
-                    attributes: &[
-                        wgpu::VertexAttributeDescriptor {
-                            offset: 0,
-                            format: wgpu::VertexFormat::Char4,
-                            attribute_index: 0,
-                        },
-                    ],
-                },
-            ],
-            sample_count: 1,
-        })
-    }
-
     pub fn reload(&mut self, device: &wgpu::Device) {
         info!("Reloading shaders");
-        match self.terrain {
-            Terrain::Ray { ref mut pipeline, .. } => {
-                *pipeline = Render::create_terrain_ray_pipeline(
-                    &self.terrain_pipeline_layout,
-                    device,
-                );
-            }
-            /*
-            Terrain::Tess { ref mut low, ref mut high, screen_space } => {
-                let (lo, hi) = Render::create_terrain_tess_psos(factory, screen_space);
-                *low = lo;
-                *high = hi;
-            }*/
-        }
         self.object.reload(device);
+        self.terrain.reload(device);
     }
 
     /*

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -52,6 +52,7 @@ pub struct Vertex {
 #[derive(Clone, Copy)]
 pub struct Locals {
     _matrix: [[f32; 4]; 4],
+    _pad: [u8; 192], //HACK: pad to 256
 }
 
 impl Locals {
@@ -59,6 +60,7 @@ impl Locals {
         use cgmath::Matrix4;
         Locals {
             _matrix: Matrix4::from(transform).into(),
+            _pad: [0; 192],
         }
     }
 }

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -1,6 +1,5 @@
 use crate::render::{
-    Render,
-    read_shaders,
+    Palette, Shaders,
     COLOR_FORMAT, DEPTH_FORMAT,
     GlobalContext,
 };
@@ -64,7 +63,7 @@ impl Context {
         layout: &wgpu::PipelineLayout,
         device: &wgpu::Device,
     ) -> wgpu::RenderPipeline {
-        let shaders = read_shaders("object", &[], device)
+        let shaders = Shaders::new("object", &[], device)
             .unwrap();
         device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             layout,
@@ -189,7 +188,7 @@ impl Context {
     pub fn new(
         init_encoder: &mut wgpu::CommandEncoder,
         device: &wgpu::Device,
-        palette: &[[u8; 4]],
+        palette_data: &[[u8; 4]],
         global: &GlobalContext,
     ) -> Self {
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
@@ -220,9 +219,7 @@ impl Context {
             size: mem::size_of::<Locals>() as u32,
             usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
         });
-        let palette_view = Render::create_palette(
-            init_encoder, palette, device
-        );
+        let palette = Palette::new(init_encoder, device, palette_data);
         let (color_table_view, color_table_sampler) = Self::create_color_table(
             init_encoder, device
         );
@@ -242,7 +239,7 @@ impl Context {
                 },
                 wgpu::Binding {
                     binding: 2,
-                    resource: wgpu::BindingResource::TextureView(&palette_view),
+                    resource: wgpu::BindingResource::TextureView(&palette.view),
                 },
                 wgpu::Binding {
                     binding: 3,

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -1,0 +1,272 @@
+use crate::render::{
+    Render,
+    read_shaders,
+    COLOR_FORMAT, DEPTH_FORMAT,
+    GlobalContext,
+};
+use m3d::NUM_COLOR_IDS;
+
+use wgpu;
+
+use std::mem;
+
+
+const COLOR_TABLE: [[u8; 2]; NUM_COLOR_IDS as usize] = [
+    [0, 0],   // reserved
+    [128, 3], // body
+    [176, 4], // window
+    [224, 7], // wheel
+    [184, 4], // defence
+    [224, 3], // weapon
+    [224, 7], // tube
+    [128, 3], // body red
+    [144, 3], // body blue
+    [160, 3], // body yellow
+    [228, 4], // body gray
+    [112, 4], // yellow (charged)
+    [0, 2],   // material 0
+    [32, 2],  // material 1
+    [64, 4],  // material 2
+    [72, 3],  // material 3
+    [88, 3],  // material 4
+    [104, 4], // material 5
+    [112, 4], // material 6
+    [120, 4], // material 7
+    [184, 4], // black
+    [240, 3], // body green
+    [136, 4], // skyfarmer kenoboo
+    [128, 4], // skyfarmer pipetka
+    [224, 4], // rotten item
+];
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Vertex {
+    pub pos: [i8; 4],
+    pub color: u32,
+    pub normal: [i8; 4],
+}
+
+#[derive(Clone, Copy)]
+pub struct Locals {
+    pub matrix: [[f32; 4]; 4],
+}
+
+pub struct Context {
+    pub uniform_buf: wgpu::Buffer,
+    pub bind_group: wgpu::BindGroup,
+    pub pipeline_layout: wgpu::PipelineLayout,
+    pub pipeline: wgpu::RenderPipeline,
+}
+
+impl Context {
+    fn create_pipeline(
+        layout: &wgpu::PipelineLayout,
+        device: &wgpu::Device,
+    ) -> wgpu::RenderPipeline {
+        let shaders = read_shaders("object", &[], device)
+            .unwrap();
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            layout,
+            vertex_stage: wgpu::PipelineStageDescriptor {
+                module: &shaders.vs,
+                entry_point: "main",
+            },
+            fragment_stage: wgpu::PipelineStageDescriptor {
+                module: &shaders.fs,
+                entry_point: "main",
+            },
+            rasterization_state: wgpu::RasterizationStateDescriptor {
+                front_face: wgpu::FrontFace::Ccw,
+                // original was not drawn with rasterizer, used no culling
+                cull_mode: wgpu::CullMode::None,
+                depth_bias: 0,
+                depth_bias_slope_scale: 0.0,
+                depth_bias_clamp: 0.0,
+            },
+            primitive_topology: wgpu::PrimitiveTopology::TriangleList,
+            color_states: &[
+                wgpu::ColorStateDescriptor {
+                    format: COLOR_FORMAT,
+                    alpha: wgpu::BlendDescriptor::REPLACE,
+                    color: wgpu::BlendDescriptor::REPLACE,
+                    write_mask: wgpu::ColorWriteFlags::all(),
+                },
+            ],
+            depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
+                format: DEPTH_FORMAT,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::LessEqual,
+                stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_read_mask: !0,
+                stencil_write_mask: !0,
+            }),
+            index_format: wgpu::IndexFormat::Uint16,
+            vertex_buffers: &[
+                wgpu::VertexBufferDescriptor {
+                    stride: mem::size_of::<Vertex>() as u32,
+                    step_mode: wgpu::InputStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttributeDescriptor {
+                            offset: 0,
+                            format: wgpu::VertexFormat::Char4,
+                            attribute_index: 0,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            offset: 4,
+                            format: wgpu::VertexFormat::Uint,
+                            attribute_index: 1,
+                        },
+                        wgpu::VertexAttributeDescriptor {
+                            offset: 8,
+                            format: wgpu::VertexFormat::Uchar4Norm,
+                            attribute_index: 2,
+                        },
+                    ],
+                },
+            ],
+            sample_count: 1,
+        })
+    }
+
+    fn create_color_table(
+        encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device
+    ) -> (wgpu::TextureView, wgpu::Sampler) {
+        let extent = wgpu::Extent3d {
+            width: NUM_COLOR_IDS as u32,
+            height: 1,
+            depth: 1,
+        };
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: extent,
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D1,
+            format: wgpu::TextureFormat::Rg8Uint,
+            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+        });
+
+        let staging = device
+            .create_buffer_mapped(NUM_COLOR_IDS as usize, wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(&COLOR_TABLE);
+        encoder.copy_buffer_to_texture(
+            wgpu::BufferCopyView {
+                buffer: &staging,
+                offset: 0,
+                row_pitch: NUM_COLOR_IDS as u32 * 2,
+                image_height: 1,
+            },
+            wgpu::TextureCopyView {
+                texture: &texture,
+                level: 0,
+                slice: 0,
+                origin: wgpu::Origin3d {
+                    x: 0.0,
+                    y: 0.0,
+                    z: 0.0,
+                },
+            },
+            extent,
+        );
+
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            r_address_mode: wgpu::AddressMode::ClampToEdge,
+            s_address_mode: wgpu::AddressMode::ClampToEdge,
+            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            lod_min_clamp: 0.0,
+            lod_max_clamp: 0.0,
+            max_anisotropy: 0,
+            compare_function: wgpu::CompareFunction::Always,
+            border_color: wgpu::BorderColor::TransparentBlack,
+        });
+        (texture.create_default_view(), sampler)
+    }
+
+    pub fn new(
+        init_encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device,
+        palette: &[[u8; 4]],
+        global: &GlobalContext,
+    ) -> Self {
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            bindings: &[
+                wgpu::BindGroupLayoutBinding { // object locals
+                    binding: 0,
+                    visibility: wgpu::ShaderStageFlags::VERTEX,
+                    ty: wgpu::BindingType::UniformBuffer,
+                },
+                wgpu::BindGroupLayoutBinding { // color map
+                    binding: 1,
+                    visibility: wgpu::ShaderStageFlags::VERTEX,
+                    ty: wgpu::BindingType::SampledTexture,
+                },
+                wgpu::BindGroupLayoutBinding { // palette map
+                    binding: 2,
+                    visibility: wgpu::ShaderStageFlags::VERTEX,
+                    ty: wgpu::BindingType::SampledTexture,
+                },
+                wgpu::BindGroupLayoutBinding { // main sampler
+                    binding: 3,
+                    visibility: wgpu::ShaderStageFlags::VERTEX,
+                    ty: wgpu::BindingType::Sampler,
+                },
+            ],
+        });
+        let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            size: mem::size_of::<Locals>() as u32,
+            usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+        });
+        let palette_view = Render::create_palette(
+            init_encoder, palette, device
+        );
+        let (color_table_view, color_table_sampler) = Self::create_color_table(
+            init_encoder, device
+        );
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &bind_group_layout,
+            bindings: &[
+                wgpu::Binding {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &uniform_buf,
+                        range: 0 .. mem::size_of::<Locals>() as u32,
+                    },
+                },
+                wgpu::Binding {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&color_table_view),
+                },
+                wgpu::Binding {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(&palette_view),
+                },
+                wgpu::Binding {
+                    binding: 3,
+                    resource: wgpu::BindingResource::Sampler(&color_table_sampler),
+                },
+            ],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            bind_group_layouts: &[
+                &global.bind_group_layout,
+                &bind_group_layout,
+            ],
+        });
+        let pipeline = Self::create_pipeline(&pipeline_layout, device);
+
+        Context {
+            uniform_buf,
+            bind_group,
+            pipeline_layout,
+            pipeline,
+        }
+    }
+
+    pub fn reload(&mut self, device: &wgpu::Device) {
+        self.pipeline = Self::create_pipeline(&self.pipeline_layout, device);
+    }
+}

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -1,7 +1,7 @@
 use crate::render::{
     Palette, Shaders,
     COLOR_FORMAT, DEPTH_FORMAT,
-    GlobalContext,
+    global::Context as GlobalContext,
 };
 use m3d::NUM_COLOR_IDS;
 

--- a/src/render/terrain.rs
+++ b/src/render/terrain.rs
@@ -1,0 +1,480 @@
+use crate::{
+    level,
+    render::{
+        GlobalContext, Palette, Shaders,
+        COLOR_FORMAT, DEPTH_FORMAT,
+    },
+};
+
+use wgpu;
+
+use std::mem;
+
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Vertex {
+    _pos: [i8; 4],
+}
+
+#[derive(Clone, Copy)]
+struct SurfaceConstants {
+    _tex_scale: [f32; 4],
+}
+
+#[derive(Clone, Copy)]
+pub struct Constants {
+    _scr_size: [f32; 4],
+}
+
+impl Constants {
+    pub fn new(extent: &wgpu::Extent3d) -> Self {
+        Constants {
+            _scr_size: [extent.width as f32, extent.height as f32, 0.0, 0.0],
+        }
+    }
+}
+
+pub enum Kind {
+    Ray {
+        pipeline: wgpu::RenderPipeline,
+        vertex_buf: wgpu::Buffer,
+        index_buf: wgpu::Buffer,
+        num_indices: usize,
+    },
+    /*Tess {
+        low: gfx::PipelineState<R, terrain::Meta>,
+        high: gfx::PipelineState<R, terrain::Meta>,
+        screen_space: bool,
+    },*/
+}
+
+pub struct Context {
+    pub uniform_buf: wgpu::Buffer,
+    pub bind_group: wgpu::BindGroup,
+    pipeline_layout: wgpu::PipelineLayout,
+    pub kind: Kind,
+}
+
+impl Context {
+    fn create_ray_pipeline(
+        layout: &wgpu::PipelineLayout,
+        device: &wgpu::Device,
+    ) -> wgpu::RenderPipeline {
+        let shaders = Shaders::new("terrain_ray", &[], device)
+            .unwrap();
+        device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            layout,
+            vertex_stage: wgpu::PipelineStageDescriptor {
+                module: &shaders.vs,
+                entry_point: "main",
+            },
+            fragment_stage: wgpu::PipelineStageDescriptor {
+                module: &shaders.fs,
+                entry_point: "main",
+            },
+            rasterization_state: wgpu::RasterizationStateDescriptor {
+                front_face: wgpu::FrontFace::Ccw,
+                cull_mode: wgpu::CullMode::None,
+                depth_bias: 0,
+                depth_bias_slope_scale: 0.0,
+                depth_bias_clamp: 0.0,
+            },
+            primitive_topology: wgpu::PrimitiveTopology::TriangleList,
+            color_states: &[
+                wgpu::ColorStateDescriptor {
+                    format: COLOR_FORMAT,
+                    alpha: wgpu::BlendDescriptor::REPLACE,
+                    color: wgpu::BlendDescriptor::REPLACE,
+                    write_mask: wgpu::ColorWriteFlags::all(),
+                },
+            ],
+            depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
+                format: DEPTH_FORMAT,
+                depth_write_enabled: true,
+                depth_compare: wgpu::CompareFunction::Always,
+                stencil_front: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_back: wgpu::StencilStateFaceDescriptor::IGNORE,
+                stencil_read_mask: !0,
+                stencil_write_mask: !0,
+            }),
+            index_format: wgpu::IndexFormat::Uint16,
+            vertex_buffers: &[
+                wgpu::VertexBufferDescriptor {
+                    stride: mem::size_of::<Vertex>() as u32,
+                    step_mode: wgpu::InputStepMode::Vertex,
+                    attributes: &[
+                        wgpu::VertexAttributeDescriptor {
+                            offset: 0,
+                            format: wgpu::VertexFormat::Char4,
+                            attribute_index: 0,
+                        },
+                    ],
+                },
+            ],
+            sample_count: 1,
+        })
+    }
+
+    pub fn new(
+        init_encoder: &mut wgpu::CommandEncoder,
+        device: &wgpu::Device,
+        level: &level::Level,
+        global: &GlobalContext,
+    ) -> Self {
+        let origin = wgpu::Origin3d { x: 0.0, y: 0.0, z: 0.0 };
+        let extent = wgpu::Extent3d {
+            width: level.size.0 as u32,
+            height: level.size.1 as u32,
+            depth: 1,
+        };
+        let flood_extent = wgpu::Extent3d {
+            width: level.size.1 as u32 >> level.flood_section_power,
+            height: 1,
+            depth: 1,
+        };
+        let table_extent = wgpu::Extent3d {
+            width: level::NUM_TERRAINS as u32,
+            height: 1,
+            depth: 1,
+        };
+
+        let terrrain_table = level.terrains
+            .iter()
+            .map(|terr| [
+                terr.shadow_offset,
+                terr.height_shift,
+                terr.colors.start,
+                terr.colors.end,
+            ])
+            .collect::<Vec<_>>();
+
+        let height_texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: extent,
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R8Unorm,
+            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+        });
+        let meta_texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: extent,
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::R8Uint,
+            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+        });
+        let flood_texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: flood_extent,
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D1,
+            format: wgpu::TextureFormat::R8Unorm,
+            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+        });
+        let table_texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: table_extent,
+            array_size: 1,
+            dimension: wgpu::TextureDimension::D1,
+            format: wgpu::TextureFormat::Rgba8Uint,
+            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+        });
+
+        let height_staging = device
+            .create_buffer_mapped(level.height.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(&level.height);
+        let meta_staging = device
+            .create_buffer_mapped(level.meta.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(&level.meta);
+        let flood_staging = device
+            .create_buffer_mapped(level.flood_map.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(&level.flood_map);
+        let table_staging = device
+            .create_buffer_mapped(terrrain_table.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .fill_from_slice(&terrrain_table);
+
+        init_encoder.copy_buffer_to_texture(
+            wgpu::BufferCopyView {
+                buffer: &height_staging,
+                offset: 0,
+                row_pitch: level.size.0 as u32,
+                image_height: level.size.1 as u32,
+            },
+            wgpu::TextureCopyView {
+                texture: &height_texture,
+                level: 0,
+                slice: 0,
+                origin,
+            },
+            extent,
+        );
+        init_encoder.copy_buffer_to_texture(
+            wgpu::BufferCopyView {
+                buffer: &meta_staging,
+                offset: 0,
+                row_pitch: level.size.0 as u32,
+                image_height: level.size.1 as u32,
+            },
+            wgpu::TextureCopyView {
+                texture: &meta_texture,
+                level: 0,
+                slice: 0,
+                origin,
+            },
+            extent,
+        );
+        init_encoder.copy_buffer_to_texture(
+            wgpu::BufferCopyView {
+                buffer: &flood_staging,
+                offset: 0,
+                row_pitch: flood_extent.width,
+                image_height: 1,
+            },
+            wgpu::TextureCopyView {
+                texture: &flood_texture,
+                level: 0,
+                slice: 0,
+                origin,
+            },
+            flood_extent,
+        );
+        init_encoder.copy_buffer_to_texture(
+            wgpu::BufferCopyView {
+                buffer: &table_staging,
+                offset: 0,
+                row_pitch: table_extent.width * 4,
+                image_height: 1,
+            },
+            wgpu::TextureCopyView {
+                texture: &table_texture,
+                level: 0,
+                slice: 0,
+                origin,
+            },
+            table_extent,
+        );
+        let palette = Palette::new(init_encoder, device, &level.palette);
+
+        let repeat_nearest_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            r_address_mode: wgpu::AddressMode::Repeat,
+            s_address_mode: wgpu::AddressMode::Repeat,
+            t_address_mode: wgpu::AddressMode::Repeat,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            lod_min_clamp: 0.0,
+            lod_max_clamp: 0.0,
+            max_anisotropy: 0,
+            compare_function: wgpu::CompareFunction::Always,
+            border_color: wgpu::BorderColor::TransparentBlack,
+        });
+        let flood_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            r_address_mode: wgpu::AddressMode::Repeat,
+            s_address_mode: wgpu::AddressMode::ClampToEdge,
+            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            lod_min_clamp: 0.0,
+            lod_max_clamp: 0.0,
+            max_anisotropy: 0,
+            compare_function: wgpu::CompareFunction::Always,
+            border_color: wgpu::BorderColor::TransparentBlack,
+        });
+        let table_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            r_address_mode: wgpu::AddressMode::ClampToEdge,
+            s_address_mode: wgpu::AddressMode::ClampToEdge,
+            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            lod_min_clamp: 0.0,
+            lod_max_clamp: 0.0,
+            max_anisotropy: 0,
+            compare_function: wgpu::CompareFunction::Always,
+            border_color: wgpu::BorderColor::TransparentBlack,
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            bindings: &[
+                wgpu::BindGroupLayoutBinding { // surface uniforms
+                    binding: 0,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::UniformBuffer,
+                },
+                wgpu::BindGroupLayoutBinding { // terrain locals
+                    binding: 1,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::UniformBuffer,
+                },
+                wgpu::BindGroupLayoutBinding { // height map
+                    binding: 2,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::SampledTexture,
+                },
+                wgpu::BindGroupLayoutBinding { // meta map
+                    binding: 3,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::SampledTexture,
+                },
+                wgpu::BindGroupLayoutBinding { // flood map
+                    binding: 4,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::SampledTexture,
+                },
+                wgpu::BindGroupLayoutBinding { // table map
+                    binding: 5,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::SampledTexture,
+                },
+                wgpu::BindGroupLayoutBinding { // palette map
+                    binding: 6,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::SampledTexture,
+                },
+                wgpu::BindGroupLayoutBinding { // main sampler
+                    binding: 7,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler,
+                },
+                wgpu::BindGroupLayoutBinding { // flood sampler
+                    binding: 8,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler,
+                },
+                wgpu::BindGroupLayoutBinding { // table sampler
+                    binding: 9,
+                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler,
+                },
+            ],
+        });
+
+        let surface_uni_buf = device
+            .create_buffer_mapped(1, wgpu::BufferUsageFlags::UNIFORM)
+            .fill_from_slice(&[SurfaceConstants {
+                _tex_scale: [
+                    level.size.0 as f32,
+                    level.size.1 as f32,
+                    level::HEIGHT_SCALE as f32,
+                    0.0,
+                ],
+            }]);
+        let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            size: mem::size_of::<Constants>() as u32,
+            usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &bind_group_layout,
+            bindings: &[
+                wgpu::Binding {
+                    binding: 0,
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &surface_uni_buf,
+                        range: 0 .. mem::size_of::<SurfaceConstants>() as u32,
+                    },
+                },
+                wgpu::Binding {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Buffer {
+                        buffer: &uniform_buf,
+                        range: 0 .. mem::size_of::<Constants>() as u32,
+                    },
+                },
+                wgpu::Binding {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(
+                        &height_texture.create_default_view(),
+                    ),
+                },
+                wgpu::Binding {
+                    binding: 3,
+                    resource: wgpu::BindingResource::TextureView(
+                        &meta_texture.create_default_view(),
+                    ),
+                },
+                wgpu::Binding {
+                    binding: 4,
+                    resource: wgpu::BindingResource::TextureView(
+                        &flood_texture.create_default_view(),
+                    ),
+                },
+                wgpu::Binding {
+                    binding: 5,
+                    resource: wgpu::BindingResource::TextureView(
+                        &table_texture.create_default_view(),
+                    ),
+                },
+                wgpu::Binding {
+                    binding: 6,
+                    resource: wgpu::BindingResource::TextureView(&palette.view),
+                },
+                wgpu::Binding {
+                    binding: 7,
+                    resource: wgpu::BindingResource::Sampler(&repeat_nearest_sampler),
+                },
+                wgpu::Binding {
+                    binding: 8,
+                    resource: wgpu::BindingResource::Sampler(&flood_sampler),
+                },
+                wgpu::Binding {
+                    binding: 9,
+                    resource: wgpu::BindingResource::Sampler(&table_sampler),
+                },
+            ],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            bind_group_layouts: &[
+                &global.bind_group_layout,
+                &bind_group_layout,
+            ],
+        });
+
+        let vertices = [
+            Vertex { _pos: [0, 0, 0, 1] },
+            Vertex { _pos: [-1, 0, 0, 0] },
+            Vertex { _pos: [0, -1, 0, 0] },
+            Vertex { _pos: [1, 0, 0, 0] },
+            Vertex { _pos: [0, 1, 0, 0] },
+        ];
+        let indices = [0u16, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1];
+
+        let vertex_buf = device
+            .create_buffer_mapped(vertices.len(), wgpu::BufferUsageFlags::VERTEX)
+            .fill_from_slice(&vertices);
+        let index_buf = device
+            .create_buffer_mapped(indices.len(), wgpu::BufferUsageFlags::INDEX)
+            .fill_from_slice(&indices);
+
+        let pipeline = Self::create_ray_pipeline(&pipeline_layout, device);
+
+        Context {
+            uniform_buf,
+            bind_group,
+            pipeline_layout,
+            kind: Kind::Ray {
+                pipeline,
+                vertex_buf,
+                index_buf,
+                num_indices: indices.len(),
+            },
+        }
+    }
+
+    pub fn reload(&mut self, device: &wgpu::Device) {
+        match self.kind {
+            Kind::Ray { ref mut pipeline, .. } => {
+                *pipeline = Self::create_ray_pipeline(
+                    &self.pipeline_layout,
+                    device,
+                );
+            }
+            /*
+            Terrain::Tess { ref mut low, ref mut high, screen_space } => {
+                let (lo, hi) = Render::create_terrain_tess_psos(factory, screen_space);
+                *low = lo;
+                *high = hi;
+            }*/
+        }
+    }
+}

--- a/src/render/terrain.rs
+++ b/src/render/terrain.rs
@@ -1,8 +1,9 @@
 use crate::{
     level,
     render::{
-        GlobalContext, Palette, Shaders,
+        Palette, Shaders,
         COLOR_FORMAT, DEPTH_FORMAT,
+        global::Context as GlobalContext,
     },
 };
 

--- a/src/render/terrain.rs
+++ b/src/render/terrain.rs
@@ -62,7 +62,7 @@ impl Context {
         layout: &wgpu::PipelineLayout,
         device: &wgpu::Device,
     ) -> wgpu::RenderPipeline {
-        let shaders = Shaders::new("terrain_ray", &[], device)
+        let shaders = Shaders::new("terrain_ray_old", &[], device)
             .unwrap();
         device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
             layout,

--- a/src/space.rs
+++ b/src/space.rs
@@ -80,7 +80,19 @@ impl Camera {
             disp: self.loc,
         };
         let view_mx = Matrix4::from(view.inverse_transform().unwrap());
-        self.proj.to_matrix() * view_mx
+        let mut mvp = self.proj.to_matrix() * view_mx;
+        // convert from GL to wgpu/gfx-rs
+        // 1) depth conversion from [-1,1] to [0,1]
+        mvp.x.z = 0.5*(mvp.x.z + mvp.x.w);
+        mvp.y.z = 0.5*(mvp.y.z + mvp.y.w);
+        mvp.z.z = 0.5*(mvp.z.z + mvp.z.w);
+        mvp.w.z = 0.5*(mvp.w.z + mvp.w.w);
+        // 2) invert Y
+        mvp.x.y *= -1.0;
+        mvp.y.y *= -1.0;
+        mvp.z.y *= -1.0;
+        mvp.w.y *= -1.0;
+        mvp
     }
 
     pub fn follow(


### PR DESCRIPTION
Fixes #72 

Converts the graphics subsystem to wgpu-rs, modularizes it, and moves the whole codebase to Rust 2018. Works on:
- [x] macOS/Metal
- [x] linux/Vulkan
- [x] windows/Vulkan
- [x] windows/Dx12
- [x] windows/Dx11

Note: the port was done from an earlier version of vange-rs prior to the new raytracing algorithm (bc8ac0defa4533d8173208603ae3823ef54f421e). This PR misses some of the features:
  - new raytracing - #74
  - debug rendering - #75
