### PR TITLE
Consistent lighting and FOV

### DIFF
--- a/bin/level/app.rs
+++ b/bin/level/app.rs
@@ -106,11 +106,14 @@ impl LevelView {
             scale: glam::Vec3::new(1.0, -1.0, 1.0),
             proj: match settings.game.camera.projection {
                 config::settings::Projection::Perspective => {
+                    let h = settings.window.size[1] as f32;
+                    let focal = space::DEFAULT_FOCAL_PX;
                     let pf = space::PerspectiveParams {
-                        fovy: 45.0f32.to_radians(),
-                        aspect: settings.window.size[0] as f32 / settings.window.size[1] as f32,
+                        fovy: space::PerspectiveParams::fov_from_focal_px(focal, h),
+                        aspect: settings.window.size[0] as f32 / h,
                         near: depth.0,
                         far: depth.1,
+                        focal_px: Some(focal),
                     };
                     space::Projection::Perspective(pf)
                 }

--- a/bin/level/headless.rs
+++ b/bin/level/headless.rs
@@ -91,12 +91,17 @@ fn make_camera(opts: &SnapshotOptions) -> space::Camera {
         loc: cam_loc,
         rot,
         scale: Vec3::new(1.0, -1.0, 1.0),
-        proj: space::Projection::Perspective(space::PerspectiveParams {
-            fovy: 45.0f32.to_radians(),
-            aspect: opts.width as f32 / opts.height.max(1) as f32,
-            near: 10.0,
-            far: 4000.0,
-        }),
+        proj: {
+            let h = opts.height.max(1) as f32;
+            let focal = space::DEFAULT_FOCAL_PX;
+            space::Projection::Perspective(space::PerspectiveParams {
+                fovy: space::PerspectiveParams::fov_from_focal_px(focal, h),
+                aspect: opts.width as f32 / h,
+                near: 10.0,
+                far: 4000.0,
+                focal_px: Some(focal),
+            })
+        },
     }
 }
 

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -227,8 +227,8 @@ impl Application for ResourceView {
 
             pass.set_pipeline(self.object.pipelines.select(render::PipelineKind::Main));
             pass.set_bind_group(0, &self.global.bind_group, &[]);
-            pass.set_bind_group(1, &self.object.bind_group, &[]);
-            pass.set_bind_group(2, &self.object.surface_bind_group, &[]);
+            pass.set_bind_group(1, &self.object.surface_bind_group, &[]);
+            pass.set_bind_group(2, &self.object.bind_group, &[]);
 
             batcher.draw(&mut pass);
         }

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -35,6 +35,7 @@ impl ResourceView {
                 aspect: settings.window.size[0] as f32 / settings.window.size[1] as f32,
                 near: 5.0,
                 far: 400.0,
+                focal_px: None,
             }),
         };
 

