### PR TITLE
Better altitude fetches in shader

### DIFF
--- a/res/shader/surface.inc.wgsl
+++ b/res/shader/surface.inc.wgsl
@@ -95,3 +95,35 @@ fn get_surface(pos: vec2<f32>) -> Surface {
 
     return suf;
 }
+
+struct SurfaceAlt {
+    low: f32;
+    high: f32;
+    delta: f32;
+};
+
+fn get_surface_alt(pos: vec2<f32>) -> SurfaceAlt {
+    let tci = get_map_coordinates(pos);
+    let meta = textureLoad(t_Meta, tci, 0).x;
+    let altitude = textureLoad(t_Height, tci, 0).x * u_Surface.texture_scale.z;
+
+    if ((meta & c_DoubleLevelMask) != 0u) {
+        let tci_other = tci ^ vec2<i32>(1, 0);
+        let meta_other = textureLoad(t_Meta, tci_other, 0).x;
+        let alt_other = textureLoad(t_Height, tci_other, 0).x * u_Surface.texture_scale.z;
+        let deltas = vec2<u32>(get_delta(meta), get_delta(meta_other));
+        let raw = select(
+            vec3<f32>(altitude, alt_other, f32((deltas.x << c_DeltaBits) + deltas.y)),
+            vec3<f32>(alt_other, altitude, f32((deltas.y << c_DeltaBits) + deltas.x)),
+            (tci.x & 1) != 0,
+        );
+        return SurfaceAlt(raw.x, raw.y, raw.z * c_DeltaScale * u_Surface.texture_scale.z);
+    } else {
+        return SurfaceAlt(altitude, altitude, 0.0);
+    }
+}
+
+fn get_surface_smooth(pos: vec2<f32>) -> SurfaceAlt {
+    var suf: SurfaceAlt;
+    return suf;
+}

--- a/res/shader/terrain/ray.wgsl
+++ b/res/shader/terrain/ray.wgsl
@@ -35,13 +35,13 @@ fn cast_ray_impl(
 
     for (var i = 0; i < num_forward; i = i + 1) {
         let c = a + step;
-        let suf = get_surface(c.xy);
+        let suf = get_surface_alt(c.xy);
 
-        if (c.z > suf.high_alt) {
+        if (c.z > suf.high) {
             high = true; // re-appear on the surface
             a = c;
         } else {
-            let height = select(suf.low_alt, suf.high_alt, high);
+            let height = select(suf.low, suf.high, high);
             if (c.z <= height) {
                 b = c;
                 break;
@@ -51,21 +51,19 @@ fn cast_ray_impl(
         }
     }
 
-    var result = get_surface(b.xy);
-
-    for (var i = 0; i < num_binary; i = i + 1) {
+    for (var i = 0; i < num_binary; i += 1) {
         let c = mix(a, b, 0.5);
-        let suf = get_surface(c.xy);
+        let suf = get_surface_alt(c.xy);
 
-        let height = select(suf.low_alt, suf.high_alt, high);
+        let height = select(suf.low, suf.high, high);
         if (c.z <= height) {
             b = c;
-            result = suf;
         } else {
             a = c;
         }
     }
 
+    let result = get_surface(b.xy);
     return CastResult(result, a, b);
 }
 


### PR DESCRIPTION
Closes #8

The new `get_surface_alt` is highly optimized to only care about altitudes. It attempts to minimize the dependencies between instructions. Currently only affects regular ray tracing.
Rough measurement show about 10% performance boost in ray tracing in default settings (5.5ms to 5.0ms per frame), and 25% in double-quality settings (8.3ms to 6.5ms).