### PR TITLE
Deploy: run Jekyll to generate blog post pages

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -32,10 +32,16 @@ jobs:
     - name: Generate JS bindings
       run: wasm-bindgen target/wasm32-unknown-unknown/release/web.wasm --out-dir docs/ --target web --no-typescript
 
+    - name: Build Jekyll site
+      uses: actions/jekyll-build-pages@v1
+      with:
+        source: docs/
+        destination: _site/
+
     - name: Upload pages artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: docs/
+        path: _site/
 
   deploy:
     needs: build

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,5 +4,10 @@ title: Vangers Oxidation Project
 description: >-
   Vange-rs experiments and technology blog: future technology from the past.
 
-baseurl: "/"
+baseurl: ""
 url: "https://vange.rs"
+
+# Include WASM artifacts that Jekyll would otherwise skip
+include:
+  - "*.wasm"
+  - "*.js"


### PR DESCRIPTION
The blog post links were 404 because the deploy workflow uploaded docs/ as raw static files, bypassing Jekyll. The _posts/*.md files were never processed into HTML.

Add a Jekyll build step (actions/jekyll-build-pages) that processes docs/ into _site/, then upload _site/ instead. Also fix baseurl from "/" to "" to avoid double-slash URLs, and include *.wasm/*.js in the Jekyll config so WASM artifacts aren't skipped.

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8