### PR TITLE
Added CNAME pointing at the vange.rs domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,2 @@
+vange.rs
+


### PR DESCRIPTION
I've just paid for the fourth year of the vange.rs domain and noticed that you now have a GitHub Pages website. Let's have it use https://vange.rs .

I've configured the DNS part already, now we need to configure the repo.

The guides about using a custom domain with GitHub pages have become much more confusing than before:
https://docs.github.com/en/free-pro-team@latest/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site

If I understood correctly, this PR is not strictly required. Instead, you can use project configuration UI to include the domain and the same commit will be added automatically. But I'm not sure if the UI configuration is still required if you accept this PR. 🤔

Also, you should enforce HTTPS in the project configuration (if not already).

PS Having this figured out may cause a short outage of the website. I hope it's not a big deal.