### PR TITLE
Make front face configurable

### DIFF
--- a/bin/car/app.rs
+++ b/bin/car/app.rs
@@ -29,6 +29,18 @@ impl CarView {
         downlevel_caps: &wgpu::DownlevelCapabilities,
         color_format: wgpu::TextureFormat,
     ) -> Self {
+        let cam = space::Camera {
+            loc: cgmath::vec3(0.0, -64.0, 32.0),
+            rot: cgmath::Rotation3::from_angle_x::<cgmath::Rad<_>>(cgmath::Angle::turn_div_6()),
+            scale: cgmath::vec3(1.0, -1.0, 1.0),
+            proj: space::Projection::Perspective(cgmath::PerspectiveFov {
+                fovy: cgmath::Deg(45.0).into(),
+                aspect: settings.window.size[0] as f32 / settings.window.size[1] as f32,
+                near: 1.0,
+                far: 100.0,
+            }),
+        };
+
         info!("Initializing the render");
         let pal_data = level::read_palette(settings.open_palette(), None);
         #[cfg(feature = "glsl")]
@@ -41,8 +53,14 @@ impl CarView {
             store_init.resource(),
             None,
         );
-        let object =
-            render::object::Context::new(device, queue, downlevel_caps, &pal_data, &global);
+        let object = render::object::Context::new(
+            device,
+            queue,
+            downlevel_caps,
+            cam.front_face(),
+            &pal_data,
+            &global,
+        );
 
         info!("Loading car registry");
         let game_reg = config::game::Registry::load(settings);
@@ -79,17 +97,7 @@ impl CarView {
             ),
             global,
             object,
-            cam: space::Camera {
-                loc: cgmath::vec3(0.0, -64.0, 32.0),
-                rot: cgmath::Rotation3::from_angle_x::<cgmath::Rad<_>>(cgmath::Angle::turn_div_6()),
-                scale: cgmath::vec3(1.0, -1.0, 1.0),
-                proj: space::Projection::Perspective(cgmath::PerspectiveFov {
-                    fovy: cgmath::Deg(45.0).into(),
-                    aspect: settings.window.size[0] as f32 / settings.window.size[1] as f32,
-                    near: 1.0,
-                    far: 100.0,
-                }),
-            },
+            cam,
             rotation: (cgmath::Rad(0.), cgmath::Rad(0.)),
             light_config: settings.render.light,
         }

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -26,6 +26,18 @@ impl ResourceView {
         downlevel_caps: &wgpu::DownlevelCapabilities,
         color_format: wgpu::TextureFormat,
     ) -> Self {
+        let cam = space::Camera {
+            loc: cgmath::vec3(0.0, -200.0, 100.0),
+            rot: cgmath::Rotation3::from_angle_x::<cgmath::Rad<_>>(cgmath::Angle::turn_div_6()),
+            scale: cgmath::vec3(1.0, -1.0, 1.0),
+            proj: space::Projection::Perspective(cgmath::PerspectiveFov {
+                fovy: cgmath::Deg(45.0).into(),
+                aspect: settings.window.size[0] as f32 / settings.window.size[1] as f32,
+                near: 5.0,
+                far: 400.0,
+            }),
+        };
+
         info!("Initializing the render");
         let pal_data = level::read_palette(settings.open_palette(), None);
         #[cfg(feature = "glsl")]
@@ -38,8 +50,14 @@ impl ResourceView {
             store_init.resource(),
             None,
         );
-        let object =
-            render::object::Context::new(device, queue, downlevel_caps, &pal_data, &global);
+        let object = render::object::Context::new(
+            device,
+            queue,
+            downlevel_caps,
+            cam.front_face(),
+            &pal_data,
+            &global,
+        );
 
         info!("Loading model {}", path);
         let file = settings.open_relative(path);
@@ -54,17 +72,7 @@ impl ResourceView {
                 disp: cgmath::Vector3::unit_z(),
                 rot: cgmath::One::one(),
             },
-            cam: space::Camera {
-                loc: cgmath::vec3(0.0, -200.0, 100.0),
-                rot: cgmath::Rotation3::from_angle_x::<cgmath::Rad<_>>(cgmath::Angle::turn_div_6()),
-                scale: cgmath::vec3(1.0, -1.0, 1.0),
-                proj: space::Projection::Perspective(cgmath::PerspectiveFov {
-                    fovy: cgmath::Deg(45.0).into(),
-                    aspect: settings.window.size[0] as f32 / settings.window.size[1] as f32,
-                    near: 5.0,
-                    far: 400.0,
-                }),
-            },
+            cam,
             rotation: cgmath::Rad(0.),
             light_config: settings.render.light,
         }

