### PR TITLE
Use an integer texture instead of a storage buffer

### DIFF
--- a/bin/boilerplate.rs
+++ b/bin/boilerplate.rs
@@ -90,8 +90,6 @@ impl Harness {
             Terrain::RayTraced { .. } | Terrain::Sliced { .. } | Terrain::Painted { .. } => {
                 wgpu::Limits {
                     max_texture_dimension_2d: adapter_limits.max_texture_dimension_2d,
-                    max_storage_buffers_per_shader_stage: 1,
-                    max_storage_buffer_binding_size: terrain_buffer_size,
                     ..wgpu::Limits::downlevel_webgl2_defaults()
                 }
             }

--- a/lib/ffi/src/lib.rs
+++ b/lib/ffi/src/lib.rs
@@ -234,8 +234,6 @@ pub extern "C" fn rv_init(desc: InitDescriptor) -> Option<ptr::NonNull<Context>>
 
     let limits = wgpu::Limits {
         max_texture_dimension_2d: adapter_limits.max_texture_dimension_2d,
-        max_storage_buffers_per_shader_stage: 1,
-        max_storage_buffer_binding_size: 1 << 28,
         ..wgpu::Limits::downlevel_webgl2_defaults()
     };
 


### PR DESCRIPTION
This is lowering the runtime requirements from GLES-3.1 to GLES-3.0, thus unlocking the path to WebGL2
Closes  #165
Related to #163