--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -13,6 +13,7 @@ pub struct ResourceView {
     car: Option<CarContext>,
     global: render::global::Context,
     object: render::object::Context,
+    _stub_surface: render::object::StubSurface,
     transform: space::Transform,
     camera: space::Camera,
     rotation: (f32, f32),
@@ -40,7 +41,14 @@ impl ResourceView {
         info!("Initializing the render");
         let pal_data = level::read_palette(settings.open_palette(), None);
         let global = render::global::Context::new(gfx, None);
-        let object = render::object::Context::new(gfx, camera.front_face(), &pal_data, &global);
+        let stub_surface = render::object::create_stub_surface(&gfx.device);
+        let object = render::object::Context::new(
+            gfx,
+            camera.front_face(),
+            &pal_data,
+            &global,
+            stub_surface.inputs(),
+        );
 
         let (model, car) = if let Some(path_str) = path {
             info!("Loading model {}", path_str);
@@ -84,6 +92,7 @@ impl ResourceView {
             car,
             global,
             object,
+            _stub_surface: stub_surface,
             transform: space::Transform {
                 scale: 1.0,
                 disp: glam::Vec3::Z,
@@ -218,6 +227,7 @@ impl Application for ResourceView {
             pass.set_pipeline(self.object.pipelines.select(render::PipelineKind::Main));
             pass.set_bind_group(0, &self.global.bind_group, &[]);
             pass.set_bind_group(1, &self.object.bind_group, &[]);
+            pass.set_bind_group(2, &self.object.surface_bind_group, &[]);
 
             batcher.draw(&mut pass);
         }

--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -396,11 +396,14 @@ impl Game {
             scale: Vec3::new(1.0, -1.0, 1.0),
             proj: match settings.game.camera.projection {
                 config::settings::Projection::Perspective => {
+                    let h = settings.window.size[1] as f32;
+                    let focal = space::DEFAULT_FOCAL_PX;
                     let pf = space::PerspectiveParams {
-                        fovy: 45.0f32.to_radians(),
-                        aspect: settings.window.size[0] as f32 / settings.window.size[1] as f32,
+                        fovy: space::PerspectiveParams::fov_from_focal_px(focal, h),
+                        aspect: settings.window.size[0] as f32 / h,
                         near: depth.0,
                         far: depth.1,
+                        focal_px: Some(focal),
                     };
                     space::Projection::Perspective(pf)
                 }

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -363,12 +363,13 @@ impl WebApp {
     fn load_settings() -> settings::Settings {
         let mut s: settings::Settings =
             ron::de::from_str(Self::SETTINGS_RON).expect("Failed to parse embedded settings.ron");
-        // Apply a 0.75x vertical scale to the web build. True 3D
-        // heightmap rendering otherwise looks taller than original
-        // Vangers (which projected the heightmap as a flat shaded
-        // plane); 0.75 brings the silhouette much closer to the 1998
-        // look without flattening the terrain.
-        s.game.geometry.height = (s.game.geometry.height * 3) / 4;
+        // Vertical heightmap scale for the web build. True 3D heightmap
+        // rendering looks taller than original Vangers (which projected
+        // the heightmap as a flat shaded plane); 0xA0/0x100 = 0.625
+        // brings the silhouette close to the 1998 look without
+        // flattening it. Hard-coded here so native + the FFI keep the
+        // settings.ron default (0x100).
+        s.game.geometry.height = 0xA0;
         s
     }
 

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -361,7 +361,15 @@ impl WebApp {
     const SETTINGS_RON: &str = include_str!("../../config/settings.template.ron");
 
     fn load_settings() -> settings::Settings {
-        ron::de::from_str(Self::SETTINGS_RON).expect("Failed to parse embedded settings.ron")
+        let mut s: settings::Settings =
+            ron::de::from_str(Self::SETTINGS_RON).expect("Failed to parse embedded settings.ron");
+        // Apply a 0.75x vertical scale to the web build. True 3D
+        // heightmap rendering otherwise looks taller than original
+        // Vangers (which projected the heightmap as a flat shaded
+        // plane); 0.75 brings the silhouette much closer to the 1998
+        // look without flattening the terrain.
+        s.game.geometry.height = (s.game.geometry.height * 3) / 4;
+        s
     }
 
     fn new(gfx: &GraphicsContext, is_webgpu: bool) -> Self {

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -62,6 +62,37 @@ extern "C" {
     fn js_selected_level() -> Result<JsValue, JsValue>;
 }
 
+/// Khox is the smallest stock level (2048 × 8192) and the only one
+/// that fits in an 8192-px texture. Used as the fallback when the
+/// adapter can't allocate a 16384-px texture for the larger levels.
+const SMALL_LEVEL: &str = "khox";
+
+/// Largest map dimension the stock big levels expect (Fostral, Glorx,
+/// Necross, etc. are 2048 × 16384). If the adapter can't go this high
+/// we have to fall back to a smaller level.
+const LARGE_LEVEL_TEXTURE_DIM: u32 = 16384;
+
+/// If the adapter can't allocate a [`LARGE_LEVEL_TEXTURE_DIM`] texture,
+/// override the selection to [`SMALL_LEVEL`] and tell the user why.
+/// Returns the (possibly substituted) level id.
+fn pick_level_for_adapter(requested: String, max_texture_dim: u32) -> String {
+    if max_texture_dim >= LARGE_LEVEL_TEXTURE_DIM || requested == SMALL_LEVEL {
+        return requested;
+    }
+    let msg = format!(
+        "GPU caps texture dimension at {} px; the big levels need {} px. Loading {} instead.",
+        max_texture_dim, LARGE_LEVEL_TEXTURE_DIM, SMALL_LEVEL
+    );
+    log::warn!(
+        "Substituting '{}' for requested level '{}' ({})",
+        SMALL_LEVEL,
+        requested,
+        msg
+    );
+    let _ = js_progress_error(&msg);
+    SMALL_LEVEL.to_string()
+}
+
 /// Read the selected level id from JS (set by the level picker UI),
 /// falling back to the URL fragment `#level=<id>`, then to
 /// [`DEFAULT_LEVEL`].
@@ -983,7 +1014,9 @@ impl ApplicationHandler for WebHandler {
 
             // Best-effort fetch of release data. On any failure we
             // fall back to the procedural test level.
-            let level_id = selected_level_id();
+            let requested = selected_level_id();
+            let level_id =
+                pick_level_for_adapter(requested, adapter.limits().max_texture_dimension_2d);
             log::info!("Selected level: {}", level_id);
             let vfs_level = fetch_release_level(&level_id).await;
 

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -401,12 +401,17 @@ impl WebApp {
             loc: glam::vec3(0.0, 0.0, 200.0),
             rot: glam::Quat::IDENTITY,
             scale: glam::vec3(1.0, -1.0, 1.0),
-            proj: space::Projection::Perspective(space::PerspectiveParams {
-                fovy: 45.0f32.to_radians(),
-                aspect: gfx.screen_size.width as f32 / gfx.screen_size.height.max(1) as f32,
-                near: cam_config.depth_range.0,
-                far: cam_config.depth_range.1,
-            }),
+            proj: {
+                let h = gfx.screen_size.height.max(1) as f32;
+                let focal = space::DEFAULT_FOCAL_PX;
+                space::Projection::Perspective(space::PerspectiveParams {
+                    fovy: space::PerspectiveParams::fov_from_focal_px(focal, h),
+                    aspect: gfx.screen_size.width as f32 / h,
+                    near: cam_config.depth_range.0,
+                    far: cam_config.depth_range.1,
+                    focal_px: Some(focal),
+                })
+            },
         };
 
         // On WebGPU, override terrain to RayVoxelTraced (needs compute).

--- a/config/settings.template.ron
+++ b/config/settings.template.ron
@@ -13,8 +13,8 @@
 		),
 		camera: (
 			angle: 60,
-			height: 320,
-			offset: 40,
+			height: 240,
+			offset: 0,
 			speed: 1,
 			depth_range: (10, 2000),
 			projection: Perspective, // can be "Flat" or "Perspective"

--- a/lib/ffi/src/lib.rs
+++ b/lib/ffi/src/lib.rs
@@ -295,6 +295,7 @@ pub extern "C" fn rv_init(desc: InitDescriptor) -> Option<ptr::NonNull<Context>>
                 near: 1.0,
                 far: 100.0,
                 fovy: 45.0f32.to_radians(),
+                focal_px: None,
             }),
         },
         objects_palette,
@@ -335,6 +336,7 @@ pub extern "C" fn rv_camera_init(ctx: &mut Context, desc: CameraDescription) {
         near: desc.near,
         far: desc.far,
         fovy: desc.fov.to_radians(),
+        focal_px: None,
     });
 }
 

--- a/res/shader/object.wgsl
+++ b/res/shader/object.wgsl
@@ -14,10 +14,6 @@ struct Geometry {
     @location(3) pos_scale: vec4<f32>,
     @location(4) orientation: vec4<f32>,
     @location(6) body_and_color_id: vec2<u32>,
-    // Per-instance water level (world Z), populated CPU-side from the
-    // flood map at the vehicle's xy. Negative means "no water here", so
-    // the underwater tint never kicks in.
-    @location(7) water_level: f32,
 };
 
 struct BodyGeometry {
@@ -55,7 +51,6 @@ struct Varyings {
     @location(0) palette_range: vec2<f32>,
     @location(1) position: vec3<f32>,
     @location(2) normal: vec3<f32>,
-    @location(3) water_level: f32,
 };
 
 @vertex
@@ -81,7 +76,6 @@ fn color_vs(
         palette_range,
         world,
         world_normal,
-        geo.water_level,
     );
 }
 
@@ -89,10 +83,53 @@ fn color_vs(
 @group(0) @binding(1) var s_PaletteSampler: sampler;
 @group(1) @binding(1) var t_Palette: texture_2d<f32>;
 
+// Surface bindings, shared with the terrain pipeline so we can decide
+// per-fragment whether the vehicle is over a water cell, and at what
+// world Z that cell's water surface sits.
+struct SurfaceConstants {
+    texture_scale: vec4<f32>,
+    terrain_bits: u32,
+    delta_mode: u32,
+};
+@group(2) @binding(0) var<uniform> u_Surface: SurfaceConstants;
+@group(2) @binding(2) var t_Terrain: texture_2d<u32>;
+@group(2) @binding(4) var t_Flood: texture_2d<f32>;
+
+const c_DoubleLevelMask: u32 = 64u;
+const c_WaterTerrain: u32 = 0u;
+
+fn get_terrain_type(meta_data: u32) -> u32 {
+    let bits = u_Surface.terrain_bits;
+    return (meta_data >> (bits & 0xFu)) & (bits >> 4u);
+}
+
+// Returns the cell's low-layer terrain type at the given world xy. The
+// "low" layer matches what `physics::mod::collide` uses for water
+// detection, so vehicles in dual-level tunnel cells with a non-water
+// floor stay dry.
+fn low_terrain_type_at(world_xy: vec2<f32>) -> u32 {
+    let wrapped = world_xy - floor(world_xy / u_Surface.texture_scale.xy) * u_Surface.texture_scale.xy;
+    let tci = vec2<i32>(wrapped);
+    let data = textureLoad(t_Terrain, vec2<i32>(tci.x / 2, tci.y), 0);
+    if ((data.y & c_DoubleLevelMask) != 0u) {
+        return get_terrain_type(data.y);
+    }
+    let subdata = select(data.xy, data.zw, (tci.x & 1) != 0);
+    return get_terrain_type(subdata.y);
+}
+
+fn flood_z_at(world_y: f32) -> f32 {
+    let dim = textureDimensions(t_Flood);
+    let section_y = u_Surface.texture_scale.y / f32(dim.x);
+    let row_raw = i32(floor(world_y / section_y));
+    let row = ((row_raw % i32(dim.x)) + i32(dim.x)) % i32(dim.x);
+    let raw = textureLoad(t_Flood, vec2<i32>(row, 0), 0).x;
+    return raw * u_Surface.texture_scale.z;
+}
+
 // Matches the documented fallback water tint from
 // `src/level/mod.rs::load` (`0 => (0.0, 0.0, 200.0), // blue (water)`)
-// and the surface tone in `water.wgsl`. Keeps the water surface and
-// the underwater vehicle tint in the same hue.
+// and the surface tone in `water.wgsl`.
 const c_UnderwaterColor = vec3<f32>(0.0, 0.0, 200.0 / 255.0);
 // 1 / e-fold depth in world units. ~30 → ~95% blue at 90 units submerged.
 const c_UnderwaterDepthFactor: f32 = 1.0 / 30.0;
@@ -107,13 +144,19 @@ fn color_fs(in: Varyings, @builtin(front_facing) is_front: bool) -> @location(0)
     let tc = clamp(tc_raw, in.palette_range.x + 0.5, in.palette_range.y - 0.5) / 256.0;
     var color = textureSample(t_Palette, s_PaletteSampler, vec2<f32>(tc, 0.5));
 
-    // Underwater tint: vehicles are not aware of the water palette, so
-    // tint per fragment by the depth below the per-instance water level.
-    // Terrain has the water texture baked into its palette already.
-    let submersion = in.water_level - in.position.z;
-    if (submersion > 0.0) {
-        let mix_amount = 1.0 - exp(-submersion * c_UnderwaterDepthFactor);
-        color = vec4<f32>(mix(color.rgb, c_UnderwaterColor, mix_amount), color.a);
+    // Per-fragment underwater tint: only over cells whose low terrain
+    // type is water, and only for fragments whose world Z is below the
+    // per-Y flood level. Half-submerged vehicles get the tint on the
+    // submerged half only. The texture_scale.x > 0 guard is for the
+    // standalone model viewer, which binds a stub surface and disables
+    // the check by zeroing the map size.
+    if (u_Surface.texture_scale.x > 0.0
+        && low_terrain_type_at(in.position.xy) == c_WaterTerrain) {
+        let submersion = flood_z_at(in.position.y) - in.position.z;
+        if (submersion > 0.0) {
+            let mix_amount = 1.0 - exp(-submersion * c_UnderwaterDepthFactor);
+            color = vec4<f32>(mix(color.rgb, c_UnderwaterColor, mix_amount), color.a);
+        }
     }
     return color;
 }

--- a/res/shader/object.wgsl
+++ b/res/shader/object.wgsl
@@ -1,4 +1,4 @@
-//!include body.inc globals.inc quat.inc shadow.inc
+//!include body.inc globals.inc quat.inc shadow.inc surface.inc
 
 const c_BodyColorId: u32 = 1u;
 
@@ -8,7 +8,17 @@ struct Storage {
 
 @group(0) @binding(2) var<storage, read> s_Storage: Storage;
 
-@group(1) @binding(0) var t_ColorTable: texture_2d<u32>;
+// Per-Y water level. Lives on the same bind group as the surface
+// uniforms / terrain meta (@group(1)) — these are all bound from the
+// terrain pipeline, or from the model-viewer stub.
+@group(1) @binding(4) var t_Flood: texture_2d<f32>;
+
+// Object-local resources: per-color lookup, palette texture, sampler.
+@group(2) @binding(0) var t_ColorTable: texture_2d<u32>;
+@group(2) @binding(1) var t_Palette: texture_2d<f32>;
+// Palette sampler comes from globals — this group's binding 2 is the
+// `NonFiltering` colour-table sampler used only by the vertex stage.
+@group(0) @binding(1) var s_PaletteSampler: sampler;
 
 struct Geometry {
     @location(3) pos_scale: vec4<f32>,
@@ -79,45 +89,13 @@ fn color_vs(
     );
 }
 
-
-@group(0) @binding(1) var s_PaletteSampler: sampler;
-@group(1) @binding(1) var t_Palette: texture_2d<f32>;
-
-// Surface bindings, shared with the terrain pipeline so we can decide
-// per-fragment whether the vehicle is over a water cell, and at what
-// world Z that cell's water surface sits.
-struct SurfaceConstants {
-    texture_scale: vec4<f32>,
-    terrain_bits: u32,
-    delta_mode: u32,
-};
-@group(2) @binding(0) var<uniform> u_Surface: SurfaceConstants;
-@group(2) @binding(2) var t_Terrain: texture_2d<u32>;
-@group(2) @binding(4) var t_Flood: texture_2d<f32>;
-
-const c_DoubleLevelMask: u32 = 64u;
 const c_WaterTerrain: u32 = 0u;
 
-fn get_terrain_type(meta_data: u32) -> u32 {
-    let bits = u_Surface.terrain_bits;
-    return (meta_data >> (bits & 0xFu)) & (bits >> 4u);
-}
-
-// Returns the cell's low-layer terrain type at the given world xy. The
-// "low" layer matches what `physics::mod::collide` uses for water
-// detection, so vehicles in dual-level tunnel cells with a non-water
-// floor stay dry.
-fn low_terrain_type_at(world_xy: vec2<f32>) -> u32 {
-    let wrapped = world_xy - floor(world_xy / u_Surface.texture_scale.xy) * u_Surface.texture_scale.xy;
-    let tci = vec2<i32>(wrapped);
-    let data = textureLoad(t_Terrain, vec2<i32>(tci.x / 2, tci.y), 0);
-    if ((data.y & c_DoubleLevelMask) != 0u) {
-        return get_terrain_type(data.y);
-    }
-    let subdata = select(data.xy, data.zw, (tci.x & 1) != 0);
-    return get_terrain_type(subdata.y);
-}
-
+// Per-Y flood map sample, scaled into world Z. Mirrors the formula in
+// `water.wgsl::main_vs`. Sampling a 1×1 stub texture (model viewer)
+// returns 0; a stub `texture_scale.z = 0` then keeps the resulting
+// water Z at 0, which makes the fragment-side submersion check a
+// no-op for vehicles above ground.
 fn flood_z_at(world_y: f32) -> f32 {
     let dim = textureDimensions(t_Flood);
     let section_y = u_Surface.texture_scale.y / f32(dim.x);
@@ -144,19 +122,16 @@ fn color_fs(in: Varyings, @builtin(front_facing) is_front: bool) -> @location(0)
     let tc = clamp(tc_raw, in.palette_range.x + 0.5, in.palette_range.y - 0.5) / 256.0;
     var color = textureSample(t_Palette, s_PaletteSampler, vec2<f32>(tc, 0.5));
 
-    // Per-fragment underwater tint: only over cells whose low terrain
-    // type is water, and only for fragments whose world Z is below the
-    // per-Y flood level. Half-submerged vehicles get the tint on the
-    // submerged half only. The texture_scale.x > 0 guard is for the
-    // standalone model viewer, which binds a stub surface and disables
-    // the check by zeroing the map size.
-    if (u_Surface.texture_scale.x > 0.0
-        && low_terrain_type_at(in.position.xy) == c_WaterTerrain) {
-        let submersion = flood_z_at(in.position.y) - in.position.z;
-        if (submersion > 0.0) {
-            let mix_amount = 1.0 - exp(-submersion * c_UnderwaterDepthFactor);
-            color = vec4<f32>(mix(color.rgb, c_UnderwaterColor, mix_amount), color.a);
-        }
+    // Per-fragment underwater tint. All texture fetches happen at
+    // uniform top level — only the *blend* is conditional. The cell's
+    // low terrain type comes from the shared surface helper; the per-Y
+    // water level from the flood map.
+    let surface = get_surface(in.position.xy);
+    let water_z = flood_z_at(in.position.y);
+    let submersion = water_z - in.position.z;
+    if (surface.low_type == c_WaterTerrain && submersion > 0.0) {
+        let mix_amount = 1.0 - exp(-submersion * c_UnderwaterDepthFactor);
+        color = vec4<f32>(mix(color.rgb, c_UnderwaterColor, mix_amount), color.a);
     }
     return color;
 }

--- a/res/shader/shadow.inc.wgsl
+++ b/res/shader/shadow.inc.wgsl
@@ -5,7 +5,12 @@
 
 const c_Ambient: f32 = 0.25;
 
-fn fetch_shadow(pos: vec3<f32>) -> f32 {
+// Raw 4-tap PCF visibility in [0, 1]. Unlike `fetch_shadow`, this does
+// NOT mix in the ambient floor — the caller composes shadow visibility
+// with surface lighting (e.g. cosine diffuse) and adds ambient at the
+// end. Used by terrain shading, where the cosine term needs the raw
+// occlusion value rather than a pre-mixed brightness.
+fn fetch_shadow_visibility(pos: vec3<f32>) -> f32 {
     let flip_correction = vec2<f32>(1.0, -1.0);
 
     if (u_Globals.light_view_proj[3][3] == 0.0) {
@@ -20,17 +25,17 @@ fn fetch_shadow(pos: vec3<f32>) -> f32 {
 
     let light_local = 0.5 * (homogeneous_coords.xy * flip_correction / homogeneous_coords.w + 1.0);
     let depth = homogeneous_coords.z / homogeneous_coords.w;
-    // 4-tap PCF: sample at the four corners of the texel and average.
-    // The hardware comparison sampler does linear filtering between the
-    // depth comparisons inside each tap, so the resulting kernel is
-    // effectively a 3×3 box blur for the cost of 4 samples — a clear
-    // step up from the previous single-tap aliased shadow edges.
     let texel = vec2<f32>(1.0) / vec2<f32>(textureDimensions(t_Shadow));
     var shadow = 0.0;
     shadow += textureSampleCompareLevel(t_Shadow, s_Shadow, light_local + texel * vec2<f32>(-0.5, -0.5), depth);
     shadow += textureSampleCompareLevel(t_Shadow, s_Shadow, light_local + texel * vec2<f32>( 0.5, -0.5), depth);
     shadow += textureSampleCompareLevel(t_Shadow, s_Shadow, light_local + texel * vec2<f32>(-0.5,  0.5), depth);
     shadow += textureSampleCompareLevel(t_Shadow, s_Shadow, light_local + texel * vec2<f32>( 0.5,  0.5), depth);
-    shadow *= 0.25;
-    return mix(c_Ambient, 1.0, shadow);
+    return 0.25 * shadow;
+}
+
+// Convenience wrapper: visibility mixed with the ambient floor. Object
+// and water shaders use this directly as a brightness multiplier.
+fn fetch_shadow(pos: vec3<f32>) -> f32 {
+    return mix(c_Ambient, 1.0, fetch_shadow_visibility(pos));
 }

--- a/res/shader/terrain/color.inc.wgsl
+++ b/res/shader/terrain/color.inc.wgsl
@@ -71,20 +71,37 @@ fn evaluate_color_id(ty: u32, pos: vec3<f32>, lit_factor: f32) -> f32 {
     return evaluate_palette(ty, lit_factor * tmp);
 }
 
-// Original Vangers baked diffuse + altitude shading into the palette
-// gradient and into the colormap itself, with `evaluate_color_id`
-// preserved here for the scatter compute that still needs a 0..1 ramp.
+// Two lighting paths, switched at runtime via `u_Locals.lighting_flags.x`:
+//   0 = baked    — the original Vangers approach: lighting (cell-to-cell
+//                  diff, altitude attenuation, shadow) is folded into a
+//                  brightness value 0..1, which is then mapped to the
+//                  per-terrain palette gradient. Faithful to the 1998
+//                  look but the palette gradient itself acts as the
+//                  lighting ramp, so our shadow map mostly compresses
+//                  the gradient instead of darkening the surface.
+//   1 = unbaked  — sample the brightest entry of the terrain's gradient
+//                  as the unshaded albedo, then apply shadow * cosine
+//                  diffuse explicitly: base * (ambient + (1-ambient) *
+//                  visibility * n·l). Real shadow contribution; flat
+//                  surfaces no longer get the gradient's mid-tone for
+//                  free.
 //
-// For the live render we now use the brightest entry of each terrain's
-// gradient as the unshaded base color, then apply our own shadow +
-// cosine diffuse on top. This gives consistent lighting across all
-// surface orientations and lets the shadow map actually darken
-// terrain (the previous approach mostly amplified the baked gradient).
+// The toggle lives on the terrain "Locals" uniform so it costs one
+// branch on a uniform value (no dynamic divergence), and lets us A/B
+// the two looks at runtime.
 fn evaluate_color(ty: u32, pos: vec3<f32>, shadow_visibility: f32) -> vec4<f32> {
     let terr = vec4<f32>(textureLoad(t_Table, vec2<i32>(i32(ty), 0), 0));
-    let base_id = (terr.w - 0.5) / 256.0;
-    // textureSampleLevel — the caller may be inside non-uniform control
-    // flow (voxel-draw early-outs).
+    if (u_Locals.lighting_flags.x == 0u) {
+        let lit_factor = mix(c_TerrainAmbient, 1.0, shadow_visibility);
+        let color_id = evaluate_color_id(ty, pos, lit_factor);
+        return textureSampleLevel(t_Palette, s_Palette, vec2<f32>(color_id, 0.5), 0.0);
+    }
+
+    // Brightest gradient entry for this terrain. terr.w is the
+    // inclusive max palette index (see `TerrainConfig::colors`), so the
+    // texel center sits at (terr.w + 0.5) / 256 — same convention as
+    // `evaluate_palette` for value=1.
+    let base_id = (terr.w + 0.5) / 256.0;
     let base = textureSampleLevel(t_Palette, s_Palette, vec2<f32>(base_id, 0.5), 0.0);
 
     // Surface normal from a 2-cell-wide central-difference height

--- a/res/shader/terrain/color.inc.wgsl
+++ b/res/shader/terrain/color.inc.wgsl
@@ -10,6 +10,12 @@
 const c_HorFactor: f32 = 0.5; //H_CORRECTION
 const c_DiffuseScale: f32 = 8.0;
 const c_ShadowDepthScale: f32 = 0.6; //~ 2.0 / 3.0;
+// Floor brightness applied to terrain in deep shadow. Matches the
+// `c_Ambient` used by `fetch_shadow` so unobstructed surfaces and
+// fully-shadowed ones meet at the same darkness when the cosine term
+// is zero. Defined here because `scatter.wgsl` includes color.inc but
+// not shadow.inc, so it can't pull in `c_Ambient`.
+const c_TerrainAmbient: f32 = 0.25;
 
 // see `RenderPrepare` in `land.cpp` for the original game logic
 
@@ -65,11 +71,31 @@ fn evaluate_color_id(ty: u32, pos: vec3<f32>, lit_factor: f32) -> f32 {
     return evaluate_palette(ty, lit_factor * tmp);
 }
 
-fn evaluate_color(ty: u32, pos: vec3<f32>, lit_factor: f32) -> vec4<f32> {
-    let color_id = evaluate_color_id(ty, pos, lit_factor);
-    // textureSampleLevel keeps the call valid even when the caller is
-    // inside non-uniform control flow (e.g. ray-cast early-outs in the
-    // voxel draw shader). The palette has a single mip level, so an
-    // explicit LOD of 0 matches the implicit-derivative result.
-    return textureSampleLevel(t_Palette, s_Palette, vec2<f32>(color_id, 0.5), 0.0);
+// Original Vangers baked diffuse + altitude shading into the palette
+// gradient and into the colormap itself, with `evaluate_color_id`
+// preserved here for the scatter compute that still needs a 0..1 ramp.
+//
+// For the live render we now use the brightest entry of each terrain's
+// gradient as the unshaded base color, then apply our own shadow +
+// cosine diffuse on top. This gives consistent lighting across all
+// surface orientations and lets the shadow map actually darken
+// terrain (the previous approach mostly amplified the baked gradient).
+fn evaluate_color(ty: u32, pos: vec3<f32>, shadow_visibility: f32) -> vec4<f32> {
+    let terr = vec4<f32>(textureLoad(t_Table, vec2<i32>(i32(ty), 0), 0));
+    let base_id = (terr.w - 0.5) / 256.0;
+    // textureSampleLevel — the caller may be inside non-uniform control
+    // flow (voxel-draw early-outs).
+    let base = textureSampleLevel(t_Palette, s_Palette, vec2<f32>(base_id, 0.5), 0.0);
+
+    // Surface normal from a 2-cell-wide central-difference height
+    // gradient. The gradient measures Δheight over Δxy = 2, so
+    // dheight/dxy = gradient * 0.5 — flipping signs gives the upward
+    // surface normal.
+    let gradient = get_surface_gradient(pos);
+    let normal = normalize(vec3<f32>(-0.5 * gradient.x, -0.5 * gradient.y, 1.0));
+    let light_dir = normalize(u_Globals.light_pos.xyz - pos * u_Globals.light_pos.w);
+    let n_dot_l = max(0.0, dot(normal, light_dir));
+
+    let modulation = c_TerrainAmbient + (1.0 - c_TerrainAmbient) * shadow_visibility * n_dot_l;
+    return vec4<f32>(base.rgb * modulation, base.a);
 }

--- a/res/shader/terrain/color.inc.wgsl
+++ b/res/shader/terrain/color.inc.wgsl
@@ -67,5 +67,9 @@ fn evaluate_color_id(ty: u32, pos: vec3<f32>, lit_factor: f32) -> f32 {
 
 fn evaluate_color(ty: u32, pos: vec3<f32>, lit_factor: f32) -> vec4<f32> {
     let color_id = evaluate_color_id(ty, pos, lit_factor);
-    return textureSample(t_Palette, s_Palette, vec2<f32>(color_id, 0.5));
+    // textureSampleLevel keeps the call valid even when the caller is
+    // inside non-uniform control flow (e.g. ray-cast early-outs in the
+    // voxel draw shader). The palette has a single mip level, so an
+    // explicit LOD of 0 matches the implicit-derivative result.
+    return textureSampleLevel(t_Palette, s_Palette, vec2<f32>(color_id, 0.5), 0.0);
 }

--- a/res/shader/terrain/locals.inc.wgsl
+++ b/res/shader/terrain/locals.inc.wgsl
@@ -6,6 +6,7 @@ struct Locals {
     sample_range: vec4<f32>,     // XY = X range, ZW = y range
     fog_color: vec4<f32>,
     fog_params: vec4<f32>,       // X=near, Y = far
+    lighting_flags: vec4<u32>,   // X = 0 baked / 1 unbaked diffuse
 };
 @group(1) @binding(1) var<uniform> u_Locals: Locals;
 

--- a/res/shader/terrain/paint.wgsl
+++ b/res/shader/terrain/paint.wgsl
@@ -48,7 +48,7 @@ fn vertex(
 
 @fragment
 fn fragment(in: Varyings) -> @location(0) vec4<f32> {
-    let lit_factor = fetch_shadow(in.plane_pos);
-    let terrain_color = evaluate_color(in.ty, in.world_pos, lit_factor);
+    let visibility = fetch_shadow_visibility(in.plane_pos);
+    let terrain_color = evaluate_color(in.ty, in.world_pos, visibility);
     return apply_fog(terrain_color, in.plane_pos.xy);
 }

--- a/res/shader/terrain/ray.wgsl
+++ b/res/shader/terrain/ray.wgsl
@@ -161,8 +161,8 @@ fn cast_ray_to_map(base: vec3<f32>, dir: vec3<f32>) -> CastPoint {
     return pt;
 }
 
-fn color_point(pt: CastPoint, lit_factor: f32) -> vec4<f32> {
-    return evaluate_color(pt.ty, pt.pos, lit_factor);
+fn color_point(pt: CastPoint, visibility: f32) -> vec4<f32> {
+    return evaluate_color(pt.ty, pt.pos, visibility);
 }
 
 struct RayInput {
@@ -204,8 +204,8 @@ fn ray_color(in: RayInput) -> FragOutput {
     let view = normalize(sp_far_world - sp_near_world);
     let pt = cast_ray_to_map(sp_near_world, view);
 
-    let lit_factor = fetch_shadow(pt.pos);
-    var frag_color = color_point(pt, lit_factor);
+    let visibility = fetch_shadow_visibility(pt.pos);
+    var frag_color = color_point(pt, visibility);
 
     let target_ndc = u_Globals.view_proj * vec4<f32>(pt.pos, 1.0);
     let depth = target_ndc.z / target_ndc.w;

--- a/res/shader/terrain/voxel-draw.wgsl
+++ b/res/shader/terrain/voxel-draw.wgsl
@@ -251,8 +251,8 @@ fn draw_color(@builtin(position) frag_coord: vec4<f32>) -> FragOutput {
         return FragOutput(u_Locals.fog_color, 1.0);
     }
 
-    let lit_factor = fetch_shadow(pt.pos);
-    let frag_color = evaluate_color(pt.ty, pt.pos, lit_factor);
+    let visibility = fetch_shadow_visibility(pt.pos);
+    let frag_color = evaluate_color(pt.ty, pt.pos, visibility);
     let actual_color = mix(frag_color, debug_color, debug_color.a);
 
     let target_ndc = u_Globals.view_proj * vec4<f32>(pt.pos, 1.0);

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -568,8 +568,8 @@ impl Render {
 
             pass.push_debug_group("vehicles");
             pass.set_pipeline(&self.object.pipelines.shadow);
-            pass.set_bind_group(1, &self.object.bind_group, &[]);
-            pass.set_bind_group(2, &self.object.surface_bind_group, &[]);
+            pass.set_bind_group(1, &self.object.surface_bind_group, &[]);
+            pass.set_bind_group(2, &self.object.bind_group, &[]);
             batcher.draw(&mut pass);
             pass.pop_debug_group();
         }
@@ -640,8 +640,8 @@ impl Render {
 
             pass.push_debug_group("vehicles");
             pass.set_pipeline(&self.object.pipelines.main);
-            pass.set_bind_group(1, &self.object.bind_group, &[]);
-            pass.set_bind_group(2, &self.object.surface_bind_group, &[]);
+            pass.set_bind_group(1, &self.object.surface_bind_group, &[]);
+            pass.set_bind_group(2, &self.object.bind_group, &[]);
             batcher.draw(&mut pass);
             pass.pop_debug_group();
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -283,52 +283,6 @@ impl Batcher {
             .push(instance);
     }
 
-    /// Fill in `Instance::water_level` from the level's flood map for
-    /// every queued instance. Must be called before `prepare`, otherwise
-    /// the instance buffer ships the default `f32::NEG_INFINITY`
-    /// (no-water sentinel) and the underwater tint never kicks in.
-    pub fn set_water_levels(&mut self, level: &level::Level) {
-        let flood_count = level.flood_map.len();
-        if flood_count == 0 {
-            return;
-        }
-        let section_y = level.size.1 as f32 / flood_count as f32;
-        // Matches the water shader's R8Unorm sampling: byte/255 * height.
-        let z_scale = level.geometry.height as f32 / 255.0;
-        let compute = |i: &mut object::Instance| {
-            let xy = i.world_xy();
-            // Gate the tint on the cell actually being water-type —
-            // otherwise tunnels (dual-level cells with a non-water floor)
-            // tint blue because the vehicle's z naturally sits below the
-            // per-Y flood level. Mirrors the water-cell pattern in
-            // `physics::mod::collide`.
-            let coord = (xy[0].floor() as i32, xy[1].floor() as i32);
-            let is_water = matches!(
-                level.get(coord),
-                level::Texel::Single(level::Point(_, 0))
-                    | level::Texel::Dual {
-                        low: level::Point(_, 0),
-                        ..
-                    }
-            );
-            if !is_water {
-                i.set_water_level(f32::NEG_INFINITY);
-                return;
-            }
-            let row = (xy[1] / section_y).floor() as i32;
-            let idx = row.rem_euclid(flood_count as i32) as usize;
-            i.set_water_level(level.flood_map[idx] as f32 * z_scale);
-        };
-        for arr in self.instances.values_mut() {
-            for inst in arr.data.iter_mut() {
-                compute(inst);
-            }
-        }
-        for inst in self.debug_instances.iter_mut() {
-            compute(inst);
-        }
-    }
-
     pub fn add_model(
         &mut self,
         model: &model::VisualModel,
@@ -483,8 +437,6 @@ impl Render {
 
         info!("Creating global context...");
         let global = global::Context::new(gfx, shadow.as_ref().map(|shadow| &shadow.view));
-        info!("Creating object context...");
-        let object = object::Context::new(gfx, front_face, object_palette, &global);
         info!("Creating terrain context...");
         let terrain = terrain::Context::new(
             gfx,
@@ -493,6 +445,25 @@ impl Render {
             &global,
             &settings.terrain,
             &settings.light.shadow.terrain,
+        );
+        info!("Creating object context...");
+        let terrain_view = terrain
+            .terrain_texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let flood_view = terrain
+            .flood
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let object = object::Context::new(
+            gfx,
+            front_face,
+            object_palette,
+            &global,
+            object::SurfaceInputs {
+                uniform_buf: &terrain.surface_uni_buf,
+                terrain_view: &terrain_view,
+                flood_view: &flood_view,
+            },
         );
         info!("Creating water context...");
         let water = water::Context::new(&gfx.device, &settings.water, &global, &terrain);
@@ -548,7 +519,6 @@ impl Render {
         queue: &wgpu::Queue,
     ) {
         profiling::scope!("draw_world");
-        batcher.set_water_levels(level);
         batcher.prepare(device);
         self.terrain.update_dirty(encoder, level, device);
 
@@ -599,6 +569,7 @@ impl Render {
             pass.push_debug_group("vehicles");
             pass.set_pipeline(&self.object.pipelines.shadow);
             pass.set_bind_group(1, &self.object.bind_group, &[]);
+            pass.set_bind_group(2, &self.object.surface_bind_group, &[]);
             batcher.draw(&mut pass);
             pass.pop_debug_group();
         }
@@ -670,6 +641,7 @@ impl Render {
             pass.push_debug_group("vehicles");
             pass.set_pipeline(&self.object.pipelines.main);
             pass.set_bind_group(1, &self.object.bind_group, &[]);
+            pass.set_bind_group(2, &self.object.surface_bind_group, &[]);
             batcher.draw(&mut pass);
             pass.pop_debug_group();
 

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -90,11 +90,6 @@ pub struct Instance {
     orientation: [f32; 4],
     shape_scale: f32,
     body_and_color_id: [u32; 2],
-    /// World water level at the vehicle's xy. Filled in by
-    /// `Batcher::set_water_levels` before each frame's draw. A negative
-    /// sentinel means "no water at this xy" so the shader's underwater
-    /// tint stays inactive.
-    water_level: f32,
 }
 unsafe impl Pod for Instance {}
 unsafe impl Zeroable for Instance {}
@@ -107,22 +102,13 @@ impl Instance {
             orientation: gt.orientation,
             shape_scale,
             body_and_color_id: [0, color_id as u32],
-            water_level: f32::NEG_INFINITY,
         }
-    }
-
-    pub fn world_xy(&self) -> [f32; 2] {
-        [self.pos_scale[0], self.pos_scale[1]]
-    }
-
-    pub fn set_water_level(&mut self, level: f32) {
-        self.water_level = level;
     }
 }
 
 #[derive(Copy, Clone)]
 pub struct InstanceDesc {
-    attributes: [wgpu::VertexAttribute; 5],
+    attributes: [wgpu::VertexAttribute; 4],
 }
 
 impl InstanceDesc {
@@ -133,7 +119,6 @@ impl InstanceDesc {
                 4 => Float32x4,
                 5 => Float32,
                 6 => Uint32x2,
-                7 => Float32,
             ],
         }
     }
@@ -147,7 +132,72 @@ impl InstanceDesc {
     }
 }
 
+/// Resources the object pipeline needs to do a per-pixel underwater
+/// check: the surface uniforms (for `texture_scale`), the terrain meta
+/// texture (cell type), and the flood texture (per-Y water level). The
+/// game-side render pipeline supplies these from the terrain context;
+/// the standalone model viewer supplies stubs via [`create_stub_surface`].
+pub struct SurfaceInputs<'a> {
+    pub uniform_buf: &'a wgpu::Buffer,
+    pub terrain_view: &'a wgpu::TextureView,
+    pub flood_view: &'a wgpu::TextureView,
+}
+
+/// Build dummy surface resources for tools (the model viewer) that draw
+/// vehicles without a real terrain. The uniform's `texture_scale.x` is
+/// 0, which the object shader uses as the "skip the underwater branch"
+/// signal.
+pub struct StubSurface {
+    pub uniform_buf: wgpu::Buffer,
+    pub terrain_view: wgpu::TextureView,
+    pub flood_view: wgpu::TextureView,
+}
+
+pub fn create_stub_surface(device: &wgpu::Device) -> StubSurface {
+    use wgpu::util::DeviceExt as _;
+
+    let zero_uniform = [0u8; 32];
+    let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Stub surface uniforms"),
+        contents: &zero_uniform,
+        usage: wgpu::BufferUsages::UNIFORM,
+    });
+    let make_view = |label, format| {
+        let tex = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some(label),
+            size: wgpu::Extent3d {
+                width: 1,
+                height: 1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            view_formats: &[],
+            usage: wgpu::TextureUsages::TEXTURE_BINDING,
+        });
+        tex.create_view(&wgpu::TextureViewDescriptor::default())
+    };
+    StubSurface {
+        uniform_buf,
+        terrain_view: make_view("Stub terrain", wgpu::TextureFormat::Rgba8Uint),
+        flood_view: make_view("Stub flood", wgpu::TextureFormat::R8Unorm),
+    }
+}
+
+impl StubSurface {
+    pub fn inputs(&self) -> SurfaceInputs<'_> {
+        SurfaceInputs {
+            uniform_buf: &self.uniform_buf,
+            terrain_view: &self.terrain_view,
+            flood_view: &self.flood_view,
+        }
+    }
+}
+
 pub struct Context {
+    pub surface_bind_group: wgpu::BindGroup,
     pub bind_group: wgpu::BindGroup,
     pub shape_bind_group_layout: Result<wgpu::BindGroupLayout, VertexStorageNotSupported>,
     pub pipeline_layout: wgpu::PipelineLayout,
@@ -287,6 +337,7 @@ impl Context {
         front_face: wgpu::FrontFace,
         palette_data: &[[u8; 4]],
         global: &GlobalContext,
+        surface: SurfaceInputs<'_>,
     ) -> Self {
         let bind_group_layout =
             gfx.device
@@ -375,17 +426,78 @@ impl Context {
                 },
             ],
         });
+        let surface_bind_group_layout =
+            gfx.device
+                .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                    label: Some("Object surface"),
+                    entries: &[
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 0,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Buffer {
+                                ty: wgpu::BufferBindingType::Uniform,
+                                has_dynamic_offset: false,
+                                min_binding_size: None,
+                            },
+                            count: None,
+                        },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 2,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Texture {
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                                sample_type: wgpu::TextureSampleType::Uint,
+                                multisampled: false,
+                            },
+                            count: None,
+                        },
+                        wgpu::BindGroupLayoutEntry {
+                            binding: 4,
+                            visibility: wgpu::ShaderStages::FRAGMENT,
+                            ty: wgpu::BindingType::Texture {
+                                view_dimension: wgpu::TextureViewDimension::D2,
+                                sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                                multisampled: false,
+                            },
+                            count: None,
+                        },
+                    ],
+                });
+        let surface_bind_group = gfx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Object surface"),
+            layout: &surface_bind_group_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: surface.uniform_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::TextureView(surface.terrain_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: wgpu::BindingResource::TextureView(surface.flood_view),
+                },
+            ],
+        });
+
         let pipeline_layout = gfx
             .device
             .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("object"),
-                bind_group_layouts: &[Some(&global.bind_group_layout), Some(&bind_group_layout)],
+                bind_group_layouts: &[
+                    Some(&global.bind_group_layout),
+                    Some(&bind_group_layout),
+                    Some(&surface_bind_group_layout),
+                ],
                 immediate_size: 0,
             });
         let pipelines =
             Self::create_pipelines(&pipeline_layout, &gfx.device, gfx.color_format, front_face);
 
         Context {
+            surface_bind_group,
             bind_group,
             shape_bind_group_layout,
             pipeline_layout,

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -156,10 +156,17 @@ pub struct StubSurface {
 pub fn create_stub_surface(device: &wgpu::Device) -> StubSurface {
     use wgpu::util::DeviceExt as _;
 
-    let zero_uniform = [0u8; 32];
+    // SurfaceConstants layout: vec4 texture_scale, u32 terrain_bits,
+    // u32 delta_mode, u32 pad0, u32 pad1. We need texture_scale.x and
+    // .y to be non-zero so the shader's wrap math doesn't divide by 0,
+    // and texture_scale.z = 0 so the flood-fed water Z stays at 0
+    // (keeps the underwater check inert for vehicles above ground).
+    let mut bytes = [0u8; 32];
+    bytes[0..4].copy_from_slice(&1.0f32.to_ne_bytes()); // texture_scale.x
+    bytes[4..8].copy_from_slice(&1.0f32.to_ne_bytes()); // texture_scale.y
     let uniform_buf = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
         label: Some("Stub surface uniforms"),
-        contents: &zero_uniform,
+        contents: &bytes,
         usage: wgpu::BufferUsages::UNIFORM,
     });
     let make_view = |label, format| {
@@ -482,14 +489,18 @@ impl Context {
             ],
         });
 
+        // Surface goes at @group(1) so the object shader can `//!include
+        // surface.inc` directly (it hard-codes group 1 to match the
+        // terrain and water pipelines). Object-local resources move to
+        // @group(2).
         let pipeline_layout = gfx
             .device
             .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
                 label: Some("object"),
                 bind_group_layouts: &[
                     Some(&global.bind_group_layout),
-                    Some(&bind_group_layout),
                     Some(&surface_bind_group_layout),
+                    Some(&bind_group_layout),
                 ],
                 immediate_size: 0,
             });

--- a/src/render/terrain/mod.rs
+++ b/src/render/terrain/mod.rs
@@ -296,7 +296,7 @@ pub struct Flood {
 }
 
 pub struct Context {
-    surface_uni_buf: wgpu::Buffer,
+    pub surface_uni_buf: wgpu::Buffer,
     pub uniform_buf: wgpu::Buffer,
     pub bind_group: wgpu::BindGroup,
     pub bind_group_layout: wgpu::BindGroupLayout,
@@ -305,7 +305,7 @@ pub struct Context {
     raytrace_geo: Geometry,
     kind: Kind,
     shadow_kind: ShadowKind,
-    terrain_texture: wgpu::Texture,
+    pub terrain_texture: wgpu::Texture,
     palette_texture: wgpu::Texture,
     pub flood: Flood,
     pub dirty_rects: Vec<super::DirtyRect>,

--- a/src/render/terrain/mod.rs
+++ b/src/render/terrain/mod.rs
@@ -55,6 +55,10 @@ struct Constants {
     fog_color: [f32; 3],
     pad: f32,
     fog_params: [f32; 4],
+    /// `[0]` = lighting mode. 0 = baked palette gradient (original
+    /// Vangers look), 1 = unbaked albedo + cosine diffuse + shadow.
+    /// The remaining slots are reserved.
+    lighting_flags: [u32; 4],
 }
 unsafe impl Pod for Constants {}
 unsafe impl Zeroable for Constants {}
@@ -312,6 +316,10 @@ pub struct Context {
     pub dirty_flood: bool,
     pub dirty_palette: Range<u32>,
     active_surface_constants: SurfaceConstants,
+    /// `false` (default) → original baked-palette lighting; `true` →
+    /// unbaked albedo + explicit cosine diffuse + shadow visibility.
+    /// Wired into `evaluate_color` via `Locals::lighting_flags`.
+    pub unbaked_lighting: bool,
 }
 
 impl Context {
@@ -1443,6 +1451,10 @@ impl Context {
                 pad0: 0,
                 pad1: 0,
             },
+            // Default to unbaked diffuse + shadow — matches the look
+            // we tuned in the cosine-lighting commit. Toggle in the UI
+            // to A/B against the original baked-palette path.
+            unbaked_lighting: true,
         }
     }
 
@@ -1882,6 +1894,7 @@ impl Context {
                     fog_color: fog.color,
                     pad: 1.0,
                     fog_params: [depth_range.end - fog.depth, depth_range.end, 0.0, 0.0],
+                    lighting_flags: [self.unbaked_lighting as u32, 0, 0, 0],
                 }),
                 usage: wgpu::BufferUsages::COPY_SRC,
             });
@@ -1991,6 +2004,7 @@ impl Context {
                     fog_color: [0.0; 3],
                     pad: 1.0,
                     fog_params: [10000000.0, 10000000.0, 0.0, 0.0],
+                    lighting_flags: [self.unbaked_lighting as u32, 0, 0, 0],
                 }),
                 usage: wgpu::BufferUsages::COPY_SRC,
             });
