### PR TITLE
Pick WebGPU/WebGL2 backend at request_adapter, not by probing twice

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -762,53 +762,48 @@ impl ApplicationHandler for WebHandler {
         let init_future = {
             let window_clone = window.clone();
             async move {
-                // Try WebGPU first — it supports compute shaders needed
-                // for RayVoxelTraced terrain. Fall back to WebGL2 which
-                // only supports RayTraced (fragment-only) rendering.
-                //
-                // The adapter request is part of the per-backend probe:
-                // creating a `wgpu::Instance` with `BROWSER_WEBGPU`
-                // succeeds even when the browser has WebGPU disabled —
-                // it's `request_adapter` that returns `None`. Doing the
-                // probe only at instance level meant we picked WebGPU,
-                // then panicked at the unwrap below.
-                async fn try_backend(
-                    backends: wgpu::Backends,
-                    window: Arc<Window>,
-                ) -> Option<(wgpu::Instance, wgpu::Surface<'static>, wgpu::Adapter)>
+                // A single Instance with both backends. The earlier
+                // probe-then-fallback strategy failed in browsers with
+                // WebGPU disabled: probing WebGPU first calls
+                // `canvas.getContext('webgpu')` (which puts the canvas
+                // into "webgpu" mode for its lifetime, even if it
+                // returns null), so the subsequent WebGL2 probe's
+                // `getContext('webgl2')` returned null too. Letting
+                // wgpu pick a backend at `request_adapter` time keeps
+                // the canvas untouched until we know which one we'll
+                // actually use, and the `compatible_surface` hint lets
+                // it select either webgpu or webgl2 cleanly.
+                let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+                    backends: wgpu::Backends::BROWSER_WEBGPU | wgpu::Backends::GL,
+                    ..wgpu::InstanceDescriptor::new_without_display_handle()
+                });
+                let surface = instance
+                    .create_surface(window_clone.clone())
+                    .expect("Failed to create the canvas surface");
+                let adapter = match instance
+                    .request_adapter(&wgpu::RequestAdapterOptions {
+                        power_preference: wgpu::PowerPreference::HighPerformance,
+                        compatible_surface: Some(&surface),
+                        force_fallback_adapter: false,
+                    })
+                    .await
                 {
-                    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-                        backends,
-                        ..wgpu::InstanceDescriptor::new_without_display_handle()
-                    });
-                    let surface = instance.create_surface(window).ok()?;
-                    let adapter = instance
-                        .request_adapter(&wgpu::RequestAdapterOptions {
-                            power_preference: wgpu::PowerPreference::HighPerformance,
-                            compatible_surface: Some(&surface),
-                            force_fallback_adapter: false,
-                        })
-                        .await
-                        .ok()?;
-                    Some((instance, surface, adapter))
-                }
-
-                let (instance, surface, adapter, is_webgpu) = if let Some((i, s, a)) =
-                    try_backend(wgpu::Backends::BROWSER_WEBGPU, window_clone.clone()).await
-                {
-                    log::info!("Using WebGPU backend");
-                    (i, s, a, true)
-                } else if let Some((i, s, a)) =
-                    try_backend(wgpu::Backends::GL, window_clone.clone()).await
-                {
-                    log::info!("WebGPU unavailable, falling back to WebGL2");
-                    (i, s, a, false)
-                } else {
-                    let _ = js_progress_error(
-                        "No GPU adapter available — enable WebGPU or WebGL2 in the browser",
-                    );
-                    panic!("No GPU adapter available");
+                    Ok(a) => a,
+                    Err(e) => {
+                        let msg = format!(
+                            "No GPU adapter available — enable WebGPU or WebGL2 in the browser ({:?})",
+                            e
+                        );
+                        let _ = js_progress_error(&msg);
+                        panic!("{}", msg);
+                    }
                 };
+                let is_webgpu = adapter.get_info().backend == wgpu::Backend::BrowserWebGpu;
+                if is_webgpu {
+                    log::info!("Using WebGPU backend");
+                } else {
+                    log::info!("WebGPU unavailable, using WebGL2");
+                }
 
                 let adapter_limits = adapter.limits();
                 let required_limits = if is_webgpu {

--- a/res/shader/object.wgsl
+++ b/res/shader/object.wgsl
@@ -89,7 +89,11 @@ fn color_vs(
 @group(0) @binding(1) var s_PaletteSampler: sampler;
 @group(1) @binding(1) var t_Palette: texture_2d<f32>;
 
-const c_UnderwaterColor = vec3<f32>(0.0, 0.1, 0.4);
+// Matches the documented fallback water tint from
+// `src/level/mod.rs::load` (`0 => (0.0, 0.0, 200.0), // blue (water)`)
+// and the surface tone in `water.wgsl`. Keeps the water surface and
+// the underwater vehicle tint in the same hue.
+const c_UnderwaterColor = vec3<f32>(0.0, 0.0, 200.0 / 255.0);
 // 1 / e-fold depth in world units. ~30 → ~95% blue at 90 units submerged.
 const c_UnderwaterDepthFactor: f32 = 1.0 / 30.0;
 

--- a/res/shader/water.wgsl
+++ b/res/shader/water.wgsl
@@ -5,7 +5,11 @@
 @group(1) @binding(8) var s_Flood: sampler;
 
 const c_TerrainWater = 0u;
-const c_WaterColor = vec3<f32>(0.0, 0.1, 0.4);
+// Matches the codebase's documented fallback water tone in
+// `src/level/mod.rs::load` (`0 => (0.0, 0.0, 200.0), // blue (water)`),
+// scaled to 0..1. Cleaner medium-blue than the previous teal-leaning
+// `(0.0, 0.1, 0.4)` value.
+const c_WaterColor = vec3<f32>(0.0, 0.0, 200.0 / 255.0);
 
 struct Varyings {
     @builtin(position) clip_pos: vec4<f32>,


### PR DESCRIPTION
The previous fallback scheme created two separate `wgpu::Instance`s in sequence — one with `BROWSER_WEBGPU` and, on failure, one with `GL` — and called `create_surface` on the canvas in each. The first probe calls `canvas.getContext('webgpu')` even when WebGPU is disabled, and that pins the canvas's context type to "webgpu" for its lifetime. The second probe's `getContext('webgl2')` then returns null, the WebGL adapter request fails too, and the panic message reaches the user as "No GPU adapter available" with a stack ending in
`<WebHandler>::resumed::{{closure}}::try_backend::{{closure}}` -> `Instance::request_adapter`.

Switch to a single Instance with both backends and one `create_surface` call. wgpu picks the backend internally at `request_adapter` based on what the canvas can actually provide; we just read `adapter.get_info().backend` afterwards to know whether to take the WebGPU or WebGL2 setup branch.