### PR TITLE
Web: add frame-rate + bbox diagnostics to spawn/physics logs

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -290,11 +290,13 @@ fn spawn_default_agent(
     };
 
     log::info!(
-        "Spawned agent '{}' at ({}, {}, {:.1})",
+        "Spawned agent '{}' at ({}, {}, {:.1}) scale={:.3} bbox=({:?})",
         car_name,
         coords.0,
         coords.1,
-        height
+        height,
+        scale,
+        car.model.body.bbox,
     );
 
     Some(Agent {
@@ -614,6 +616,9 @@ struct WebHandler {
     last_frame: Option<Instant>,
     /// Rolling frame counter for throttled debug logs.
     frame_counter: u32,
+    /// Wall-clock time of the last throttled debug log, for
+    /// measuring effective frame rate.
+    last_log: Option<Instant>,
     #[cfg(target_arch = "wasm32")]
     ws_client: Option<net_ws::WsClient>,
     /// Status text overlay (used in multiplayer logging)
@@ -669,6 +674,7 @@ impl WebHandler {
             },
             keys_pressed: std::collections::HashSet::new(),
             frame_counter: 0,
+            last_log: None,
             last_frame: None,
             #[cfg(target_arch = "wasm32")]
             ws_client,
@@ -1112,17 +1118,22 @@ impl WebHandler {
                 let target_transform = agent.transform;
                 self.frame_counter = self.frame_counter.wrapping_add(1);
                 gpu.app.cam.follow(&target_transform, dt, &follow);
-                // Throttled debug trace — once per second, confirms
-                // the physics loop is advancing the agent state AND
-                // the camera is actually tracking it.
+                // Throttled debug trace — every 60 render frames,
+                // log the agent, camera, and the wall-clock interval
+                // between log lines so the user can spot framerate
+                // issues (long gap = low fps).
                 if self.frame_counter.is_multiple_of(60) {
+                    let now = Instant::now();
+                    let interval = self.last_log.map_or(0.0, |t| (now - t).as_secs_f32());
+                    self.last_log = Some(now);
                     log::info!(
-                        "agent pos={:.1},{:.1},{:.1} traction={:.2} rudder={:.2} vel={:.1} cam=({:.1},{:.1},{:.1})",
+                        "frame={} dt_60={:.2}s (~{:.0}fps) agent=({:.1},{:.1},{:.1}) vel={:.1} cam=({:.1},{:.1},{:.1})",
+                        self.frame_counter,
+                        interval,
+                        if interval > 0.0 { 60.0 / interval } else { 0.0 },
                         agent.transform.disp.x,
                         agent.transform.disp.y,
                         agent.transform.disp.z,
-                        agent.dynamo.traction,
-                        agent.dynamo.rudder,
                         agent.dynamo.linear_velocity.length(),
                         gpu.app.cam.loc.x,
                         gpu.app.cam.loc.y,

--- a/src/model.rs
+++ b/src/model.rs
@@ -8,7 +8,7 @@ use wgpu::util::DeviceExt as _;
 
 use std::{fs::File, ops::Range, slice, sync::Arc};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct BoundingBox {
     pub min: [f32; 3],
     pub max: [f32; 3],


### PR DESCRIPTION
Adds two diagnostic improvements for debugging the "vehicle not visible" and "camera stays in place" reports:

1. Spawn log now includes the vehicle's model scale and bounding box — so if the vehicle mesh has degenerate dimensions or a bogus scale (e.g. OxidizeMonk with scale=0.227, bbox radius=123) it's visible in the console.

2. Throttled physics log now reports the wall-clock interval between log lines and a derived fps estimate. With the log firing every 60 frames, a 1-second interval = 60fps; a 5-second interval = 12fps. Lets us distinguish "render loop stalled" from "render loop running but slow" from the browser console.

Format:
  frame=60 dt_60=1.05s (~57fps) agent=(99.6,124.9,102.2) vel=12.8
      cam=(117.4,264.9,321.9)

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8