### PR TITLE
Web: add motor/traction/wheel diagnostics for vehicle debugging

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -290,13 +290,14 @@ fn spawn_default_agent(
     };
 
     log::info!(
-        "Spawned agent '{}' at ({}, {}, {:.1}) scale={:.3} bbox=({:?})",
+        "Spawned agent '{}' at ({}, {}, {:.1}) scale={:.3} wheels={} phys_wheels={}",
         car_name,
         coords.0,
         coords.1,
         height,
         scale,
-        car.model.body.bbox,
+        car.model.wheels.len(),
+        phys_data.wheels.len(),
     );
 
     Some(Agent {
@@ -1111,6 +1112,12 @@ impl WebHandler {
             let level_ref = &gpu.app.level;
             let follow = gpu.app.follow;
             if let Some(ref mut agent) = gpu.app.agent {
+                if motor != 0.0 && agent.control.motor == 0.0 {
+                    log::info!(
+                        "Key input: motor={} rudder={} keys={:?}",
+                        motor, rudder, self.keys_pressed
+                    );
+                }
                 agent.control.motor = motor;
                 agent.control.rudder = rudder;
                 agent.control.brake = brake;


### PR DESCRIPTION
The user's log shows vel=0.0 and constant position at 120fps — the vehicle doesn't move despite key input being claimed. Add targeted diagnostics to distinguish:

1. Keys not reaching motor (focus issue)
2. Motor set but traction stays zero (common.prm traction_incr issue)
3. Traction non-zero but no velocity (physics/wheel issue)

Spawn log now includes wheel count (visual + physics). A one-shot log fires when motor first transitions from 0 to non-zero, printing the current keys_pressed set.

https://claude.ai/code/session_01EzS4toL8ewZGV6MZHf4Kh8