### PR TITLE
Web: fix rendering — use spawn_app, center camera on terrain

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -41,7 +41,7 @@ impl WebApp {
         let objects_palette = [[0xFF; 4]; 0x100];
 
         let cam = space::Camera {
-            loc: glam::vec3(0.0, 0.0, 400.0),
+            loc: glam::vec3(128.0, 128.0, 400.0),
             rot: glam::Quat::IDENTITY,
             scale: glam::vec3(1.0, -1.0, 1.0),
             proj: space::Projection::Perspective(space::PerspectiveParams {
@@ -749,8 +749,21 @@ pub fn web_main() {
 
     let event_loop = EventLoop::new().unwrap();
     event_loop.set_control_flow(ControlFlow::Poll);
-    let mut handler = WebHandler::new();
-    event_loop.run_app(&mut handler).unwrap();
+    let handler = WebHandler::new();
+
+    // On WASM, use spawn_app to avoid the "exceptions for control flow"
+    // error that run_app throws. spawn_app sets up the event loop
+    // asynchronously and returns normally.
+    #[cfg(target_arch = "wasm32")]
+    {
+        use winit::platform::web::EventLoopExtWebSys;
+        event_loop.spawn_app(handler);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let mut handler = handler;
+        event_loop.run_app(&mut handler).unwrap();
+    }
 }
 
 fn main() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -180,10 +180,16 @@ WGSL shaders, compute-based voxel baking</code></pre>
                 document.getElementById('loading').style.display = 'none';
             } catch (err) {
                 const msg = String(err);
-                if (msg.includes('WebGPU')) {
+                // winit uses exceptions for control flow on WASM;
+                // this is expected and not an actual error
+                if (msg.includes('Using exceptions for control flow')) {
+                    document.getElementById('loading').style.display = 'none';
+                    return;
+                }
+                if (msg.includes('WebGL') || msg.includes('WebGPU')) {
                     document.getElementById('loading').innerHTML =
-                        'WebGPU is not supported in this browser.<br>' +
-                        'Try Chrome 113+, Edge 113+, or Firefox Nightly.';
+                        'WebGL2 is not supported in this browser.<br>' +
+                        'Try Chrome, Edge, or Firefox with WebGL2 enabled.';
                 } else {
                     document.getElementById('loading').textContent = 'Error: ' + msg;
                 }


### PR DESCRIPTION
Two issues prevented the web build from showing anything useful:

1. winit's run_app() on WASM throws "Using exceptions for control flow" to set up requestAnimationFrame. This exception was caught by the HTML error handler and displayed over the canvas. Fix by using EventLoopExtWebSys::spawn_app() which doesn't throw.

2. The camera was at (0,0,400) — the corner of the 256x256 test level. Only one quadrant of terrain was visible. Moved to (128,128,400) to center on the terrain.

Also updated the HTML error handler to filter the winit control-flow message and show a WebGL2-specific message instead of WebGPU.

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8