### PR TITLE
Web: flatten level zip layout + add release packing script

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -23,10 +23,11 @@ use vangers::data;
 /// is missing (404) we fall back to the procedural test level.
 const DEFAULT_LEVEL: &str = "fostral";
 
-/// INI path inside the per-level zip. Zips are expected to contain
-/// `<level_id>/world.ini` plus the .vmc/.vmp/.pal files it references.
-fn level_ini_path(level_id: &str) -> String {
-    format!("{}/world.ini", level_id)
+/// INI path inside the per-level zip. Each `<id>.zip` stores the level
+/// files at the archive root (no `<id>/` prefix), so the INI key is
+/// just `"world.ini"`.
+fn level_ini_path(_level_id: &str) -> String {
+    "world.ini".to_string()
 }
 
 /// JS bridge for loading-screen UI. The HTML defines these on `window`;

--- a/tools/pack-data.py
+++ b/tools/pack-data.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Package a Vangers installation into release zips for vange-rs web.
+
+Usage:
+    python3 tools/pack-data.py --root PATH_TO_VANGERS --out PATH_TO_OUTPUT [options]
+
+Produces one zip per level plus a `common.zip` holding cross-level
+assets, laid out to match the layout expected by `src/data.rs`:
+
+    <out>/
+      common.zip            game.lst, wrlds.dat, resource/, everything
+                            outside a level directory
+      fostral.zip           contents of the Fostral level directory,
+                            flat (no leading `fostral/` prefix)
+      necross.zip           ...
+      ...
+
+A level directory is any directory containing a `world.ini` file; the
+directory's own name becomes the level id (the zip basename). This
+matches the URL scheme the web client uses:
+
+    https://github.com/kvark/vange-rs/releases/download/data-0/<id>.zip
+
+Upload the resulting zips as assets to the `data-0` release (e.g. via
+`gh release upload data-0 *.zip`).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import zipfile
+from pathlib import Path
+
+
+def find_level_dirs(root: Path) -> dict[str, Path]:
+    """Map level id -> level dir. Level id is the directory name.
+
+    A level is any directory containing a `world.ini` (case-insensitive).
+    Duplicates (same basename in two paths) abort the script; the user
+    must disambiguate.
+    """
+    levels: dict[str, Path] = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Case-insensitive match for world.ini.
+        if any(f.lower() == "world.ini" for f in filenames):
+            d = Path(dirpath)
+            lid = d.name.lower()
+            if lid in levels:
+                sys.exit(
+                    f"error: two level directories share the name {lid!r}:\n"
+                    f"  {levels[lid]}\n  {d}\n"
+                    f"rename one or pass --levels to pick explicitly."
+                )
+            levels[lid] = d
+    return levels
+
+
+def pack_level(level_id: str, level_dir: Path, out_path: Path, verbose: bool) -> None:
+    """Zip the contents of `level_dir` directly into `out_path`.
+
+    Files are stored without the `<level_id>/` prefix so the client's
+    VFS can load them with keys like `"world.ini"` / `"output.vmc"`.
+    """
+    if verbose:
+        print(f"  building {out_path.name} from {level_dir}")
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        for p in sorted(level_dir.rglob("*")):
+            if p.is_dir():
+                continue
+            # Path inside the archive: relative to the level dir.
+            arcname = p.relative_to(level_dir).as_posix()
+            if verbose:
+                print(f"    + {arcname}")
+            zf.write(p, arcname=arcname)
+
+
+def pack_common(
+    root: Path,
+    level_dirs: set[Path],
+    out_path: Path,
+    verbose: bool,
+) -> None:
+    """Zip everything under `root` that isn't inside a level directory."""
+    level_dirs_abs = {d.resolve() for d in level_dirs}
+    if verbose:
+        print(f"  building {out_path.name} (cross-level assets)")
+    with zipfile.ZipFile(out_path, "w", zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
+        for p in sorted(root.rglob("*")):
+            if p.is_dir():
+                continue
+            # Skip anything under a level directory.
+            if any(anc in level_dirs_abs for anc in p.resolve().parents):
+                continue
+            arcname = p.relative_to(root).as_posix()
+            if verbose:
+                print(f"    + {arcname}")
+            zf.write(p, arcname=arcname)
+
+
+def human_bytes(n: int) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if n < 1024:
+            return f"{n:.1f} {unit}" if unit != "B" else f"{n} B"
+        n /= 1024
+    return f"{n:.1f} TiB"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Package Vangers data for the vange-rs web release.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    ap.add_argument(
+        "--root",
+        required=True,
+        type=Path,
+        help="path to the Vangers installation (contains game.lst)",
+    )
+    ap.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="output directory for the zip assets (created if missing)",
+    )
+    ap.add_argument(
+        "--levels",
+        help="comma-separated level ids to include (default: all discovered)",
+    )
+    ap.add_argument(
+        "--skip-common",
+        action="store_true",
+        help="do not build common.zip (useful when only re-packing levels)",
+    )
+    ap.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="list every file as it is added",
+    )
+    args = ap.parse_args()
+
+    root = args.root.expanduser().resolve()
+    if not root.is_dir():
+        sys.exit(f"error: --root is not a directory: {root}")
+
+    out = args.out.expanduser().resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    print(f"Scanning {root}")
+    levels = find_level_dirs(root)
+    if not levels:
+        sys.exit("error: no world.ini found anywhere under --root")
+
+    selected: dict[str, Path]
+    if args.levels:
+        wanted = {s.strip().lower() for s in args.levels.split(",") if s.strip()}
+        unknown = wanted - set(levels)
+        if unknown:
+            sys.exit(f"error: unknown level(s): {', '.join(sorted(unknown))}")
+        selected = {k: levels[k] for k in wanted}
+    else:
+        selected = levels
+
+    print(f"Found {len(levels)} level(s); packing {len(selected)}:")
+    for lid in sorted(selected):
+        print(f"  - {lid}  ({selected[lid].relative_to(root)})")
+
+    for lid, d in sorted(selected.items()):
+        out_path = out / f"{lid}.zip"
+        pack_level(lid, d, out_path, args.verbose)
+        print(f"    -> {out_path.name}  {human_bytes(out_path.stat().st_size)}")
+
+    if not args.skip_common:
+        out_path = out / "common.zip"
+        # Pass all discovered level dirs (even ones not selected) so
+        # common.zip never duplicates level data that lives elsewhere.
+        pack_common(root, set(levels.values()), out_path, args.verbose)
+        print(f"    -> {out_path.name}  {human_bytes(out_path.stat().st_size)}")
+
+    print("\nDone. Upload with:")
+    tag = "data-0"
+    print(f"  gh release upload {tag} {out}/*.zip --repo kvark/vange-rs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Each `<id>.zip` now stores its files at the archive root (e.g. `fostral.zip` contains `world.ini`, `output.vmc`, ...) instead of nesting them under `<id>/`. The client looks up the INI at key `"world.ini"` regardless of level, so a single convention covers every level archive.

Adds `tools/pack-data.py`, a standalone Python script that takes a Vangers installation and produces the zip assets ready for upload to the `data-0` release:

  python3 tools/pack-data.py --root PATH_TO_VANGERS --out ./out -v

It discovers level directories by scanning for `world.ini`, packs each level's contents flat into `<id>.zip`, and bundles everything outside a level dir (game.lst, wrlds.dat, resource/) into `common.zip`. Supports `--levels` to select a subset and `--skip-common` to rebuild only level zips.

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8