### PR TITLE
Removed palette from MapDescription

### DIFF
--- a/lib/ffi/src/lib.rs
+++ b/lib/ffi/src/lib.rs
@@ -76,7 +76,6 @@ pub struct MapDescription {
     material_begin_offsets: *const u8,
     material_end_offsets: *const u8,
     material_count: i32,
-    palette: *const u8,
 }
 
 struct LevelContext {


### PR DESCRIPTION
We don't use this field in `rv_map_init` and update the palette in `rv_map_update_palette` anyway, so it can be safely removed.