### PR TITLE
Revert shader experiments, force non-sRGB surface for correct Y-flip

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -9,6 +9,7 @@ on:
       - 'src/**'
       - 'lib/**'
       - 'bin/web/**'
+      - 'res/**'
       - 'docs/**'
       - 'Cargo.toml'
       - 'Cargo.lock'

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -806,9 +806,23 @@ impl ApplicationHandler for WebHandler {
                                     vfs_level: Option<(Vfs, String)>|
               -> GpuState {
             let caps = surface.get_capabilities(adapter);
+            // Force non-sRGB surface format on WebGL. wgpu's GL present
+            // has two paths: glBlitFramebuffer (non-sRGB) correctly
+            // Y-flips the image to account for naga's vertex Y-flip.
+            // The sRGB path uses a fullscreen shader whose UV mapping
+            // breaks under GL_REPEAT wrapping on negative coords,
+            // producing an upside-down image. The palette-based
+            // rendering doesn't rely on hardware sRGB conversion, so
+            // a non-sRGB format is visually equivalent.
+            let format = caps
+                .formats
+                .iter()
+                .copied()
+                .find(|f| !f.is_srgb())
+                .unwrap_or(caps.formats[0]);
             let config = wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                format: caps.formats[0],
+                format,
                 width: screen_size.width,
                 height: screen_size.height,
                 present_mode: wgpu::PresentMode::Fifo,

--- a/res/shader/terrain/locals.inc.wgsl
+++ b/res/shader/terrain/locals.inc.wgsl
@@ -25,16 +25,6 @@ fn get_frag_world(frag_coord: vec2<f32>, z: f32) -> vec3<f32> {
     return homogeneous.xyz / homogeneous.w;
 }
 
-/// Reconstruct world position from a clip-space varying (passed from
-/// the vertex shader). Unlike `get_frag_world` this doesn't use
-/// `@builtin(position)` and works identically on all GPU backends —
-/// naga's GL vertex Y-flip propagates through the interpolated varying.
-fn get_clip_world(clip_pos: vec4<f32>, z: f32) -> vec3<f32> {
-    let ndc = vec4<f32>(clip_pos.xy / clip_pos.w, z, 1.0);
-    let homogeneous = u_Globals.inv_view_proj * ndc;
-    return homogeneous.xyz / homogeneous.w;
-}
-
 fn apply_fog(terrain_color: vec4<f32>, world_pos: vec2<f32>) -> vec4<f32> {
     let cam_distance = clamp(length(world_pos - u_Locals.cam_origin_dir.xy), u_Locals.fog_params.x, u_Locals.fog_params.y);
     let fog_amount = smoothstep(u_Locals.fog_params.x, u_Locals.fog_params.y, cam_distance);

--- a/res/shader/terrain/ray.wgsl
+++ b/res/shader/terrain/ray.wgsl
@@ -1,20 +1,14 @@
 //!include globals.inc terrain/locals.inc surface.inc shadow.inc terrain/color.inc
 
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) clip_pos: vec4<f32>,
-};
-
 @vertex
-fn main(@location(0) pos: vec4<i32>) -> VertexOutput {
+fn main(@location(0) pos: vec4<i32>) -> @builtin(position) vec4<f32> {
     // orhto projections don't like infinite values
-    let clip = select(
+    return select(
         u_Globals.view_proj * vec4<f32>(pos),
         // the expected geometry is 4 trianges meeting in the center
         vec4<f32>(vec2<f32>(pos.xy), 0.0, 0.5),
         u_Globals.view_proj[2][3] == 0.0
     );
-    return VertexOutput(clip, clip);
 }
 
 //imported: Surface, u_Surface, get_surface, evaluate_color
@@ -167,14 +161,13 @@ fn color_point(pt: CastPoint, lit_factor: f32) -> vec4<f32> {
 }
 
 struct RayInput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) clip_pos: vec4<f32>,
+    @builtin(position) frag_coord: vec4<f32>,
 };
 
 @fragment
 fn ray_depth(in: RayInput) -> @builtin(frag_depth) f32 {
-    let sp_near_world = get_clip_world(in.clip_pos, 0.0);
-    let sp_far_world = get_clip_world(in.clip_pos, 1.0);
+    let sp_near_world = get_frag_world(in.frag_coord.xy, 0.0);
+    let sp_far_world = get_frag_world(in.frag_coord.xy, 1.0);
     let view = normalize(sp_far_world - sp_near_world);
     let pt = cast_ray_to_map(sp_near_world, view);
 
@@ -189,8 +182,8 @@ struct FragOutput {
 
 @fragment
 fn ray_color_debug(in: RayInput) -> FragOutput {
-    let sp_near_world = get_clip_world(in.clip_pos, 0.0);
-    let sp_far_world = get_clip_world(in.clip_pos, 1.0);
+    let sp_near_world = get_frag_world(in.frag_coord.xy, 0.0);
+    let sp_far_world = get_frag_world(in.frag_coord.xy, 1.0);
     let view = normalize(sp_far_world - sp_near_world);
 
     let pos = cast_ray_to_plane(0.0, sp_near_world, view);
@@ -201,8 +194,8 @@ fn ray_color_debug(in: RayInput) -> FragOutput {
 
 @fragment
 fn ray_color(in: RayInput) -> FragOutput {
-    let sp_near_world = get_clip_world(in.clip_pos, 0.0);
-    let sp_far_world = get_clip_world(in.clip_pos, 1.0);
+    let sp_near_world = get_frag_world(in.frag_coord.xy, 0.0);
+    let sp_far_world = get_frag_world(in.frag_coord.xy, 1.0);
     let view = normalize(sp_far_world - sp_near_world);
     let pt = cast_ray_to_map(sp_near_world, view);
 

--- a/res/shader/terrain/voxel-draw.wgsl
+++ b/res/shader/terrain/voxel-draw.wgsl
@@ -31,20 +31,14 @@ const step_scale = 1.0;
 
 var<private> debug_color: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
 
-struct VertexOutput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) clip_pos: vec4<f32>,
-};
-
 @vertex
-fn main(@builtin(vertex_index) index: u32) -> VertexOutput {
-    let clip = vec4<f32>(
+fn main(@builtin(vertex_index) index: u32) -> @builtin(position) vec4<f32> {
+    return vec4<f32>(
         select(-1.0, 3.0, index == 1u),
         select(-1.0, 3.0, index >= 2u),
         0.0,
         1.0,
     );
-    return VertexOutput(clip, clip);
 }
 
 const TYPE_MISS: u32 = 0xFFu;
@@ -223,15 +217,10 @@ fn cast_ray_through_voxels(base: vec3<f32>, dir: vec3<f32>) -> CastPoint {
     return CastPoint(pos, ty);
 }
 
-struct VoxelInput {
-    @builtin(position) position: vec4<f32>,
-    @location(0) clip_pos: vec4<f32>,
-};
-
 @fragment
-fn draw_depth(in: VoxelInput) -> @builtin(frag_depth) f32 {
-    let sp_near_world = get_clip_world(in.clip_pos, 0.0);
-    let sp_far_world = get_clip_world(in.clip_pos, 1.0);
+fn draw_depth(@builtin(position) frag_coord: vec4<f32>) -> @builtin(frag_depth) f32 {
+    let sp_near_world = get_frag_world(frag_coord.xy, 0.0);
+    let sp_far_world = get_frag_world(frag_coord.xy, 1.0);
     let view = normalize(sp_far_world - sp_near_world);
     let pt = cast_ray_through_voxels(sp_near_world, view);
     //let pt = cast_ray_fallback(sp_near_world, view);
@@ -249,9 +238,9 @@ struct FragOutput {
 };
 
 @fragment
-fn draw_color(in: VoxelInput) -> FragOutput {
-    let sp_near_world = get_clip_world(in.clip_pos, 0.0);
-    let sp_far_world = get_clip_world(in.clip_pos, 1.0);
+fn draw_color(@builtin(position) frag_coord: vec4<f32>) -> FragOutput {
+    let sp_near_world = get_frag_world(frag_coord.xy, 0.0);
+    let sp_far_world = get_frag_world(frag_coord.xy, 1.0);
     let view = normalize(sp_far_world - sp_near_world);
     let pt = cast_ray_through_voxels(sp_near_world, view);
     //let pt = cast_ray_fallback(sp_near_world, view);


### PR DESCRIPTION
The clip_pos varying approach and frag_y_sign uniform both failed to fix the upside-down terrain on Firefox WebGL2. The real issue is wgpu's GL present path selection:

- Non-sRGB path: glBlitFramebuffer with Y-flipped source coords. This correctly compensates for naga's ADJUST_COORDINATE_SPACE vertex Y-flip.
- sRGB path: fullscreen triangle shader with UV coordinates in [-1, 2] range. Under the default GL_REPEAT texture wrapping, negative UVs wrap incorrectly, producing a broken Y-mapping.

Firefox reports an sRGB format as caps.formats[0], so the sRGB present path runs by default and the image is upside down.

Fix: prefer a non-sRGB surface format to ensure the blit path runs. The Vangers rendering pipeline uses palette-based colors, not linear lighting, so hardware sRGB conversion is not needed.

Also reverts all shader changes (clip_pos varying, get_clip_world) back to the original frag_coord-based code with the standard hardcoded Y-flip that matches wgpu's Vulkan+GL convention.

Adds res/** to the deploy workflow path filter so shader changes trigger redeployment.

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8