### PR TITLE
Support adapter-dependent color formats

### DIFF
--- a/bin/car/app.rs
+++ b/bin/car/app.rs
@@ -27,6 +27,7 @@ impl CarView {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         downlevel_caps: &wgpu::DownlevelCapabilities,
+        color_format: wgpu::TextureFormat,
     ) -> Self {
         info!("Initializing the render");
         let pal_data = level::read_palette(settings.open_palette(), None);
@@ -35,6 +36,7 @@ impl CarView {
         let global = render::global::Context::new(
             device,
             queue,
+            color_format,
             #[cfg(feature = "glsl")]
             store_init.resource(),
             None,

--- a/bin/car/main.rs
+++ b/bin/car/main.rs
@@ -32,6 +32,7 @@ fn main() {
         &harness.device,
         &harness.queue,
         &harness.downlevel_caps,
+        harness.color_format,
     );
 
     harness.main_loop(app);

--- a/bin/level/app.rs
+++ b/bin/level/app.rs
@@ -34,6 +34,7 @@ pub struct LevelView {
 impl LevelView {
     pub fn new(
         settings: &config::settings::Settings,
+        color_format: wgpu::TextureFormat,
         screen_extent: wgpu::Extent3d,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
@@ -114,6 +115,7 @@ impl LevelView {
             &level,
             &objects_palette,
             &settings.render,
+            color_format,
             screen_extent,
             #[cfg(feature = "glsl")]
             store_init.resource(),

--- a/bin/level/main.rs
+++ b/bin/level/main.rs
@@ -10,6 +10,7 @@ fn main() {
 
     let app = app::LevelView::new(
         &settings,
+        harness.color_format,
         harness.extent,
         &harness.device,
         &harness.queue,

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -24,6 +24,7 @@ impl ResourceView {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         downlevel_caps: &wgpu::DownlevelCapabilities,
+        color_format: wgpu::TextureFormat,
     ) -> Self {
         info!("Initializing the render");
         let pal_data = level::read_palette(settings.open_palette(), None);
@@ -32,6 +33,7 @@ impl ResourceView {
         let global = render::global::Context::new(
             device,
             queue,
+            color_format,
             #[cfg(feature = "glsl")]
             store_init.resource(),
             None,

--- a/bin/model/main.rs
+++ b/bin/model/main.rs
@@ -31,6 +31,7 @@ fn main() {
         &harness.device,
         &harness.queue,
         &harness.downlevel_caps,
+        harness.color_format,
     );
 
     harness.main_loop(app);

--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -324,6 +324,7 @@ pub struct Game {
 impl Game {
     pub fn new(
         settings: &config::Settings,
+        color_format: wgpu::TextureFormat,
         screen_extent: wgpu::Extent3d,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
@@ -373,6 +374,7 @@ impl Game {
             &level,
             &pal_data,
             &settings.render,
+            color_format,
             screen_extent,
             #[cfg(feature = "glsl")]
             store_init.resource(),

--- a/bin/road/main.rs
+++ b/bin/road/main.rs
@@ -32,6 +32,7 @@ fn main() {
 
     let game = game::Game::new(
         &settings,
+        harness.color_format,
         harness.extent,
         &harness.device,
         &harness.queue,

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -4,7 +4,7 @@ use crate::{
     render::{
         global::Context as GlobalContext,
         object::{Context as ObjectContext, Instance as ObjectInstance},
-        VertexStorageNotSupported, COLOR_FORMAT, DEPTH_FORMAT,
+        VertexStorageNotSupported, DEPTH_FORMAT,
     },
 };
 
@@ -102,6 +102,7 @@ pub struct Context {
     bind_group_line: wgpu::BindGroup,
     bind_group_face: wgpu::BindGroup,
     bind_group_edge: wgpu::BindGroup,
+    color_format: wgpu::TextureFormat,
     // hold the buffers alive
     vertex_buf: Option<wgpu::Buffer>,
     color_buf: Option<wgpu::Buffer>,
@@ -204,6 +205,7 @@ impl Context {
             bind_group_line,
             bind_group_face,
             bind_group_edge,
+            color_format: global.color_format,
             vertex_buf: None,
             color_buf: None,
         };
@@ -237,7 +239,7 @@ impl Context {
                     module: &shaders.fs,
                     entry_point: "main",
                     targets: &[wgpu::ColorTargetState {
-                        format: COLOR_FORMAT,
+                        format: self.color_format,
                         blend: Some(wgpu::BlendState {
                             alpha: wgpu::BlendComponent {
                                 src_factor: wgpu::BlendFactor::One,
@@ -312,7 +314,7 @@ impl Context {
                             module: &shader,
                             entry_point: "main_fs",
                             targets: &[wgpu::ColorTargetState {
-                                format: COLOR_FORMAT,
+                                format: self.color_format,
                                 blend: Some(wgpu::BlendState {
                                     color: blend,
                                     alpha: blend,

--- a/src/render/global.rs
+++ b/src/render/global.rs
@@ -39,12 +39,14 @@ pub struct Context {
     pub uniform_buf: wgpu::Buffer,
     pub bind_group: wgpu::BindGroup,
     pub shadow_bind_group: wgpu::BindGroup,
+    pub color_format: wgpu::TextureFormat,
 }
 
 impl Context {
     pub fn new(
         device: &wgpu::Device,
         queue: &wgpu::Queue,
+        color_format: wgpu::TextureFormat,
         #[cfg(feature = "glsl")] store_buffer: wgpu::BindingResource<'_>,
         shadow_view: Option<&wgpu::TextureView>,
     ) -> Self {
@@ -222,6 +224,7 @@ impl Context {
             uniform_buf,
             bind_group,
             shadow_bind_group,
+            color_format,
         }
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -37,7 +37,6 @@ pub mod body {
 }
 
 pub use shadow::FORMAT as SHADOW_FORMAT;
-pub const COLOR_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8Unorm;
 pub const DEPTH_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Depth32Float;
 
 #[derive(Clone, Copy, Debug)]
@@ -536,6 +535,7 @@ impl Render {
         level: &level::Level,
         object_palette: &[[u8; 4]],
         settings: &settings::Render,
+        color_format: wgpu::TextureFormat,
         screen_size: wgpu::Extent3d,
         #[cfg(feature = "glsl")] store_buffer: wgpu::BindingResource<'_>,
     ) -> Self {
@@ -550,6 +550,7 @@ impl Render {
         let global = global::Context::new(
             device,
             queue,
+            color_format,
             #[cfg(feature = "glsl")]
             store_buffer,
             shadow.as_ref().map(|shadow| &shadow.view),

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -1,7 +1,7 @@
 use crate::{
     render::{
         body::GpuBody, global::Context as GlobalContext, GpuTransform, Palette, PipelineSet,
-        VertexStorageNotSupported, COLOR_FORMAT, DEPTH_FORMAT, SHADOW_FORMAT,
+        VertexStorageNotSupported, DEPTH_FORMAT, SHADOW_FORMAT,
     },
     space::Transform,
 };
@@ -108,10 +108,15 @@ pub struct Context {
     pub shape_bind_group_layout: Result<wgpu::BindGroupLayout, VertexStorageNotSupported>,
     pub pipeline_layout: wgpu::PipelineLayout,
     pub pipelines: PipelineSet,
+    pub color_format: wgpu::TextureFormat,
 }
 
 impl Context {
-    fn create_pipelines(layout: &wgpu::PipelineLayout, device: &wgpu::Device) -> PipelineSet {
+    fn create_pipelines(
+        layout: &wgpu::PipelineLayout,
+        device: &wgpu::Device,
+        color_format: wgpu::TextureFormat,
+    ) -> PipelineSet {
         let vertex_descriptor = wgpu::VertexBufferLayout {
             array_stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
             step_mode: wgpu::VertexStepMode::Vertex,
@@ -131,7 +136,7 @@ impl Context {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "color_fs",
-                targets: &[COLOR_FORMAT.into()],
+                targets: &[color_format.into()],
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
@@ -319,17 +324,18 @@ impl Context {
             bind_group_layouts: &[&global.bind_group_layout, &bind_group_layout],
             push_constant_ranges: &[],
         });
-        let pipelines = Self::create_pipelines(&pipeline_layout, device);
+        let pipelines = Self::create_pipelines(&pipeline_layout, device, global.color_format);
 
         Context {
             bind_group,
             shape_bind_group_layout,
             pipeline_layout,
             pipelines,
+            color_format: global.color_format,
         }
     }
 
     pub fn reload(&mut self, device: &wgpu::Device) {
-        self.pipelines = Self::create_pipelines(&self.pipeline_layout, device);
+        self.pipelines = Self::create_pipelines(&self.pipeline_layout, device, self.color_format);
     }
 }


### PR DESCRIPTION
Fixes  #153
This makes it actually run on GLES, but the terrain colors are wrong. I think it's great news - we can fix the bugs, but at least we know it can work.

![vangers-gles-1](https://user-images.githubusercontent.com/107301/143776633-cb265fd3-b41c-4b12-aeda-2aeceb5fb5c4.jpg)