@@ -2127,6 +2141,10 @@ impl Context {
     }
 
     pub fn draw_ui(&mut self, ui: &mut egui::Ui) {
+        ui.checkbox(
+            &mut self.unbaked_lighting,
+            "Unbaked diffuse + shadow (terrain)",
+        );
         match self.kind {
             Kind::RayVoxel(ref mut rv) => {
                 ui.add(egui::Slider::new(&mut rv.max_outer_steps, 0..=100).text("Max outer steps"));

--- a/src/space.rs
+++ b/src/space.rs
@@ -68,7 +68,28 @@ pub struct PerspectiveParams {
     pub aspect: f32,
     pub near: f32,
     pub far: f32,
+    /// If `Some`, [`Projection::update`] recomputes `fovy` from this
+    /// focal length (in screen pixels) and the new viewport height,
+    /// matching the original Vangers `focus_flt = 512` formula in
+    /// `road.cpp`. `None` keeps `fovy` fixed across resizes.
+    pub focal_px: Option<f32>,
 }
+
+impl PerspectiveParams {
+    /// Original-Vangers FOV: vertical FOV that places `focal_px` screen
+    /// pixels at the same angular size as one world unit at distance
+    /// `focal_px`. `focus_flt = 512` in the 1998 source.
+    pub fn fov_from_focal_px(focal_px: f32, height_px: f32) -> f32 {
+        2.0 * (0.5 * height_px / focal_px).atan()
+    }
+}
+
+/// Default focal length for camera setup, matching `focus_flt = 512` in
+/// the original Vangers `road.cpp`. Together with the window height
+/// this gives a vertical FOV close to what the 1998 game showed at
+/// equivalent resolutions, which feels less "telephoto" than the prior
+/// fixed 45°.
+pub const DEFAULT_FOCAL_PX: f32 = 512.0;
 
 #[derive(Copy, Clone)]
 pub enum Projection {
@@ -112,6 +133,9 @@ impl Projection {
             }
             Projection::Perspective(ref mut p) => {
                 p.aspect = w as f32 / h as f32;
+                if let Some(focal) = p.focal_px {
+                    p.fovy = PerspectiveParams::fov_from_focal_px(focal, h as f32);
+                }
             }
         }
     }

--- a/tests/net_physics.rs
+++ b/tests/net_physics.rs
@@ -48,6 +48,7 @@ fn make_camera(transform: &space::Transform) -> space::Camera {
             aspect: 4.0 / 3.0,
             near: 10.0,
             far: 2000.0,
+            focal_px: None,
         }),
     };
     // Warm up the camera follow so it starts at rest

--- a/tests/shaders.rs
+++ b/tests/shaders.rs
@@ -6,6 +6,8 @@ fn parse(name: &str, substitutions: &[(&str, String)]) {
 
 #[test]
 fn parse_shaders() {
+    parse("object", &[]);
+    parse("water", &[]);
     parse("terrain/ray", &[]);
     parse("terrain/paint", &[]);
     parse("terrain/scatter", &[]);


### PR DESCRIPTION
Take a novel direction. Instead of faithfully replicating the baked light from the game, extract the pure albedo and re-apply the lighting dynamically. Not as good, but consistent.