### PR TITLE
Configure delta semantics per material

### DIFF
--- a/config/settings-windows-voxel.ron
+++ b/config/settings-windows-voxel.ron
@@ -1,21 +1,19 @@
 (
-	data_path: "",
-	// "/opt/gog/Vangers/game" #Linux (example)
-	// "/Applications/GOG/Vangers.app/Contents/Resources/game" #OSX
+	data_path: "C:\\Program Files (x86)\\GOG Galaxy\\Games\\Vangers\\data",
 	game: (
 		level: "Fostral", // see `wrlds.dat` for the list
 		cycle: "", // see `bunches.prm` for the list, leave empty for bonus worlds
 		geometry: (
 			height: 0x100,
-			delta_mask: 0xFF,
+			delta_mask: 239,
 			delta_power: 3,
 			delta_const: 4,
 		),
 		camera: (
-			angle: 60,
+			angle: 45,
 			height: 210,
 			offset: 140,
-			speed: 1,
+			speed: 3,
 			depth_range: (10, 2000),
 			projection: Perspective, // can be "Flat" or "Perspective"
 		),
@@ -52,17 +50,22 @@
 			shadow: (
 				size: 1024,
 				terrain:
-					RayTraced,
-					// RayVoxelTraced( max_outer_steps: 20, max_inner_steps: 20 ),
+					//RayTraced,
+					RayVoxelTraced( max_outer_steps: 20, max_inner_steps: 20 ),
 			),
 		),
 		fog: (
 			color: (0.1, 0.2, 0.3),
 			depth: 50,
 		),
-		terrain: RayTraced,
+		//terrain: RayTraced,
 		// RayTraced,
-		// RayVoxelTraced( voxel_size: (2, 4, 1), max_outer_steps: 40, max_inner_steps: 40, max_update_texels: 1_000_000 ),
+		terrain: RayVoxelTraced(
+			voxel_size: (2, 4, 1),
+			max_outer_steps: 40,
+			max_inner_steps: 40,
+			max_update_texels: 1_000_000,
+		),
 		// Scattered( density: (2, 2, 2) ),
 		// Sliced,
 		// Painted,

--- a/res/ffi/config.ron
+++ b/res/ffi/config.ron
@@ -1,8 +1,9 @@
 (
 	geometry: (
-		height: 256,
-		delta_model: Cave,
+		height: 0x100,
+		delta_mask: 239,
 		delta_power: 3,
+		delta_const: 4,
 	),
 	render: (
 		wgpu_trace_path: "",

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -45,24 +45,12 @@ pub struct Physics {
     pub shape_sampling: u8,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Deserialize)]
-pub enum DeltaModel {
-    Cave,
-    Thickness,
-    Ignored,
-}
-
-impl Default for DeltaModel {
-    fn default() -> Self {
-        Self::Cave
-    }
-}
-
 #[derive(Clone, Debug, Deserialize)]
 pub struct Geometry {
     pub height: u32,
-    pub delta_model: DeltaModel,
+    pub delta_mask: u32,
     pub delta_power: u8,
+    pub delta_const: u8,
 }
 
 impl Default for Geometry {
@@ -70,8 +58,9 @@ impl Default for Geometry {
         // Note: these values match the original game logic
         Self {
             height: 0x100,
-            delta_model: DeltaModel::Cave,
+            delta_mask: 0xFFFF,
             delta_power: 3,
+            delta_const: 1,
         }
     }
 }

--- a/src/render/terrain.rs
+++ b/src/render/terrain.rs
@@ -1521,11 +1521,9 @@ impl Context {
     ) {
         let surface_constants = {
             let bits = level.terrain_bits();
-            let delta_model = match level.geometry.delta_model {
-                settings::DeltaModel::Cave => 0,
-                settings::DeltaModel::Thickness => 1,
-                settings::DeltaModel::Ignored => 2,
-            };
+            let delta_mode = (level.geometry.delta_mask << 16)
+                | ((level.geometry.delta_const as u32) << 8)
+                | level.geometry.delta_power as u32;
             SurfaceConstants {
                 texture_scale: [
                     level.size.0 as f32,
@@ -1534,7 +1532,7 @@ impl Context {
                     0.0,
                 ],
                 terrain_bits: bits.shift as u32 | ((bits.mask as u32) << 4),
-                delta_mode: (delta_model << 8) | level.geometry.delta_power as u32,
+                delta_mode,
                 pad0: 0,
                 pad1: 0,
             }


### PR DESCRIPTION
![tweak-cables](https://github.com/kvark/vange-rs/assets/107301/85233923-6afc-4c22-bf56-ca235074699e)

Includes a recommended config for voxel-based rendering (settings-windows-voxel).