--- a/lib/ffi/src/lib.rs
+++ b/lib/ffi/src/lib.rs
@@ -309,6 +309,7 @@ pub extern "C" fn rv_map_init(ctx: &mut Context, desc: MapDescription) {
         &ctx.render_config,
         ctx.color_format,
         ctx.extent, //Note: needs update on window resize
+        ctx.camera.front_face(),
     );
     ctx.level = Some(LevelContext {
         desc,

--- a/res/shader/object.wgsl
+++ b/res/shader/object.wgsl
@@ -86,7 +86,7 @@ fn color_vs(
 [[stage(fragment)]]
 fn color_fs(in: Varyings, [[builtin(front_facing)]] is_front: bool) -> [[location(0)]] vec4<f32> {
     let lit_factor = fetch_shadow(in.position);
-    let normal = normalize(in.normal) * select(1.0, -1.0, is_front);
+    let normal = normalize(in.normal) * select(-1.0, 1.0, is_front);
     let light = normalize(u_Globals.light_pos.xyz - in.position * u_Globals.light_pos.w);
     let n_dot_l = lit_factor * max(0.0, dot(normal, light));
     let tc_raw = mix(in.palette_range.x, in.palette_range.y, n_dot_l);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -558,6 +558,7 @@ impl Render {
         settings: &settings::Render,
         color_format: wgpu::TextureFormat,
         screen_size: wgpu::Extent3d,
+        front_face: wgpu::FrontFace,
         #[cfg(feature = "glsl")] store_buffer: wgpu::BindingResource<'_>,
     ) -> Self {
         profiling::scope!("Init Renderer");
@@ -576,7 +577,14 @@ impl Render {
             store_buffer,
             shadow.as_ref().map(|shadow| &shadow.view),
         );
-        let object = object::Context::new(device, queue, downlevel_caps, object_palette, &global);
+        let object = object::Context::new(
+            device,
+            queue,
+            downlevel_caps,
+            front_face,
+            object_palette,
+            &global,
+        );
         let terrain = terrain::Context::new(
             device,
             queue,

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -109,6 +109,7 @@ pub struct Context {
     pub pipeline_layout: wgpu::PipelineLayout,
     pub pipelines: PipelineSet,
     pub color_format: wgpu::TextureFormat,
+    front_face: wgpu::FrontFace,
 }
 
 impl Context {
@@ -116,6 +117,7 @@ impl Context {
         layout: &wgpu::PipelineLayout,
         device: &wgpu::Device,
         color_format: wgpu::TextureFormat,
+        front_face: wgpu::FrontFace,
     ) -> PipelineSet {
         let vertex_descriptor = wgpu::VertexBufferLayout {
             array_stride: mem::size_of::<Vertex>() as wgpu::BufferAddress,
@@ -140,7 +142,7 @@ impl Context {
             }),
             primitive: wgpu::PrimitiveState {
                 topology: wgpu::PrimitiveTopology::TriangleList,
-                front_face: wgpu::FrontFace::Ccw,
+                front_face,
                 // original was not drawn with rasterizer, used no culling
                 ..Default::default()
             },
@@ -237,6 +239,7 @@ impl Context {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         downlevel_caps: &wgpu::DownlevelCapabilities,
+        front_face: wgpu::FrontFace,
         palette_data: &[[u8; 4]],
         global: &GlobalContext,
     ) -> Self {
@@ -327,7 +330,8 @@ impl Context {
             bind_group_layouts: &[&global.bind_group_layout, &bind_group_layout],
             push_constant_ranges: &[],
         });
-        let pipelines = Self::create_pipelines(&pipeline_layout, device, global.color_format);
+        let pipelines =
+            Self::create_pipelines(&pipeline_layout, device, global.color_format, front_face);
 
         Context {
             bind_group,
@@ -335,10 +339,16 @@ impl Context {
             pipeline_layout,
             pipelines,
             color_format: global.color_format,
+            front_face,
         }
     }
 
     pub fn reload(&mut self, device: &wgpu::Device) {
-        self.pipelines = Self::create_pipelines(&self.pipeline_layout, device, self.color_format);
+        self.pipelines = Self::create_pipelines(
+            &self.pipeline_layout,
+            device,
+            self.color_format,
+            self.front_face,
+        );
     }
 }

--- a/src/space.rs
+++ b/src/space.rs
@@ -275,4 +275,12 @@ impl Camera {
         self.loc = view.disp;
         self.rot = view.rot;
     }
+
+    pub fn front_face(&self) -> wgpu::FrontFace {
+        if self.scale.x * self.scale.y > 0.0 {
+            wgpu::FrontFace::Cw
+        } else {
+            wgpu::FrontFace::Ccw
+        }
+    }
 }


### PR DESCRIPTION
Closes #155
Interestingly, while the Intel bug is being patched upstream, this PR works around it by interpolating between -1 and 1 instead of the opposite direction. I suspect the driver takes a different code path for this, since it's more straightforward, and that new code path isn't affected by the old bug.