### PR TITLE
Materials in exported OBJ

### DIFF
--- a/bin/convert/main.rs
+++ b/bin/convert/main.rs
@@ -150,6 +150,8 @@ fn main() {
             println!("\tLoading the level...");
             let config = vangers::level::LevelConfig::load(&src_path);
             let level = vangers::level::load(&config, &geometry);
+            let pal_owned = layers::extract_palette(&level);
+            let palette = Some(pal_owned.as_slice());
             if let Some(chunks) = matches.opt_get::<i32>("c").unwrap() {
                 for i in 0..chunks {
                     let file_name = format!(
@@ -162,6 +164,7 @@ fn main() {
                     let export_config = level_obj::Config {
                         xr: 0..level.size.0,
                         yr: i * chunk_y..level.size.1.min((i + 1) * chunk_y),
+                        palette,
                     };
                     level_obj::save(&dst_path.with_file_name(file_name), &level, &export_config);
                 }
@@ -170,6 +173,7 @@ fn main() {
                 let export_config = level_obj::Config {
                     xr: 0..level.size.0,
                     yr: 0..level.size.1,
+                    palette,
                 };
                 level_obj::save(&dst_path, &level, &export_config);
             }

--- a/bin/convert/main.rs
+++ b/bin/convert/main.rs
@@ -185,6 +185,18 @@ fn main() {
             let level_data = layers.export();
             level_data.save_vmp(&dst_path);
         }
+        ("pal", "mtl") => {
+            println!("\tConverting object palette to MTL...");
+            let palette_raw = fs_read(src_path).expect("Unable to open palette");
+            let palette: Vec<u8> = vangers::render::object::COLOR_TABLE
+                .iter()
+                .flat_map(|&range| {
+                    let texel = range[0] as usize + (128 >> range[1]) as usize;
+                    palette_raw[texel * 3 - 3..texel * 3].iter().cloned()
+                })
+                .collect();
+            model_obj::save_palette(dst_path, &palette).unwrap();
+        }
         ("pal", "png") => {
             println!("Converting palette to PNG...");
             let data = fs_read(&src_path).unwrap();

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -10,7 +10,7 @@ use m3d::NUM_COLOR_IDS;
 
 use std::{mem, slice};
 
-const COLOR_TABLE: [[u8; 2]; NUM_COLOR_IDS as usize] = [
+pub const COLOR_TABLE: [[u8; 2]; NUM_COLOR_IDS as usize] = [
     [0, 0],   // reserved
     [128, 3], // body
     [176, 4], // window


### PR DESCRIPTION
For levels, OBJ export will now create an associated MTL automatically. It looks like this:
```
newmtl t0
	Kd 0.5176471 0.5647059 0.65882355
newmtl t1
	Kd 0.5803922 0.6431373 0.47058824
newmtl t2
	Kd 0.5176471 0.4392157 0.34509805
newmtl t3
	Kd 0.3764706 0.4392157 0.3764706
newmtl t4
	Kd 0.53333336 0.4392157 0.17254902
newmtl t5
	Kd 0.8 0 0.047058824
newmtl t6
	Kd 0.7529412 0.78431374 0
newmtl t7
	Kd 0.26666668 0.3764706 0.26666668
```
![material-export-level](https://github.com/kvark/vange-rs/assets/107301/f25b3806-53a9-4404-8770-ff350d0dc736)


For objects, all objects are expected to have the same MTL file. It can be generated like this:
```bash
cargo run --bin convert -- c:\data\Games\Vangers\data\resource\pal\objects.pal c:\data\Assets\Vangers\game\object.mtl
 ```

Then generating an object OBJ and just placing the "object.mtl" near it will make the materials show up:
![material-export](https://github.com/kvark/vange-rs/assets/107301/dff13163-19fa-4fa2-b9f7-c3f92fd8b1c7)

I believe this is quite cool, because in any use of these assets having the colors/materials is immediately helpful.