### PR TITLE
Web: fix white vehicle, stalled WASD, and camera offset

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -348,7 +348,10 @@ impl WebApp {
         geometry: settings::Geometry,
         vfs: Option<&Vfs>,
     ) -> Self {
-        let objects_palette = [[0xFF; 4]; 0x100];
+        let objects_palette = vfs
+            .and_then(|v| v.read("resource/pal/objects.pal"))
+            .map(|b| level::read_palette_bytes(&b, None))
+            .unwrap_or([[0xFF; 4]; 0x100]);
 
         let cam = space::Camera {
             loc: glam::vec3(128.0, 128.0, 400.0),
@@ -391,12 +394,12 @@ impl WebApp {
             log::info!("No player agent — running in free-camera mode");
         }
 
-        // Conservative follow-camera tuning. Distance behind the
-        // vehicle, height above it, moderate smoothing speed.
+        // Follow-camera tuning matching native defaults
+        // (config/settings.template.ron camera section).
         let follow = space::Follow {
-            angle_x: 45f32.to_radians(),
-            offset: glam::vec3(0.0, -40.0, 30.0),
-            speed: 2.0,
+            angle_x: 60f32.to_radians(),
+            offset: glam::vec3(0.0, 140.0, 210.0),
+            speed: 1.0,
         };
 
         WebApp {

--- a/docs/index.html
+++ b/docs/index.html
@@ -121,9 +121,9 @@
             <div id="progress-text"></div>
             <div id="phase-log"></div>
         </div>
-        <canvas id="canvas"></canvas>
+        <canvas id="canvas" tabindex="0"></canvas>
         <div id="controls-hint">
-            WASD – move &nbsp;|&nbsp; Z/X – altitude &nbsp;|&nbsp; Q/E – rotate &nbsp;|&nbsp; Scroll – zoom
+            WASD – drive &nbsp;|&nbsp; Space – brake
         </div>
     </div>
 
@@ -302,7 +302,13 @@ WGSL shaders, compute-based voxel baking</code></pre>
             const wait = Math.max(READY_HOLD_MS, MIN_OVERLAY_MS - alreadyShown);
             setTimeout(() => {
                 overlay.classList.add('fade-out');
-                setTimeout(() => { overlay.style.display = 'none'; }, 400);
+                setTimeout(() => {
+                    overlay.style.display = 'none';
+                    // Focus the canvas so keyboard events reach winit.
+                    // Without this, focus stays on the level picker
+                    // <select> or a nav button, and WASD is swallowed.
+                    document.getElementById('canvas')?.focus();
+                }, 400);
             }, wait);
         };
 


### PR DESCRIPTION
Three issues reported against the deployed demo:

1. Vehicle rendered solid white. The objects palette was hardcoded to all-0xFF. Now loads resource/pal/objects.pal from the VFS when available, falling back to the white palette only when no data archive is present.

2. WASD had no effect. The canvas never received keyboard focus — winit's web backend attaches key listeners to the canvas, but after page load focus sits on the level-picker select or a nav button. Add tabindex="0" to the canvas and call canvas.focus() in vangeProgressDone() once the overlay fades. Verified: after an 8-second W hold in headless Chromium the agent moves from (128, 128, 139) to (99, 125, 101) with traction=1.65 and vel=13.

3. Camera follow parameters were wrong. The offset (0, -40, 30) and angle 45 deg were made up; the native game uses angle=60 deg, offset=(0, 140, 210), speed=1 (from config/settings.template.ron). The space::Follow::follow() method applies a 180 deg yaw patch internally, so positive-Y offset correctly trails behind the car. No per-platform Y-flip hack needed — wgpu handles the GL surface orientation internally via naga's ADJUST_COORDINATE_SPACE + Y-flipped blit in present().

Also updates the controls-hint text from the old free-camera bindings to the driving bindings (WASD + Space).

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8