### PR TITLE
Web: fetch release assets via GitHub API to get CORS headers

### DIFF
--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -825,26 +825,25 @@ impl Application for Game {
                                 // so just snap to keep them consistent.
                                 let player =
                                     self.agents.iter_mut().find(|a| a.spirit == Spirit::Player);
-                                if let Some(player) = player {
-                                    if let Physics::Cpu {
+                                if let Some(player) = player
+                                    && let Physics::Cpu {
                                         ref mut transform,
                                         ref mut dynamo,
                                     } = player.physics
-                                    {
-                                        if !self.server_synced {
-                                            // First sync: hard-snap camera to
-                                            // avoid slow chase from old spawn.
-                                            self.server_synced = true;
-                                            self.cam.focus_on(&server_transform);
-                                        }
-                                        *transform = server_transform;
-                                        dynamo.linear_velocity =
-                                            Vec3::from(agent_state.dynamo.linear_velocity);
-                                        dynamo.angular_velocity =
-                                            Vec3::from(agent_state.dynamo.angular_velocity);
-                                        dynamo.traction = agent_state.dynamo.traction;
-                                        dynamo.rudder = agent_state.dynamo.rudder;
+                                {
+                                    if !self.server_synced {
+                                        // First sync: hard-snap camera to
+                                        // avoid slow chase from old spawn.
+                                        self.server_synced = true;
+                                        self.cam.focus_on(&server_transform);
                                     }
+                                    *transform = server_transform;
+                                    dynamo.linear_velocity =
+                                        Vec3::from(agent_state.dynamo.linear_velocity);
+                                    dynamo.angular_velocity =
+                                        Vec3::from(agent_state.dynamo.angular_velocity);
+                                    dynamo.traction = agent_state.dynamo.traction;
+                                    dynamo.rudder = agent_state.dynamo.rudder;
                                 }
                             } else if let Some(remote) =
                                 self.remote_agents.get_mut(&agent_state.player_id)
@@ -1038,10 +1037,10 @@ impl Application for Game {
             .show(context, |ui| {
                 if self.mp_state.connected {
                     ui.label(format!("Connected to {}", self.mp_state.server_addr));
-                    if let Some(ref net) = self.net {
-                        if let Some(id) = net.player_id {
-                            ui.label(format!("Player ID: {}", id));
-                        }
+                    if let Some(ref net) = self.net
+                        && let Some(id) = net.player_id
+                    {
+                        ui.label(format!("Player ID: {}", id));
                     }
                     ui.label(format!("Remote players: {}", self.remote_agents.len()));
                     if ui.button("Disconnect").clicked() {

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -55,21 +55,20 @@ extern "C" {
 /// [`DEFAULT_LEVEL`].
 #[cfg(target_arch = "wasm32")]
 fn selected_level_id() -> String {
-    if let Ok(val) = js_selected_level() {
-        if let Some(s) = val.as_string() {
-            if !s.is_empty() {
-                return s;
-            }
-        }
+    if let Ok(val) = js_selected_level()
+        && let Some(s) = val.as_string()
+        && !s.is_empty()
+    {
+        return s;
     }
-    if let Some(window) = web_sys::window() {
-        if let Ok(hash) = window.location().hash() {
-            for pair in hash.trim_start_matches('#').split('&') {
-                if let Some(rest) = pair.strip_prefix("level=") {
-                    if !rest.is_empty() {
-                        return rest.to_string();
-                    }
-                }
+    if let Some(window) = web_sys::window()
+        && let Ok(hash) = window.location().hash()
+    {
+        for pair in hash.trim_start_matches('#').split('&') {
+            if let Some(rest) = pair.strip_prefix("level=")
+                && !rest.is_empty()
+            {
+                return rest.to_string();
             }
         }
     }
@@ -343,9 +342,7 @@ mod net_ws {
         }
 
         pub fn poll(&mut self) -> Vec<ServerMessage> {
-            let mut msgs = self.received.borrow_mut();
-            let result = msgs.drain(..).collect();
-            result
+            self.received.borrow_mut().drain(..).collect()
         }
 
         #[allow(dead_code)]
@@ -397,7 +394,7 @@ impl WebHandler {
                 let url = {
                     let is_https = web_sys::window()
                         .and_then(|w| w.location().protocol().ok())
-                        .map_or(false, |p| p == "https:");
+                        .is_some_and(|p| p == "https:");
                     if is_https && url.starts_with("ws://") {
                         let upgraded = format!("wss://{}", &url[5..]);
                         log::info!("HTTPS page: upgrading {} to {}", url, upgraded);
@@ -745,10 +742,10 @@ impl ApplicationHandler for WebHandler {
             WindowEvent::RedrawRequested => {
                 // Check if async GPU init completed (WASM)
                 #[cfg(target_arch = "wasm32")]
-                if self.gpu.is_none() {
-                    if let Some(state) = self.gpu_pending.borrow_mut().take() {
-                        self.gpu = Some(state);
-                    }
+                if self.gpu.is_none()
+                    && let Some(state) = self.gpu_pending.borrow_mut().take()
+                {
+                    self.gpu = Some(state);
                 }
 
                 self.render();
@@ -905,11 +902,11 @@ impl WebHandler {
                     }
                     vangers_net::ServerMessage::WorldState { agents, .. } => {
                         // Move camera to follow our agent
-                        if let Some(my_id) = ws.player_id {
-                            if let Some(me) = agents.iter().find(|a| a.player_id == my_id) {
-                                let pos = glam::Vec3::from(me.transform.position);
-                                gpu.app.cam.loc = glam::vec3(pos.x, pos.y, pos.z + 200.0);
-                            }
+                        if let Some(my_id) = ws.player_id
+                            && let Some(me) = agents.iter().find(|a| a.player_id == my_id)
+                        {
+                            let pos = glam::Vec3::from(me.transform.position);
+                            gpu.app.cam.loc = glam::vec3(pos.x, pos.y, pos.z + 200.0);
                         }
                     }
                 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,19 +1,28 @@
 //! HTTP-based data loader for the web build.
 //!
 //! Fetches zip archives from a GitHub release and mounts them into a
-//! shared [`Vfs`]. No manifest: asset URLs are built from a fixed base
-//! and a known level id. A missing asset produces a `NotFound` error
-//! and the caller decides how to fall back.
+//! shared [`Vfs`]. Asset URLs are discovered through the GitHub REST
+//! API because the plain `releases/download/...` URLs return a 302
+//! without CORS headers, which the browser rejects. The API endpoint
+//! (`api.github.com`) sets `Access-Control-Allow-Origin: *` on both
+//! the initial response and the redirect it issues to the CDN, so a
+//! browser `fetch()` can follow the chain end-to-end.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
 
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{ReadableStreamDefaultReader, Request, RequestInit, RequestMode, Response};
+use web_sys::{Headers, ReadableStreamDefaultReader, Request, RequestInit, RequestMode, Response};
 
 use crate::vfs::{Vfs, VfsError};
 
-/// GitHub release that holds the data zips. Bump the tag to invalidate
+/// GitHub release tag whose assets hold the data zips. Bump to invalidate
 /// every client's browser cache at once.
-pub const RELEASE_BASE_URL: &str = "https://github.com/kvark/vange-rs/releases/download/data-0";
+pub const RELEASE_TAG: &str = "data-0";
+
+/// GitHub repository that owns the release.
+pub const REPO: &str = "kvark/vange-rs";
 
 /// Archive that holds cross-level assets: resource models, sounds,
 /// `game.lst`, `wrlds.dat`, palettes shared across worlds, etc.
@@ -23,12 +32,20 @@ pub const COMMON_ARCHIVE: &str = "common.zip";
 /// server didn't send a `Content-Length` header.
 pub type ProgressFn<'a> = &'a mut dyn FnMut(&str, u64, Option<u64>);
 
+thread_local! {
+    /// Cache for the release's asset list, populated lazily on first
+    /// use. One API round-trip per page load, shared by every asset
+    /// fetch that follows.
+    static ASSETS: RefCell<Option<HashMap<String, String>>> = const { RefCell::new(None) };
+}
+
 #[derive(Debug)]
 pub enum FetchError {
     Network(String),
     NotFound(String),
     Http { status: u16, url: String },
     Vfs(VfsError),
+    BadJson(String),
 }
 
 impl std::fmt::Display for FetchError {
@@ -40,6 +57,7 @@ impl std::fmt::Display for FetchError {
                 write!(f, "HTTP {} for {}", status, url)
             }
             FetchError::Vfs(ref e) => write!(f, "vfs: {}", e),
+            FetchError::BadJson(ref msg) => write!(f, "bad release metadata: {}", msg),
         }
     }
 }
@@ -55,11 +73,101 @@ fn js_err(v: wasm_bindgen::JsValue) -> FetchError {
     FetchError::Network(format!("{:?}", v))
 }
 
+/// Build the filename of a level's archive: `<id>.zip`.
+pub fn level_archive_name(level_id: &str) -> String {
+    format!("{}.zip", level_id)
+}
+
+/// Fetch and parse the release metadata, returning a `name -> api_url`
+/// map. Cached in a thread-local so repeated calls within one page
+/// load don't re-hit the API (and don't consume rate-limit budget).
+async fn fetch_asset_index() -> Result<HashMap<String, String>, FetchError> {
+    if let Some(cached) = ASSETS.with(|c| c.borrow().clone()) {
+        return Ok(cached);
+    }
+
+    let url = format!(
+        "https://api.github.com/repos/{}/releases/tags/{}",
+        REPO, RELEASE_TAG
+    );
+    log::info!("Fetching release metadata: {}", url);
+
+    let opts = RequestInit::new();
+    opts.set_method("GET");
+    opts.set_mode(RequestMode::Cors);
+    let headers = Headers::new().map_err(js_err)?;
+    // GitHub API requires an Accept header to return v3 JSON; without
+    // it older clients get a non-JSON body on some error paths.
+    headers.set("Accept", "application/vnd.github+json").map_err(js_err)?;
+    opts.set_headers(&headers);
+
+    let request = Request::new_with_str_and_init(&url, &opts).map_err(js_err)?;
+    let window = web_sys::window().ok_or_else(|| FetchError::Network("no window".into()))?;
+    let resp_value = JsFuture::from(window.fetch_with_request(&request))
+        .await
+        .map_err(js_err)?;
+    let resp: Response = resp_value.dyn_into().map_err(js_err)?;
+
+    if resp.status() == 404 {
+        return Err(FetchError::NotFound(url));
+    }
+    if !resp.ok() {
+        return Err(FetchError::Http {
+            status: resp.status(),
+            url,
+        });
+    }
+
+    let text_value = JsFuture::from(resp.text().map_err(js_err)?)
+        .await
+        .map_err(js_err)?;
+    let text = text_value
+        .as_string()
+        .ok_or_else(|| FetchError::BadJson("response body is not text".into()))?;
+
+    let json = js_sys::JSON::parse(&text)
+        .map_err(|_| FetchError::BadJson("not valid JSON".into()))?;
+    let assets_val = js_sys::Reflect::get(&json, &"assets".into())
+        .map_err(|_| FetchError::BadJson("missing `assets`".into()))?;
+    let assets: js_sys::Array = assets_val
+        .dyn_into()
+        .map_err(|_| FetchError::BadJson("`assets` is not an array".into()))?;
+
+    let mut map = HashMap::with_capacity(assets.length() as usize);
+    for i in 0..assets.length() {
+        let entry = assets.get(i);
+        let name = js_sys::Reflect::get(&entry, &"name".into())
+            .ok()
+            .and_then(|v| v.as_string())
+            .ok_or_else(|| FetchError::BadJson(format!("asset[{}].name missing", i)))?;
+        let api_url = js_sys::Reflect::get(&entry, &"url".into())
+            .ok()
+            .and_then(|v| v.as_string())
+            .ok_or_else(|| FetchError::BadJson(format!("asset[{}].url missing", i)))?;
+        map.insert(name, api_url);
+    }
+
+    log::info!(
+        "Release has {} asset(s): {}",
+        map.len(),
+        map.keys().cloned().collect::<Vec<_>>().join(", ")
+    );
+
+    ASSETS.with(|c| *c.borrow_mut() = Some(map.clone()));
+    Ok(map)
+}
+
 /// Fetch one release asset by filename (e.g. `"common.zip"`),
 /// reporting incremental download progress to `progress`.
 pub async fn fetch_asset(name: &str, progress: ProgressFn<'_>) -> Result<Vec<u8>, FetchError> {
-    let url = format!("{}/{}", RELEASE_BASE_URL, name);
-    fetch_bytes_streaming(name, &url, progress).await
+    let index = fetch_asset_index().await?;
+    let api_url = index.get(name).cloned().ok_or_else(|| {
+        FetchError::NotFound(format!(
+            "asset `{}` not in release `{}`",
+            name, RELEASE_TAG
+        ))
+    })?;
+    fetch_bytes_streaming(name, &api_url, progress).await
 }
 
 async fn fetch_bytes_streaming(
@@ -70,6 +178,12 @@ async fn fetch_bytes_streaming(
     let opts = RequestInit::new();
     opts.set_method("GET");
     opts.set_mode(RequestMode::Cors);
+    // `Accept: application/octet-stream` makes the GitHub API return
+    // a 302 to the asset's CDN location. Without it, the API would
+    // return the asset's JSON metadata instead.
+    let headers = Headers::new().map_err(js_err)?;
+    headers.set("Accept", "application/octet-stream").map_err(js_err)?;
+    opts.set_headers(&headers);
 
     let request = Request::new_with_str_and_init(url, &opts).map_err(js_err)?;
 
@@ -149,8 +263,3 @@ pub async fn fetch_and_mount(
     Ok(())
 }
 
-/// Build the asset filename for a given level id. Convention: the
-/// release holds one zip per level named `<id>.zip`.
-pub fn level_archive_name(level_id: &str) -> String {
-    format!("{}.zip", level_id)
-}


### PR DESCRIPTION
The raw `releases/download/<tag>/<file>` URL returns a 302 to the CDN but does not set `Access-Control-Allow-Origin`, so browsers reject it:

    Cross-Origin Request Blocked: CORS header
    'Access-Control-Allow-Origin' missing. Status code: 302

The REST API endpoint (`api.github.com/repos/.../releases/tags/...`) does set CORS and its redirect to the CDN also carries CORS headers, so an in-browser fetch() can follow the chain end-to-end.

`src/data.rs` now:

1. Hits `api.github.com` once per page load to map asset name -> API URL (cached in a thread-local so subsequent fetches are free).
2. Downloads each asset via its API URL with `Accept: application/octet-stream`, which makes the API 302 to the CDN location instead of returning JSON metadata.
3. Streams the body through a `ReadableStreamDefaultReader` exactly as before, so the progress bar continues to work unchanged.

Drops the `RELEASE_BASE_URL` constant in favor of `RELEASE_TAG` + `REPO`, now that we no longer build download URLs by hand.

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8