### PR TITLE
Web: use ortho projection for Sliced terrain

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -40,16 +40,18 @@ impl WebApp {
         let geometry = settings::Geometry::default();
         let objects_palette = [[0xFF; 4]; 0x100];
 
+        // Use ortho projection for the Sliced terrain test level.
+        // Sliced terrain draws horizontal layers that produce a uniform
+        // color under perspective — only ortho shows height detail.
         let cam = space::Camera {
             loc: glam::vec3(128.0, 128.0, 400.0),
             rot: glam::Quat::IDENTITY,
             scale: glam::vec3(1.0, -1.0, 1.0),
-            proj: space::Projection::Perspective(space::PerspectiveParams {
-                fovy: 45.0f32.to_radians(),
-                aspect: gfx.screen_size.width as f32 / gfx.screen_size.height.max(1) as f32,
-                near: 10.0,
-                far: 2000.0,
-            }),
+            proj: space::Projection::ortho(
+                gfx.screen_size.width as u16,
+                gfx.screen_size.height as u16,
+                10.0..1024.0,
+            ),
         };
 
         // Use Sliced terrain: simple layered renderer, no compute shaders
@@ -78,9 +80,11 @@ impl WebApp {
 
     fn resize(&mut self, extent: wgpu::Extent3d, device: &wgpu::Device) {
         self.render.resize(extent, device);
-        if let space::Projection::Perspective(ref mut p) = self.cam.proj {
-            p.aspect = extent.width as f32 / extent.height.max(1) as f32;
-        }
+        self.cam.proj = space::Projection::ortho(
+            extent.width as u16,
+            extent.height as u16,
+            10.0..1024.0,
+        );
     }
 
     fn draw(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, targets: ScreenTargets) -> wgpu::CommandBuffer {
@@ -702,21 +706,15 @@ impl WebHandler {
             gpu.app.cam.rot = rotation * gpu.app.cam.rot;
         }
 
-        // Auto-orbit: slowly circle the terrain center
+        // Auto-orbit: pan across terrain from above.
+        // Sliced terrain only shows detail from a top-down view;
+        // tilted perspectives degenerate into a solid green fill.
         if !has_input {
-            let center = glam::vec3(128.0, 128.0, 0.0);
-            let radius = 200.0;
-            let height = 300.0;
-            let angle = self.elapsed * 0.15; // slow orbit
-            gpu.app.cam.loc = center + glam::vec3(
-                radius * angle.cos(),
-                radius * angle.sin(),
-                height,
-            );
-            // Look toward center with a slight downward tilt
-            let tilt = glam::Quat::from_rotation_x(-0.6);
-            let yaw = glam::Quat::from_rotation_z(angle + std::f32::consts::FRAC_PI_2);
-            gpu.app.cam.rot = yaw * tilt;
+            let angle = self.elapsed * 0.15;
+            let center_x = 128.0 + 60.0 * angle.cos();
+            let center_y = 128.0 + 60.0 * angle.sin();
+            gpu.app.cam.loc = glam::vec3(center_x, center_y, 400.0);
+            gpu.app.cam.rot = glam::Quat::IDENTITY;
         }
 
         // Process multiplayer messages


### PR DESCRIPTION
The Sliced terrain renderer draws horizontal layers at each height. Under perspective projection, these layers overlap and produce a uniform green fill — only orthographic projection reveals height contours and terrain detail.

Switch the web build to ortho projection (matching the native level viewer's headless snapshot mode). The auto-orbit camera now pans across the terrain from above, showing the terrain color variation.

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8