### PR TITLE
Web: fix upside-down image, improve keyboard focus, add all 10 worlds

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -806,9 +806,24 @@ impl ApplicationHandler for WebHandler {
                                     vfs_level: Option<(Vfs, String)>|
               -> GpuState {
             let caps = surface.get_capabilities(adapter);
+            // Prefer a non-sRGB surface format. wgpu's GL backend has
+            // two present paths: glBlitFramebuffer (non-sRGB) which
+            // correctly Y-flips the image, and a fullscreen-triangle
+            // shader (sRGB) whose UV mapping interacts poorly with
+            // default texture wrapping and can produce an upside-down
+            // image. Picking the non-sRGB variant side-steps the issue
+            // entirely. On Vulkan/Metal this is a no-op since those
+            // backends don't have the dual-path present.
+            let format = caps
+                .formats
+                .iter()
+                .copied()
+                .find(|f| !f.is_srgb())
+                .unwrap_or(caps.formats[0]);
+            log::info!("Surface format: {:?} (sRGB: {})", format, format.is_srgb());
             let config = wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                format: caps.formats[0],
+                format,
                 width: screen_size.width,
                 height: screen_size.height,
                 present_mode: wgpu::PresentMode::Fifo,

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,10 +207,16 @@ WGSL shaders, compute-based voxel baking</code></pre>
         // <id>.zip asset on the GitHub release; if the asset is missing
         // the page falls back to the procedural test level.
         const LEVELS = [
-            { id: 'fostral',  title: 'Fostral'  },
-            { id: 'necross',  title: 'Necross'  },
-            { id: 'glorx',    title: 'Glorx'    },
-            { id: 'khox',     title: 'Khox'     },
+            { id: 'fostral',    title: 'Fostral'    },
+            { id: 'glorx',      title: 'Glorx'      },
+            { id: 'necross',    title: 'Necross'    },
+            { id: 'khox',       title: 'Khox'       },
+            { id: 'boozeena',   title: 'Boozeena'   },
+            { id: 'weexow',     title: 'Weexow'     },
+            { id: 'xplo',       title: 'Xplo'       },
+            { id: 'hmok',       title: 'Hmok'       },
+            { id: 'threall',    title: 'Threall'    },
+            { id: 'ark-a-znoy', title: 'Ark-a-Znoy' },
         ];
         const DEFAULT_LEVEL = 'fostral';
 
@@ -307,10 +313,22 @@ WGSL shaders, compute-based voxel baking</code></pre>
                     // Focus the canvas so keyboard events reach winit.
                     // Without this, focus stays on the level picker
                     // <select> or a nav button, and WASD is swallowed.
-                    document.getElementById('canvas')?.focus();
+                    const c = document.getElementById('canvas');
+                    if (c) { c.focus(); c.click(); }
                 }, 400);
             }, wait);
         };
+
+        // Ensure clicking anywhere on the game panel gives focus to
+        // the canvas. Without this, clicking the surrounding area
+        // (e.g. the controls-hint or empty space) might defocus.
+        document.addEventListener('click', function(e) {
+            const panel = document.getElementById('game-panel');
+            const canvas = document.getElementById('canvas');
+            if (panel?.contains(e.target) && canvas && e.target !== canvas) {
+                canvas.focus();
+            }
+        });
 
         window.vangeProgressError = function(message) {
             const loading = document.getElementById('loading');


### PR DESCRIPTION
Y-flip fix
----------
wgpu's GL backend has two present paths:
  1. glBlitFramebuffer (non-sRGB formats) — correctly Y-flips
  2. Fullscreen-triangle sRGB shader — UV mapping relies on texture wrapping defaults that can produce an upside-down image

The surface was configured with caps.formats[0], which on WebGL2 can be Rgba8UnormSrgb, hitting the shader path. Now explicitly prefer a non-sRGB format so the blit path is always used. Logged the chosen format for diagnostics. This is a surface-level fix — no game-logic Y hacks needed; cam.scale.y = -1 stays identical to native.

Keyboard focus
--------------
tabindex="0" and vangeProgressDone's canvas.focus() weren't sufficient — if the user clicks anywhere on the game panel that isn't the canvas, focus goes elsewhere. Added:
  - canvas.click() alongside canvas.focus() on ready
  - document-level click handler that redirects any click inside #game-panel to the canvas

Level picker
------------
Release data-0 has 10 worlds; the dropdown only listed 4. Added all of them: Fostral, Glorx, Necross, Khox, Boozeena, Weexow, Xplo, Hmok, Threall, Ark-a-Znoy.

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8