### PR TITLE
Compute-scattered terrain painting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "atom"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +182,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorful"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "copyless"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "core-foundation"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -239,6 +254,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derivative"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -348,16 +373,16 @@ dependencies = [
 
 [[package]]
 name = "gfx-backend-empty"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "gfx-hal"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -373,6 +398,14 @@ dependencies = [
  "cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hibitset"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atom 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -425,6 +458,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -571,12 +612,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -782,11 +848,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "relevant"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rendy-descriptor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "relevant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rendy-memory"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "colorful 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hibitset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "relevant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -842,6 +947,11 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "scopeguard"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,6 +1000,11 @@ dependencies = [
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
@@ -1046,7 +1161,7 @@ dependencies = [
  "serde_scan 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "splay 0.1.0",
  "tiff 0.1.0",
- "wgpu 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wgpu 0.2.2 (git+https://github.com/gfx-rs/wgpu-rs)",
 ]
 
 [[package]]
@@ -1126,26 +1241,29 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/gfx-rs/wgpu-rs#5a1c5c269ab5d0cebaaddff933d6c75d5e566d2d"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "wgpu-native 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wgpu-native 0.2.6 (git+https://github.com/gfx-rs/wgpu?rev=9276cd51c0cc0b3b5bd2e7ce9c7a09aeca313227)",
 ]
 
 [[package]]
 name = "wgpu-native"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.2.6"
+source = "git+https://github.com/gfx-rs/wgpu?rev=9276cd51c0cc0b3b5bd2e7ce9c7a09aeca313227#9276cd51c0cc0b3b5bd2e7ce9c7a09aeca313227"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-backend-empty 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "copyless 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-backend-empty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gfx-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rendy-descriptor 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rendy-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1186,11 +1304,12 @@ dependencies = [
 
 [[package]]
 name = "winit"
-version = "0.18.1"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1234,6 +1353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
+"checksum atom 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3c86699c3f02778ec07158376991c8f783dd1f2f95c579ffaf0738dc984b2fe2"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
@@ -1250,6 +1370,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "6ec65ee4f9c9d16f335091d23693457ed4928657ba4982289d7fafee03bc614a"
 "checksum cocoa 0.18.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf79daa4e11e5def06e55306aa3601b87de6b5149671529318da048f67cdd77b"
+"checksum colorful 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0bca1619ff57dd7a56b58a8e25ef4199f123e78e503fe1653410350a1b98ae65"
+"checksum copyless 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59de7722d3b5c7b35dd519d617fe5116c9b879a0f145dc5431d78ab1f61d7c23"
 "checksum core-foundation 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4e2640d6d0bf22e82bed1b73c6aef8d5dd31e5abe6666c57e6d45e2649f4f887"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)" = "56790968ab1c8a1202a102e6de05fc6e1ec87da99e4e93e9a7d13efbfc1e95a9"
@@ -1257,6 +1379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum deflate 0.7.19 (registry+https://github.com/rust-lang/crates.io-index)" = "8a6abb26e16e8d419b5c78662aa9f82857c2386a073da266840e474d5055ec86"
+"checksum derivative 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6073e9676dbebdddeabaeb63e3b7cefd23c86f5c41d381ee1237cc77b1079898"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "18df8ce4470c189d18aa926022da57544f31e154631eb4cfe796aea97051fe6c"
@@ -1271,9 +1394,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
-"checksum gfx-backend-empty 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "590c15369f88b88e4ea748da52b27a521a758a947b4aee995539c9f0cc1beb4c"
-"checksum gfx-hal 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84c470bce77fcaaea6854858682a99026ff796b880b0ca30511593a6b2bc77c0"
+"checksum gfx-backend-empty 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48d970b730c75da0e4905380e9af664e0ef46c5c4643fbacf637e114df047fb5"
+"checksum gfx-hal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c045161572372465ebbcb0d33ee937b6ed8874a193148c053688a400b92b197c"
 "checksum glsl-to-spirv 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "28caebc98746d507603a2d3df66dcbe04e41d4febad0320f3eec1ef72b6bbef1"
+"checksum hibitset 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6527bc88f32e0d3926c7572874b2bf17a19b36978aacd0aacf75f7d27a5992d0"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
@@ -1281,6 +1405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libloading 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3ad660d7cb8c5822cd83d10897b0f1f1526792737a179e73896152f85b88c2"
 "checksum line_drawing 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5cc7ad3d82c845bdb5dde34ffdcc7a5fb4d2996e1e1ee0f19c33bc80e15196b9"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
+"checksum lock_api 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ed946d4529956a20f2d63ebe1b69996d5a2137c91913fe3ebbeff957f5bca7ff"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum malloc_buf 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
@@ -1298,7 +1423,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+"checksum parking_lot_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cb88cb1cb3790baa6776844f968fea3be44956cf184fa1be5a03341f5491278c"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum png 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "99c43e2159aafbfccf7b1e13f420d028a6b9384c72544ac3b829c14d48dcb002"
@@ -1322,7 +1449,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53ee8cfdddb2e0291adfb9f13d31d3bbe0a03c9a402c01b1e24188d86c35b24f"
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
+"checksum relevant 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bbc232e13d37f4547f5b9b42a5efc380cabe5dbc1807f8b893580640b2ab0308"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
+"checksum rendy-descriptor 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d994004622af2fe3848fde527258dd6bee8cf089a51e2e83fe5f2b7aeb09f6c0"
+"checksum rendy-memory 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fbdab806e4d349037b60ff6a25dad1260da58eb4b43ecac31350443278d5c002"
 "checksum ron 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "17f52a24414403f81528b67488cf8edc4eda977d3af1646bb6b106a600ead78f"
 "checksum rust-ini 0.10.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a654c5bda722c699be6b0fe4c0d90de218928da5b724c3e467fc48865c37263"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
@@ -1330,12 +1460,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rusttype 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ce3926a2057b315b3e8bca6d1cec1e97f19436a8f9127621cd538cda9c96a38b"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
 "checksum serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6eabf4b5914e88e24eea240bb7c9f9a2cbc1bbbe8d961d381975ec3c6b806c"
 "checksum serde_scan 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a46bde9df7cd825e0753a19b5454e9466d1c062b3b544a716ba032cfe8b5159"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
+"checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum smithay-client-toolkit 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aa4899558362a65589b53313935099835acf999740915e134dff20cca7c6a28b"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
@@ -1359,14 +1491,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum wayland-protocols 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fd94211387fa8ff50df1e4ff7a5529b5a9aebe68ba88acc48e5b7f5fd98f6eef"
 "checksum wayland-scanner 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3611f231e675e15c2feb7623103e6449edc6f10b0598cafb3e16e590a0561355"
 "checksum wayland-sys 0.21.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2a69d729a1747a5bf40ae05b94c7904b64fbf2381e365c046d872ce4a34aa826"
-"checksum wgpu 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "04b4caa48252eacc1209250ab72f737912c50ab41fc4517a38bd49a72f1a4dd1"
-"checksum wgpu-native 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "be0f6c9476ad14ff1b5304426a447a95653ea370f2c55fd570cb382dadfc5b16"
+"checksum wgpu 0.2.2 (git+https://github.com/gfx-rs/wgpu-rs)" = "<none>"
+"checksum wgpu-native 0.2.6 (git+https://github.com/gfx-rs/wgpu?rev=9276cd51c0cc0b3b5bd2e7ce9c7a09aeca313227)" = "<none>"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
-"checksum winit 0.18.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c57c15bd4c0ef18dff33e263e452abe32d00e2e05771cacaa410a14cc1c0776"
+"checksum winit 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d233301129ddd33260b47f76900b50e154b7254546e2edba0e5468a1a5fe4de3"
 "checksum x11-dl 2.18.3 (registry+https://github.com/rust-lang/crates.io-index)" = "940586acb859ea05c53971ac231685799a7ec1dee66ac0bccc0e6ad96e06b4e3"
 "checksum xdg 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
 "checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ rust-ini = "0.10"
 serde = "1.0"
 serde_derive = "1.0"
 serde_scan = "0.1"
-#wgpu = { github = "https://github.com/gfx-rs/wgpu", features = ["local"] }
-#wgpu = { path = "../wgpu/wgpu-rs" }
-wgpu = { version = "0.2.2" }
+wgpu = { git = "https://github.com/gfx-rs/wgpu-rs" }
+#wgpu = { path = "../wgpu-rs" }
+#wgpu = { version = "0.2.2" }
 # binaries
 env_logger = "0.5"
 getopts = "0.2"

--- a/bin/boilerplate.rs
+++ b/bin/boilerplate.rs
@@ -30,7 +30,7 @@ pub struct Harness {
     pub device: wgpu::Device,
     surface: wgpu::Surface,
     swap_chain: wgpu::SwapChain,
-    extent: wgpu::Extent3d,
+    pub extent: wgpu::Extent3d,
     depth_target: wgpu::TextureView,
 }
 

--- a/bin/boilerplate.rs
+++ b/bin/boilerplate.rs
@@ -43,10 +43,11 @@ impl Harness {
         let adapter = instance.get_adapter(&wgpu::AdapterDescriptor {
             power_preference: wgpu::PowerPreference::LowPower,
         });
-        let device = adapter.create_device(&wgpu::DeviceDescriptor {
+        let device = adapter.request_device(&wgpu::DeviceDescriptor {
             extensions: wgpu::Extensions {
                 anisotropic_filtering: false,
             },
+            limits: wgpu::Limits::default(),
         });
 
         info!("Loading the settings");
@@ -73,7 +74,7 @@ impl Harness {
 
         let surface = instance.create_surface(&window);
         let sc_desc = wgpu::SwapChainDescriptor {
-            usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+            usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
             format: COLOR_FORMAT,
             width: extent.width,
             height: extent.height,
@@ -82,10 +83,12 @@ impl Harness {
         let depth_target = device
             .create_texture(&wgpu::TextureDescriptor {
                 size: extent,
-                array_size: 1,
+                array_layer_count: 1,
+                mip_level_count: 1,
+                sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
                 format: DEPTH_FORMAT,
-                usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+                usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
             })
             .create_default_view();
 
@@ -158,7 +161,7 @@ impl Harness {
             if let Some(extent) = resized_extent {
                 self.extent = extent;
                 let sc_desc = wgpu::SwapChainDescriptor {
-                    usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+                    usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
                     format: COLOR_FORMAT,
                     width: extent.width,
                     height: extent.height,
@@ -167,10 +170,12 @@ impl Harness {
                 self.depth_target = self.device
                     .create_texture(&wgpu::TextureDescriptor {
                         size: extent,
-                        array_size: 1,
+                        array_layer_count: 1,
+                        mip_level_count: 1,
+                        sample_count: 1,
                         dimension: wgpu::TextureDimension::D2,
                         format: DEPTH_FORMAT,
-                        usage: wgpu::TextureUsageFlags::OUTPUT_ATTACHMENT,
+                        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
                     })
                     .create_default_view();
                 app.resize(&self.device, extent);

--- a/bin/car/app.rs
+++ b/bin/car/app.rs
@@ -195,7 +195,7 @@ impl Application for CarView {
             todo: 0,
         });
         let global_staging = device
-            .create_buffer_mapped(1, wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .create_buffer_mapped(1, wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&[
                 render::global::Constants::new(&self.cam, &self.light_config),
             ]);
@@ -204,7 +204,7 @@ impl Application for CarView {
             0,
             &self.global.uniform_buf,
             0,
-            mem::size_of::<render::global::Constants>() as u32,
+            mem::size_of::<render::global::Constants>() as wgpu::BufferAddress,
         );
 
         render::RenderModel {
@@ -219,6 +219,7 @@ impl Application for CarView {
                 color_attachments: &[
                     wgpu::RenderPassColorAttachmentDescriptor {
                         attachment: targets.color,
+                        resolve_target: None,
                         load_op: wgpu::LoadOp::Clear,
                         store_op: wgpu::StoreOp::Store,
                         clear_color: wgpu::Color {
@@ -238,8 +239,8 @@ impl Application for CarView {
             });
 
             pass.set_pipeline(&self.object.pipeline);
-            pass.set_bind_group(0, &self.global.bind_group);
-            pass.set_bind_group(1, &self.object.bind_group);
+            pass.set_bind_group(0, &self.global.bind_group, &[]);
+            pass.set_bind_group(1, &self.object.bind_group, &[]);
             render::Render::draw_model(
                 &mut pass,
                 &self.model,

--- a/bin/level/app.rs
+++ b/bin/level/app.rs
@@ -37,6 +37,7 @@ pub struct LevelView {
 impl LevelView {
     pub fn new(
         settings: &config::settings::Settings,
+        screen_extent: wgpu::Extent3d,
         device: &mut wgpu::Device,
     ) -> Self {
         let level = if settings.game.level.is_empty() {
@@ -93,7 +94,7 @@ impl LevelView {
 
         let objects_palette = level::read_palette(settings.open_palette(), None);
         let depth = 10f32 .. 10000f32;
-        let render = Render::new(device, &level, &objects_palette, &settings.render);
+        let render = Render::new(device, &level, &objects_palette, &settings.render, screen_extent);
 
         LevelView {
             render,
@@ -273,8 +274,9 @@ impl Application for LevelView {
         }
     }
 
-    fn resize(&mut self, _device: &wgpu::Device, extent: wgpu::Extent3d) {
+    fn resize(&mut self, device: &wgpu::Device, extent: wgpu::Extent3d) {
         self.cam.proj.update(extent.width as u16, extent.height as u16);
+        self.render.resize(extent, device);
     }
 
     fn reload(&mut self, device: &wgpu::Device) {

--- a/bin/level/main.rs
+++ b/bin/level/main.rs
@@ -5,7 +5,7 @@ mod boilerplate;
 fn main() {
     let (mut harness, settings) = boilerplate::Harness::init("level");
 
-    let app = app::LevelView::new(&settings, &mut harness.device);
+    let app = app::LevelView::new(&settings, harness.extent, &mut harness.device);
 
     harness.main_loop(app);
 }

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -132,7 +132,7 @@ impl Application for ResourceView {
             todo: 0,
         });
         let global_staging = device
-            .create_buffer_mapped(1, wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .create_buffer_mapped(1, wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&[
                 render::global::Constants::new(&self.cam, &self.light_config),
             ]);
@@ -141,7 +141,7 @@ impl Application for ResourceView {
             0,
             &self.global.uniform_buf,
             0,
-            mem::size_of::<render::global::Constants>() as u32,
+            mem::size_of::<render::global::Constants>() as wgpu::BufferAddress,
         );
         render::RenderModel {
             model: &self.model,
@@ -155,6 +155,7 @@ impl Application for ResourceView {
                 color_attachments: &[
                     wgpu::RenderPassColorAttachmentDescriptor {
                         attachment: targets.color,
+                        resolve_target: None,
                         load_op: wgpu::LoadOp::Clear,
                         store_op: wgpu::StoreOp::Store,
                         clear_color: wgpu::Color {
@@ -174,8 +175,8 @@ impl Application for ResourceView {
             });
 
             pass.set_pipeline(&self.object.pipeline);
-            pass.set_bind_group(0, &self.global.bind_group);
-            pass.set_bind_group(1, &self.object.bind_group);
+            pass.set_bind_group(0, &self.global.bind_group, &[]);
+            pass.set_bind_group(1, &self.object.bind_group, &[]);
             render::Render::draw_model(
                 &mut pass,
                 &self.model,

--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -152,6 +152,7 @@ pub struct Game {
 impl Game {
     pub fn new(
         settings: &config::Settings,
+        screen_extent: wgpu::Extent3d,
         device: &mut wgpu::Device,
     ) -> Self {
         info!("Loading world parameters");
@@ -179,7 +180,7 @@ impl Game {
         info!("Initializing the render");
         let depth = 10f32 .. 10000f32;
         let pal_data = level::read_palette(settings.open_palette(), Some(&level.terrains));
-        let render = Render::new(device, &level, &pal_data, &settings.render);
+        let render = Render::new(device, &level, &pal_data, &settings.render, screen_extent);
 
         info!("Loading world database");
         let db = {
@@ -463,8 +464,9 @@ impl Application for Game {
         }
     }
 
-    fn resize(&mut self, _device: &wgpu::Device, extent: wgpu::Extent3d) {
+    fn resize(&mut self, device: &wgpu::Device, extent: wgpu::Extent3d) {
         self.cam.proj.update(extent.width as u16, extent.height as u16);
+        self.render.resize(extent, device);
     }
 
     fn reload(&mut self, device: &wgpu::Device) {

--- a/bin/road/main.rs
+++ b/bin/road/main.rs
@@ -25,7 +25,7 @@ fn main() {
         return;
     }
 
-    let game = game::Game::new(&settings, &mut harness.device);
+    let game = game::Game::new(&settings, harness.extent, &mut harness.device);
 
     harness.main_loop(game);
 }

--- a/data/shader/color.inc.glsl
+++ b/data/shader/color.inc.glsl
@@ -37,13 +37,17 @@ float evaluate_palette(uint type, float value, float ycoord) {
     return (mix(terr.z, terr.w, value) + 0.5) / 256.0;
 }
 
-vec4 evaluate_color(uint type, vec2 tex_coord, float height_normalized, float lit_factor) {
+float evaluate_color_id(uint type, vec2 tex_coord, float height_normalized, float lit_factor) {
     float diff =
         textureLodOffset(sampler2D(t_Height, s_MainSampler), tex_coord, 0.0, ivec2(1, 0)).x -
         textureLodOffset(sampler2D(t_Height, s_MainSampler), tex_coord, 0.0, ivec2(-1, 0)).x;
     vec3 mat = type == 0U ? vec3(5.0, 1.25, 0.5) : vec3(1.0);
     float light_clr = evaluate_light(mat, diff);
     float tmp = light_clr - c_HorFactor * (1.0 - height_normalized);
-    float color_id = evaluate_palette(type, lit_factor * tmp, tex_coord.y);
+    return evaluate_palette(type, lit_factor * tmp, tex_coord.y);
+}
+
+vec4 evaluate_color(uint type, vec2 tex_coord, float height_normalized, float lit_factor) {
+    float color_id = evaluate_color_id(type, tex_coord, height_normalized, lit_factor);
     return texture(sampler1D(t_Palette, s_PaletteSampler), color_id);
 }

--- a/data/shader/terrain/ray_old.glsl
+++ b/data/shader/terrain/ray_old.glsl
@@ -23,7 +23,7 @@ void main() {
 //imported: Surface, u_TextureScale, get_surface, evaluate_color
 
 layout(set = 1, binding = 1) uniform c_Locals {
-    vec4 u_ScreenSize;      // XY = size
+    uvec4 u_ScreenSize;      // XY = size
 };
 
 const float
@@ -129,7 +129,7 @@ vec4 color_point(CastPoint pt, float lit_factor) {
 
 void main() {
     vec4 sp_ndc = vec4(
-        (gl_FragCoord.xy / u_ScreenSize.xy) * 2.0 - 1.0,
+        (gl_FragCoord.xy / vec2(u_ScreenSize.xy)) * 2.0 - 1.0,
         -1.0,
         1.0
     );

--- a/data/shader/terrain/scatter.glsl
+++ b/data/shader/terrain/scatter.glsl
@@ -16,6 +16,9 @@ layout(set = 1, binding = 1) uniform c_Locals {
 };
 
 layout(set = 2, binding = 0, r32ui) uniform uimage2D i_Output;
+layout(set = 2, binding = 1) uniform c_Scatter {
+    vec4 u_TerrainOffsetScale;
+};
 
 
 bool is_visible(vec4 p) {
@@ -36,7 +39,7 @@ void add_voxel(vec2 pos, float altitude, uint type, float lit_factor) {
 }
 
 void main() {
-    vec2 pos = vec2(gl_GlobalInvocationID.xy);
+    vec2 pos = vec2(gl_GlobalInvocationID.xy) * u_TerrainOffsetScale.xy + u_TerrainOffsetScale.zw;
     Surface suf = get_surface(pos);
     if (true) {
         add_voxel(pos, suf.high_alt, suf.high_type, 1.0);

--- a/data/shader/terrain/scatter.glsl
+++ b/data/shader/terrain/scatter.glsl
@@ -1,0 +1,48 @@
+//!include cs:surface.inc cs:color.inc
+
+#ifdef SHADER_CS
+//imported: Surface, get_surface, evaluate_color_id
+
+layout(set = 0, binding = 0) uniform Globals {
+    vec4 u_CameraPos;
+    mat4 u_ViewProj;
+    mat4 u_InvViewProj;
+    vec4 u_LightPos;
+    vec4 u_LightColor;
+};
+
+layout(set = 1, binding = 1) uniform c_Locals {
+    uvec4 u_ScreenSize;      // XY = size
+};
+
+layout(set = 2, binding = 0, r32ui) uniform uimage2D i_Output;
+
+
+bool is_visible(vec4 p) {
+    return p.w > 0.0 && p.z > 0.0 && p.x >= -p.w && p.x <= p.w && p.y >= -p.w && p.y < p.w;
+}
+
+void add_voxel(vec2 pos, float altitude, uint type, float lit_factor) {
+    vec4 screen_pos = u_ViewProj * vec4(pos, altitude, 1.0);
+    if (!is_visible(screen_pos)) {
+        return;
+    }
+    vec3 ndc = screen_pos.xyz / screen_pos.w;
+    float color_id = evaluate_color_id(type, pos / u_TextureScale.xy, altitude / u_TextureScale.z, lit_factor);
+    float depth = clamp(ndc.z, 0.0, 1.0);
+    uint value = (uint(depth * float(0xFFFFFF)) << 8U) | uint(color_id * float(0xFF));
+    ivec2 tc = min(ivec2(u_ScreenSize.xy) - 1, ivec2(round((ndc.xy * 0.5 + 0.5) * vec2(u_ScreenSize.xy))));
+    imageAtomicMin(i_Output, tc, value);
+}
+
+void main() {
+    vec2 pos = vec2(gl_GlobalInvocationID.xy);
+    Surface suf = get_surface(pos);
+    if (true) {
+        add_voxel(pos, suf.high_alt, suf.high_type, 1.0);
+    }
+    if (suf.delta != 0.0) {
+        add_voxel(pos, suf.low_alt, suf.low_type, 0.25);
+    }
+}
+#endif //CS

--- a/data/shader/terrain/scatter_clear.glsl
+++ b/data/shader/terrain/scatter_clear.glsl
@@ -1,0 +1,15 @@
+#ifdef SHADER_CS
+
+layout(set = 1, binding = 1) uniform c_Locals {
+    uvec4 u_ScreenSize;      // XY = size
+};
+
+layout(set = 2, binding = 0, r32ui) uniform uimage2D i_Output;
+
+void main() {
+    uvec2 pos = gl_GlobalInvocationID.xy;
+    if (pos.x < u_ScreenSize.x && pos.y < u_ScreenSize.y) {
+        imageStore(i_Output, ivec2(pos), uvec4(0xFFFFFF00U));
+    }
+}
+#endif //CS

--- a/data/shader/terrain/scatter_copy.glsl
+++ b/data/shader/terrain/scatter_copy.glsl
@@ -1,0 +1,30 @@
+#ifdef SHADER_VS
+
+void main() {
+    vec2 pos = vec2(0.0);
+    switch (gl_VertexIndex) {
+        case 0: pos = vec2(1.0, -1.0); break;
+        case 1: pos = vec2(1.0, 1.0); break;
+        case 2: pos = vec2(-1.0, -1.0); break;
+        case 3: pos = vec2(-1.0, 1.0); break;
+        default: break;
+    }
+    gl_Position = vec4(pos, 0.0, 1.0);
+}
+#endif //VS
+
+
+#ifdef SHADER_FS
+
+layout(set = 0, binding = 1) uniform sampler s_PaletteSampler;
+layout(set = 1, binding = 6) uniform texture1D t_Palette;
+layout(set = 2, binding = 0, r32ui) uniform readonly uimage2D i_Input;
+
+layout(location = 0) out vec4 o_Color;
+
+void main() {
+    uint value = imageLoad(i_Input, ivec2(gl_FragCoord.xy)).x;
+    o_Color = texelFetch(sampler1D(t_Palette, s_PaletteSampler), int(value & 0xFFU), 0);
+    gl_FragDepth = float(value >> 8U) / float(0xFFFFFF);
+}
+#endif //FS

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -67,6 +67,7 @@ pub enum Terrain {
         screen_space: bool,
     },
     Sliced,
+    Scattered,
 }
 
 #[derive(Deserialize)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -130,8 +130,8 @@ pub fn load_c3d(
     locals_buf: &wgpu::Buffer,
     locals_id: usize,
 ) -> Arc<Mesh> {
-    let locals_size = mem::size_of::<ObjectLocals>() as u32;
-    let locals_base = locals_id as u32 * locals_size;
+    let locals_size = mem::size_of::<ObjectLocals>() as wgpu::BufferAddress;
+    let locals_base = locals_id as wgpu::BufferAddress * locals_size;
     let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         layout: locals_layout,
         bindings: &[
@@ -149,7 +149,7 @@ pub fn load_c3d(
     debug!("\tGot {} GPU vertices...", num_vertices);
     let mapping = device.create_buffer_mapped::<ObjectVertex>(
         num_vertices,
-        wgpu::BufferUsageFlags::VERTEX,
+        wgpu::BufferUsage::VERTEX,
     );
     for (chunk, tri) in mapping.data.chunks_mut(3).zip(&raw.geometry.polygons) {
         for (vo, v) in chunk.iter_mut().zip(&tri.vertices) {
@@ -260,7 +260,7 @@ pub fn load_c3d_shape(
     let vertex_buf = {
         let mapping = device.create_buffer_mapped(
             raw.geometry.positions.len(),
-            wgpu::BufferUsageFlags::VERTEX, //| wgpu::BufferUsageFlags::SAMPLED,
+            wgpu::BufferUsage::VERTEX, //| wgpu::BufferUsage::SAMPLED,
         );
         for (vo, p) in mapping.data.iter_mut().zip(raw.geometry.positions) {
             *vo = [p[0] as f32, p[1] as f32, p[2] as f32, 1.0];
@@ -276,11 +276,11 @@ pub fn load_c3d_shape(
         //    .unwrap(),
         vertex_buf,
         polygon_buf: device
-            .create_buffer_mapped(polygon_data.len(), wgpu::BufferUsageFlags::VERTEX)
+            .create_buffer_mapped(polygon_data.len(), wgpu::BufferUsage::VERTEX)
             .fill_from_slice(&polygon_data),
         sample_buf: if with_sample_buf {
             let buffer = device
-                .create_buffer_mapped(sample_data.len(), wgpu::BufferUsageFlags::VERTEX)
+                .create_buffer_mapped(sample_data.len(), wgpu::BufferUsage::VERTEX)
                 .fill_from_slice(&sample_data);
             Some((buffer, sample_data.len()))
         } else {
@@ -302,8 +302,8 @@ pub fn load_m3d(
     let debrie_offset = wheel_offset + raw.wheels.len();
     let locals_num = debrie_offset + raw.debris.len() + raw.slots.len();
     let locals_buf = device.create_buffer(&wgpu::BufferDescriptor {
-        size: (locals_num * mem::size_of::<ObjectLocals>()) as u32,
-        usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+        size: (locals_num * mem::size_of::<ObjectLocals>()) as wgpu::BufferAddress,
+        usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::TRANSFER_DST,
     });
 
     let model = VisualModel {

--- a/src/render/global.rs
+++ b/src/render/global.rs
@@ -44,32 +44,30 @@ impl Context {
             bindings: &[
                 wgpu::BindGroupLayoutBinding {
                     binding: 0,
-                    visibility: wgpu::ShaderStageFlags::VERTEX | wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::UniformBuffer,
                 },
                 wgpu::BindGroupLayoutBinding { // palette sampler
                     binding: 1,
-                    visibility: wgpu::ShaderStageFlags::VERTEX | wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::Sampler,
                 },
             ],
         });
         let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            size: mem::size_of::<Constants>() as u32,
-            usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+            size: mem::size_of::<Constants>() as wgpu::BufferAddress,
+            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::TRANSFER_DST,
         });
         let palette_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            r_address_mode: wgpu::AddressMode::ClampToEdge,
-            s_address_mode: wgpu::AddressMode::ClampToEdge,
-            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Nearest,
             mipmap_filter: wgpu::FilterMode::Nearest,
             lod_min_clamp: 0.0,
             lod_max_clamp: 0.0,
-            max_anisotropy: 0,
             compare_function: wgpu::CompareFunction::Always,
-            border_color: wgpu::BorderColor::TransparentBlack,
         });
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
             layout: &bind_group_layout,
@@ -78,7 +76,7 @@ impl Context {
                     binding: 0,
                     resource: wgpu::BindingResource::Buffer {
                         buffer: &uniform_buf,
-                        range: 0 .. mem::size_of::<Constants>() as u32,
+                        range: 0 .. mem::size_of::<Constants>() as wgpu::BufferAddress,
                     },
                 },
                 wgpu::Binding {

--- a/src/render/global.rs
+++ b/src/render/global.rs
@@ -44,12 +44,12 @@ impl Context {
             bindings: &[
                 wgpu::BindGroupLayoutBinding {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStage::all(),
                     ty: wgpu::BindingType::UniformBuffer,
                 },
                 wgpu::BindGroupLayoutBinding { // palette sampler
                     binding: 1,
-                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStage::all(),
                     ty: wgpu::BindingType::Sampler,
                 },
             ],

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -419,24 +419,11 @@ impl Render {
             mem::size_of::<global::Constants>() as wgpu::BufferAddress,
         );
 
-        let terrain_staging = device
-            .create_buffer_mapped(1, wgpu::BufferUsage::TRANSFER_SRC)
-            .fill_from_slice(&[
-                terrain::Constants::new(&targets.extent)
-            ]);
-        encoder.copy_buffer_to_buffer(
-            &terrain_staging,
-            0,
-            &self.terrain.uniform_buf,
-            0,
-            mem::size_of::<terrain::Constants>() as wgpu::BufferAddress,
-        );
-
         for rm in render_models {
             rm.prepare(&mut encoder, device);
         }
 
-        self.terrain.prepare(&mut encoder, &self.global);
+        self.terrain.prepare(&mut encoder, device, &self.global, cam);
 
         {
             let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {

--- a/src/render/terrain.rs
+++ b/src/render/terrain.rs
@@ -77,10 +77,10 @@ impl Context {
                 module: &shaders.vs,
                 entry_point: "main",
             },
-            fragment_stage: wgpu::PipelineStageDescriptor {
+            fragment_stage: Some(wgpu::PipelineStageDescriptor {
                 module: &shaders.fs,
                 entry_point: "main",
-            },
+            }),
             rasterization_state: wgpu::RasterizationStateDescriptor {
                 front_face: wgpu::FrontFace::Ccw,
                 cull_mode: wgpu::CullMode::None,
@@ -92,9 +92,9 @@ impl Context {
             color_states: &[
                 wgpu::ColorStateDescriptor {
                     format: COLOR_FORMAT,
-                    alpha: wgpu::BlendDescriptor::REPLACE,
-                    color: wgpu::BlendDescriptor::REPLACE,
-                    write_mask: wgpu::ColorWriteFlags::all(),
+                    alpha_blend: wgpu::BlendDescriptor::REPLACE,
+                    color_blend: wgpu::BlendDescriptor::REPLACE,
+                    write_mask: wgpu::ColorWrite::all(),
                 },
             ],
             depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
@@ -109,13 +109,13 @@ impl Context {
             index_format: wgpu::IndexFormat::Uint16,
             vertex_buffers: &[
                 wgpu::VertexBufferDescriptor {
-                    stride: mem::size_of::<Vertex>() as u32,
+                    stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
                     attributes: &[
                         wgpu::VertexAttributeDescriptor {
                             offset: 0,
                             format: wgpu::VertexFormat::Char4,
-                            attribute_index: 0,
+                            shader_location: 0,
                         },
                     ],
                 },
@@ -136,10 +136,10 @@ impl Context {
                 module: &shaders.vs,
                 entry_point: "main",
             },
-            fragment_stage: wgpu::PipelineStageDescriptor {
+            fragment_stage: Some(wgpu::PipelineStageDescriptor {
                 module: &shaders.fs,
                 entry_point: "main",
-            },
+            }),
             rasterization_state: wgpu::RasterizationStateDescriptor {
                 front_face: wgpu::FrontFace::Ccw,
                 cull_mode: wgpu::CullMode::None,
@@ -151,9 +151,9 @@ impl Context {
             color_states: &[
                 wgpu::ColorStateDescriptor {
                     format: COLOR_FORMAT,
-                    alpha: wgpu::BlendDescriptor::REPLACE,
-                    color: wgpu::BlendDescriptor::REPLACE,
-                    write_mask: wgpu::ColorWriteFlags::all(),
+                    alpha_blend: wgpu::BlendDescriptor::REPLACE,
+                    color_blend: wgpu::BlendDescriptor::REPLACE,
+                    write_mask: wgpu::ColorWrite::all(),
                 },
             ],
             depth_stencil_state: Some(wgpu::DepthStencilStateDescriptor {
@@ -168,13 +168,13 @@ impl Context {
             index_format: wgpu::IndexFormat::Uint16,
             vertex_buffers: &[
                 wgpu::VertexBufferDescriptor {
-                    stride: mem::size_of::<Vertex>() as u32,
+                    stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
                     step_mode: wgpu::InputStepMode::Vertex,
                     attributes: &[
                         wgpu::VertexAttributeDescriptor {
                             offset: 0,
                             format: wgpu::VertexFormat::Char4,
-                            attribute_index: 0,
+                            shader_location: 0,
                         },
                     ],
                 },
@@ -219,44 +219,52 @@ impl Context {
 
         let height_texture = device.create_texture(&wgpu::TextureDescriptor {
             size: extent,
-            array_size: 1,
+            array_layer_count: 1,
+            mip_level_count: 1,
+            sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::R8Unorm,
-            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+            usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::TRANSFER_DST,
         });
         let meta_texture = device.create_texture(&wgpu::TextureDescriptor {
             size: extent,
-            array_size: 1,
+            array_layer_count: 1,
+            mip_level_count: 1,
+            sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
             format: wgpu::TextureFormat::R8Uint,
-            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+            usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::TRANSFER_DST,
         });
         let flood_texture = device.create_texture(&wgpu::TextureDescriptor {
             size: flood_extent,
-            array_size: 1,
+            array_layer_count: 1,
+            mip_level_count: 1,
+            sample_count: 1,
             dimension: wgpu::TextureDimension::D1,
             format: wgpu::TextureFormat::R8Unorm,
-            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+            usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::TRANSFER_DST,
         });
         let table_texture = device.create_texture(&wgpu::TextureDescriptor {
             size: table_extent,
-            array_size: 1,
+            array_layer_count: 1,
+            mip_level_count: 1,
+            sample_count: 1,
             dimension: wgpu::TextureDimension::D1,
             format: wgpu::TextureFormat::Rgba8Uint,
-            usage: wgpu::TextureUsageFlags::SAMPLED | wgpu::TextureUsageFlags::TRANSFER_DST,
+            usage: wgpu::TextureUsage::SAMPLED | wgpu::TextureUsage::TRANSFER_DST,
         });
 
         let height_staging = device
-            .create_buffer_mapped(level.height.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .create_buffer_mapped(level.height.len(), wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&level.height);
         let meta_staging = device
-            .create_buffer_mapped(level.meta.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .create_buffer_mapped(level.meta.len(), wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&level.meta);
         let flood_staging = device
-            .create_buffer_mapped(level.flood_map.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .create_buffer_mapped(level.flood_map.len(), wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&level.flood_map);
         let table_staging = device
-            .create_buffer_mapped(terrrain_table.len(), wgpu::BufferUsageFlags::TRANSFER_SRC)
+            .create_buffer_mapped(terrrain_table.len(), wgpu::BufferUsage::TRANSFER_SRC)
             .fill_from_slice(&terrrain_table);
 
         init_encoder.copy_buffer_to_texture(
@@ -268,8 +276,8 @@ impl Context {
             },
             wgpu::TextureCopyView {
                 texture: &height_texture,
-                level: 0,
-                slice: 0,
+                mip_level: 0,
+                array_layer: 0,
                 origin,
             },
             extent,
@@ -283,8 +291,8 @@ impl Context {
             },
             wgpu::TextureCopyView {
                 texture: &meta_texture,
-                level: 0,
-                slice: 0,
+                mip_level: 0,
+                array_layer: 0,
                 origin,
             },
             extent,
@@ -298,8 +306,8 @@ impl Context {
             },
             wgpu::TextureCopyView {
                 texture: &flood_texture,
-                level: 0,
-                slice: 0,
+                mip_level: 0,
+                array_layer: 0,
                 origin,
             },
             flood_extent,
@@ -313,8 +321,8 @@ impl Context {
             },
             wgpu::TextureCopyView {
                 texture: &table_texture,
-                level: 0,
-                slice: 0,
+                mip_level: 0,
+                array_layer: 0,
                 origin,
             },
             table_extent,
@@ -322,102 +330,96 @@ impl Context {
         let palette = Palette::new(init_encoder, device, &level.palette);
 
         let repeat_nearest_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            r_address_mode: wgpu::AddressMode::Repeat,
-            s_address_mode: wgpu::AddressMode::Repeat,
-            t_address_mode: wgpu::AddressMode::Repeat,
+            address_mode_u: wgpu::AddressMode::Repeat,
+            address_mode_v: wgpu::AddressMode::Repeat,
+            address_mode_w: wgpu::AddressMode::Repeat,
             mag_filter: wgpu::FilterMode::Nearest,
             min_filter: wgpu::FilterMode::Nearest,
             mipmap_filter: wgpu::FilterMode::Nearest,
             lod_min_clamp: 0.0,
             lod_max_clamp: 0.0,
-            max_anisotropy: 0,
             compare_function: wgpu::CompareFunction::Always,
-            border_color: wgpu::BorderColor::TransparentBlack,
         });
         let flood_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            r_address_mode: wgpu::AddressMode::Repeat,
-            s_address_mode: wgpu::AddressMode::ClampToEdge,
-            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            address_mode_u: wgpu::AddressMode::Repeat,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Linear,
             min_filter: wgpu::FilterMode::Linear,
             mipmap_filter: wgpu::FilterMode::Nearest,
             lod_min_clamp: 0.0,
             lod_max_clamp: 0.0,
-            max_anisotropy: 0,
             compare_function: wgpu::CompareFunction::Always,
-            border_color: wgpu::BorderColor::TransparentBlack,
         });
         let table_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            r_address_mode: wgpu::AddressMode::ClampToEdge,
-            s_address_mode: wgpu::AddressMode::ClampToEdge,
-            t_address_mode: wgpu::AddressMode::ClampToEdge,
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
             mag_filter: wgpu::FilterMode::Nearest,
             min_filter: wgpu::FilterMode::Nearest,
             mipmap_filter: wgpu::FilterMode::Nearest,
             lod_min_clamp: 0.0,
             lod_max_clamp: 0.0,
-            max_anisotropy: 0,
             compare_function: wgpu::CompareFunction::Always,
-            border_color: wgpu::BorderColor::TransparentBlack,
         });
 
         let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             bindings: &[
                 wgpu::BindGroupLayoutBinding { // surface uniforms
                     binding: 0,
-                    visibility: wgpu::ShaderStageFlags::VERTEX | wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::VERTEX | wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::UniformBuffer,
                 },
                 wgpu::BindGroupLayoutBinding { // terrain locals
                     binding: 1,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::UniformBuffer,
                 },
                 wgpu::BindGroupLayoutBinding { // height map
                     binding: 2,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::SampledTexture,
                 },
                 wgpu::BindGroupLayoutBinding { // meta map
                     binding: 3,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::SampledTexture,
                 },
                 wgpu::BindGroupLayoutBinding { // flood map
                     binding: 4,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::SampledTexture,
                 },
                 wgpu::BindGroupLayoutBinding { // table map
                     binding: 5,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::SampledTexture,
                 },
                 wgpu::BindGroupLayoutBinding { // palette map
                     binding: 6,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::SampledTexture,
                 },
                 wgpu::BindGroupLayoutBinding { // main sampler
                     binding: 7,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::Sampler,
                 },
                 wgpu::BindGroupLayoutBinding { // flood sampler
                     binding: 8,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::Sampler,
                 },
                 wgpu::BindGroupLayoutBinding { // table sampler
                     binding: 9,
-                    visibility: wgpu::ShaderStageFlags::FRAGMENT,
+                    visibility: wgpu::ShaderStage::FRAGMENT,
                     ty: wgpu::BindingType::Sampler,
                 },
             ],
         });
 
         let surface_uni_buf = device
-            .create_buffer_mapped(1, wgpu::BufferUsageFlags::UNIFORM)
+            .create_buffer_mapped(1, wgpu::BufferUsage::UNIFORM)
             .fill_from_slice(&[SurfaceConstants {
                 _tex_scale: [
                     level.size.0 as f32,
@@ -427,8 +429,8 @@ impl Context {
                 ],
             }]);
         let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
-            size: mem::size_of::<Constants>() as u32,
-            usage: wgpu::BufferUsageFlags::UNIFORM | wgpu::BufferUsageFlags::TRANSFER_DST,
+            size: mem::size_of::<Constants>() as wgpu::BufferAddress,
+            usage: wgpu::BufferUsage::UNIFORM | wgpu::BufferUsage::TRANSFER_DST,
         });
 
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -438,14 +440,14 @@ impl Context {
                     binding: 0,
                     resource: wgpu::BindingResource::Buffer {
                         buffer: &surface_uni_buf,
-                        range: 0 .. mem::size_of::<SurfaceConstants>() as u32,
+                        range: 0 .. mem::size_of::<SurfaceConstants>() as wgpu::BufferAddress,
                     },
                 },
                 wgpu::Binding {
                     binding: 1,
                     resource: wgpu::BindingResource::Buffer {
                         buffer: &uniform_buf,
-                        range: 0 .. mem::size_of::<Constants>() as u32,
+                        range: 0 .. mem::size_of::<Constants>() as wgpu::BufferAddress,
                     },
                 },
                 wgpu::Binding {
@@ -510,10 +512,10 @@ impl Context {
                 let indices = [0u16, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 1];
 
                 let vertex_buf = device
-                    .create_buffer_mapped(vertices.len(), wgpu::BufferUsageFlags::VERTEX)
+                    .create_buffer_mapped(vertices.len(), wgpu::BufferUsage::VERTEX)
                     .fill_from_slice(&vertices);
                 let index_buf = device
-                    .create_buffer_mapped(indices.len(), wgpu::BufferUsageFlags::INDEX)
+                    .create_buffer_mapped(indices.len(), wgpu::BufferUsage::INDEX)
                     .fill_from_slice(&indices);
 
                 let pipeline = Self::create_ray_pipeline(&pipeline_layout, device);
@@ -536,10 +538,10 @@ impl Context {
                 let indices = [0u16, 1, 2, 0, 2, 3];
 
                 let vertex_buf = device
-                    .create_buffer_mapped(vertices.len(), wgpu::BufferUsageFlags::VERTEX)
+                    .create_buffer_mapped(vertices.len(), wgpu::BufferUsage::VERTEX)
                     .fill_from_slice(&vertices);
                 let index_buf = device
-                    .create_buffer_mapped(indices.len(), wgpu::BufferUsageFlags::INDEX)
+                    .create_buffer_mapped(indices.len(), wgpu::BufferUsage::INDEX)
                     .fill_from_slice(&indices);
 
                 let pipeline = Self::create_slice_pipeline(&pipeline_layout, device);
@@ -584,7 +586,7 @@ impl Context {
     }
 
     pub fn draw(&self, pass: &mut wgpu::RenderPass) {
-        pass.set_bind_group(1, &self.bind_group);
+        pass.set_bind_group(1, &self.bind_group, &[]);
         // draw terrain
         match self.kind {
             Kind::Ray { ref pipeline, ref index_buf, ref vertex_buf, num_indices } => {


### PR DESCRIPTION
Uses compute shaders with image load/store atomics in order to scatter the terrain points onto screen with proper ordering.