### PR TITLE
Overhaul UI: merge multiplayer into sidebar, full web sidebar, fix vertical extrusion

### DIFF
--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -943,6 +943,9 @@ impl Application for Game {
             .unwrap();
         let mut selected_car = &player.car_name;
 
+        let connect_car_name = player.car_name.clone();
+        let connect_car_color = player.color as u8;
+
         #[allow(deprecated)]
         egui::SidePanel::right("Tweaks").show(context, |ui| {
             ui.group(|ui| {
@@ -1027,17 +1030,8 @@ impl Application for Game {
                 ui.label("Renderer:");
                 self.render.draw_ui(ui);
             });
-        });
-
-        if selected_car != &player.car_name {
-            let name = selected_car.clone();
-            player.change_car(&self.db.cars[&name], name);
-        }
-
-        // Multiplayer panel
-        egui::Window::new("Multiplayer")
-            .default_open(false)
-            .show(context, |ui| {
+            ui.group(|ui| {
+                ui.label("Multiplayer:");
                 if self.mp_state.connected {
                     ui.label(format!("Connected to {}", self.mp_state.server_addr));
                     if let Some(ref net) = self.net
@@ -1062,16 +1056,11 @@ impl Application for Game {
                         ui.text_edit_singleline(&mut self.mp_state.player_name);
                     });
                     if ui.button("Connect").clicked() {
-                        let player = self
-                            .agents
-                            .iter()
-                            .find(|a| a.spirit == Spirit::Player)
-                            .unwrap();
                         self.net = Some(NetworkClient::connect(
                             &self.mp_state.server_addr,
                             &self.mp_state.player_name,
-                            &player.car_name,
-                            player.color as u8,
+                            &connect_car_name,
+                            connect_car_color,
                         ));
                         self.mp_state.connected = true;
                         self.mp_state.status = "Connecting...".to_string();
@@ -1081,6 +1070,14 @@ impl Application for Game {
                     ui.label(&self.mp_state.status);
                 }
             });
+        });
+
+        if selected_car != &player.car_name {
+            let name = selected_car.clone();
+            player.change_car(&self.db.cars[&name], name);
+        }
+
+        
     }
 
     fn draw(

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -133,6 +133,23 @@ fn selected_level_id() -> String {
     DEFAULT_LEVEL.to_string()
 }
 
+/// Read the selected car name from the URL fragment `#car=<name>`,
+/// falling back to an empty string (which means "use the first main car").
+fn selected_car_name() -> String {
+    if let Some(window) = web_sys::window()
+        && let Ok(hash) = window.location().hash()
+    {
+        for pair in hash.trim_start_matches('#').split('&') {
+            if let Some(rest) = pair.strip_prefix("car=")
+                && !rest.is_empty()
+            {
+                return rest.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
 /// Fetch `common.zip` and `<level_id>.zip` from the release and mount
 /// both into a VFS, reporting download progress to the JS UI. Returns
 /// `None` on any error; the caller falls back to a procedural test level.
@@ -298,11 +315,41 @@ fn spawn_default_agent(
     let car_prm = vfs.read("car.prm")?;
     let (car_name, stats_data) = config::car::first_main_entry(Cursor::new(&*car_prm));
 
-    let model_info = registry.model_infos.get(&car_name)?;
+    spawn_agent_named(&car_name, &stats_data, vfs, &registry, level, device, object)
+}
+
+fn spawn_named_agent(
+    name: &str,
+    vfs: &Vfs,
+    level: &level::Level,
+    device: &wgpu::Device,
+    object: &render::object::Context,
+) -> Option<Agent> {
+    use std::io::Cursor;
+
+    let game_lst = vfs.read("game.lst")?;
+    let registry = config::game::Registry::load_reader(Cursor::new(&*game_lst));
+
+    let car_prm_bytes = vfs.read("car.prm")?;
+    let stats_data = config::car::stats_for_name(name, Cursor::new(&*car_prm_bytes))?;
+
+    spawn_agent_named(name, &stats_data, vfs, &registry, level, device, object)
+}
+
+fn spawn_agent_named(
+    car_name: &str,
+    stats_data: &[u32],
+    vfs: &Vfs,
+    registry: &config::game::Registry,
+    level: &level::Level,
+    device: &wgpu::Device,
+    object: &render::object::Context,
+) -> Option<Agent> {
+    use std::io::Cursor;
+
+    let model_info = registry.model_infos.get(car_name)?;
     let m3d_bytes = vfs.read(&model_info.path)?;
 
-    // Per-vehicle physics file lives next to the m3d. If it's missing,
-    // fall back to `default.prm` in the same directory.
     let prm_path = std::path::Path::new(&model_info.path).with_extension("prm");
     let prm_key = prm_path.to_str()?;
     let (prm_bytes, is_default) = if let Some(bytes) = vfs.read(prm_key) {
@@ -326,13 +373,12 @@ fn spawn_default_agent(
 
     let car = config::car::CarInfo {
         kind: config::car::Kind::Main,
-        stats: config::car::CarStats::new(&stats_data),
+        stats: config::car::CarStats::new(stats_data),
         physics: car_physics,
         model: visual,
         scale,
     };
 
-    // Spawn at the level center, snapped to the terrain.
     let coords = (level.size.0 / 2, level.size.1 / 2);
     let height = level.get(coords).high() + 5.0;
     let transform = space::Transform {
@@ -349,6 +395,13 @@ fn spawn_default_agent(
         control: Control::default(),
         color: PLAYER_COLOR,
     })
+}
+
+fn list_car_names(vfs: &Vfs) -> Vec<String> {
+    use std::io::Cursor;
+    vfs.read("car.prm")
+        .map(|bytes| config::car::list_car_names(Cursor::new(&*bytes)))
+        .unwrap_or_default()
 }
 
 struct WebApp {
@@ -373,6 +426,10 @@ struct WebApp {
     current_level: String,
     /// Index into [`LEVELS`] for the level picker dropdown.
     selected_level_idx: usize,
+    /// Available car names parsed from `car.prm`.
+    car_names: Vec<String>,
+    /// Index into [`car_names`] for the car picker dropdown.
+    selected_car_idx: usize,
 }
 
 impl WebApp {
@@ -407,16 +464,16 @@ impl WebApp {
         let settings = Self::load_settings();
         let level_config = level::LevelConfig::new_test();
         let level = level::load(&level_config, &settings.game.geometry);
-        Self::build(gfx, level_config, level, None, is_webgpu, &settings, DEFAULT_LEVEL)
+        Self::build(gfx, level_config, level, None, is_webgpu, &settings, DEFAULT_LEVEL, "")
     }
 
     /// Build the app from a real level in a [`Vfs`]. `ini_path` is the
     /// VFS key of the world INI (e.g. `"fostral/world.ini"`).
-    fn new_from_vfs(gfx: &GraphicsContext, vfs: &Vfs, ini_path: &str, is_webgpu: bool, level_id: &str) -> Self {
+    fn new_from_vfs(gfx: &GraphicsContext, vfs: &Vfs, ini_path: &str, is_webgpu: bool, level_id: &str, car_name: &str) -> Self {
         let settings = Self::load_settings();
         let level_config = level::LevelConfig::load_from_vfs(vfs, ini_path);
         let level = level::load_from_vfs(vfs, &level_config, &settings.game.geometry);
-        Self::build(gfx, level_config, level, Some(vfs), is_webgpu, &settings, level_id)
+        Self::build(gfx, level_config, level, Some(vfs), is_webgpu, &settings, level_id, car_name)
     }
 
     fn build(
@@ -427,6 +484,7 @@ impl WebApp {
         is_webgpu: bool,
         settings: &settings::Settings,
         level_id: &str,
+        car_name: &str,
     ) -> Self {
         let objects_palette = vfs
             .and_then(|v| v.read("resource/pal/objects.pal"))
@@ -496,10 +554,26 @@ impl WebApp {
             .and_then(|v| v.read("common.prm"))
             .map(|b| config::common::load_reader(std::io::Cursor::new(&*b)))
             .unwrap_or_else(config::common::Common::test_default);
-        let agent = vfs.and_then(|v| spawn_default_agent(v, &level, &gfx.device, &render.object));
+        let agent = vfs.and_then(|v| {
+            if car_name.is_empty() {
+                spawn_default_agent(v, &level, &gfx.device, &render.object)
+            } else {
+                spawn_named_agent(car_name, v, &level, &gfx.device, &render.object)
+            }
+        });
         if agent.is_none() {
             log::info!("No player agent — running in free-camera mode");
         }
+        let car_names = vfs.map(|v| list_car_names(v)).unwrap_or_default();
+        let default_car = agent.as_ref().map(|a| a.car.stats.clone());
+        let selected_car_idx = default_car
+            .as_ref()
+            .and_then(|_| agent.as_ref())
+            .map(|a| {
+                let name = &a.car.physics.name;
+                car_names.iter().position(|n| n == name).unwrap_or(0)
+            })
+            .unwrap_or(0);
 
         // Camera follow params from settings.ron, same conversion as
         // native (bin/road/game.rs CameraStyle::new).
@@ -534,6 +608,8 @@ impl WebApp {
             is_webgpu,
             current_level: level_id.to_string(),
             selected_level_idx: LEVELS.iter().position(|&l| l == level_id).unwrap_or(0),
+            car_names,
+            selected_car_idx,
         }
     }
 
@@ -569,10 +645,27 @@ fn draw_ui(&mut self, ctx: &egui::Context) {
                     }
                     self.level.draw_ui(ui);
                 });
-                if let Some(ref mut agent) = self.agent {
-                    ui.group(|ui| {
-                        ui.set_width(ui.available_width());
-                        ui.label("Mechous:");
+                ui.group(|ui| {
+                    ui.set_width(ui.available_width());
+                    ui.label("Mechous:");
+                    if !self.car_names.is_empty() {
+                        let mut car_changed = false;
+                        egui::ComboBox::from_id_salt("car-select")
+                            .selected_text(&self.car_names[self.selected_car_idx])
+                            .show_ui(ui, |ui| {
+                                for (i, name) in self.car_names.iter().enumerate() {
+                                    if ui.selectable_label(i == self.selected_car_idx, name.as_str()).clicked() {
+                                        self.selected_car_idx = i;
+                                        car_changed = true;
+                                    }
+                                }
+                            });
+                        if car_changed {
+                            let car_name = &self.car_names[self.selected_car_idx];
+                            js_navigate_level(&format!("{}&car={}", self.current_level, car_name));
+                        }
+                    }
+                    if let Some(ref mut agent) = self.agent {
                         egui::ComboBox::from_id_salt("color-select")
                             .selected_text(agent.color.name())
                             .show_ui(ui, |ui| {
@@ -597,8 +690,8 @@ fn draw_ui(&mut self, ctx: &egui::Context) {
                             "Speed: {:.1}",
                             agent.dynamo.linear_velocity.length()
                         ));
-                    });
-                }
+                    }
+                });
                 ui.group(|ui| {
                     ui.set_width(ui.available_width());
                     ui.label("Camera:");
@@ -1043,6 +1136,7 @@ impl ApplicationHandler for WebHandler {
                                     vfs_level: Option<(Vfs, String)>,
                                     is_webgpu: bool,
                                     level_id: String,
+                                    car_name: String,
                                     window: Arc<Window>|
               -> GpuState {
             // winit's web backend manages canvas backing size via its
@@ -1098,7 +1192,7 @@ impl ApplicationHandler for WebHandler {
                 queue,
             };
             let app = match vfs_level {
-                Some((vfs, ini_path)) => WebApp::new_from_vfs(&gfx, &vfs, &ini_path, is_webgpu, &level_id),
+                Some((vfs, ini_path)) => WebApp::new_from_vfs(&gfx, &vfs, &ini_path, is_webgpu, &level_id, &car_name),
                 None => WebApp::new(&gfx, is_webgpu),
             };
 
@@ -1143,7 +1237,8 @@ impl ApplicationHandler for WebHandler {
             let requested = selected_level_id();
             let level_id =
                 pick_level_for_adapter(requested, adapter.limits().max_texture_dimension_2d);
-            log::info!("Selected level: {}", level_id);
+            let car_name = selected_car_name();
+            log::info!("Selected level: {}, car: {}", level_id, if car_name.is_empty() { "(default)" } else { &car_name });
             let vfs_level = fetch_release_level(&level_id).await;
 
             // Level construction and renderer setup are synchronous
@@ -1167,6 +1262,7 @@ impl ApplicationHandler for WebHandler {
                 vfs_level,
                 is_webgpu,
                 level_id,
+                car_name,
                 window.clone(),
             );
             *pending.borrow_mut() = Some(state);

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -888,6 +888,170 @@ mod net_ws {
 
 use web_time::Instant;
 
+const BLIT_SHADER: &str = r"
+@group(0) @binding(0) var tex: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+
+struct VOut {
+    @builtin(position) pos: vec4f,
+    @location(0) uv: vec2f,
+};
+
+@vertex
+fn vs(@builtin(vertex_index) idx: u32) -> VOut {
+    var positions = array<vec2f, 3>(
+        vec2f(-1.0, -1.0),
+        vec2f(3.0, -1.0),
+        vec2f(-1.0, 3.0),
+    );
+    var uvs = array<vec2f, 3>(
+        vec2f(0.0, 1.0),
+        vec2f(2.0, 1.0),
+        vec2f(0.0, -1.0),
+    );
+    return VOut(vec4f(positions[idx], 0.0, 1.0), uvs[idx]);
+}
+
+@fragment
+fn fs(v: VOut) -> @location(0) vec4f {
+    return textureSample(tex, samp, v.uv);
+}
+";
+
+#[allow(dead_code)]
+struct ViewportResources {
+    color_texture: wgpu::Texture,
+    color_view: wgpu::TextureView,
+    depth_texture: wgpu::Texture,
+    depth_view: wgpu::TextureView,
+    bind_group: wgpu::BindGroup,
+    size: wgpu::Extent3d,
+}
+
+impl ViewportResources {
+    fn new(
+        size: wgpu::Extent3d,
+        format: wgpu::TextureFormat,
+        layout: &wgpu::BindGroupLayout,
+        sampler: &wgpu::Sampler,
+        device: &wgpu::Device,
+    ) -> Self {
+        let color_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Viewport Color"),
+            size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let color_view = color_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let depth_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Viewport Depth"),
+            size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: DEPTH_FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        });
+        let depth_view = depth_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Viewport Blit"),
+            layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&color_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(sampler),
+                },
+            ],
+        });
+
+        ViewportResources {
+            color_texture,
+            color_view,
+            depth_texture,
+            depth_view,
+            bind_group,
+            size,
+        }
+    }
+
+    fn ensure_size(
+        &mut self,
+        new_size: wgpu::Extent3d,
+        format: wgpu::TextureFormat,
+        layout: &wgpu::BindGroupLayout,
+        sampler: &wgpu::Sampler,
+        device: &wgpu::Device,
+    ) {
+        if self.size.width == new_size.width && self.size.height == new_size.height {
+            return;
+        }
+        *self = Self::new(new_size, format, layout, sampler, device);
+    }
+}
+
+fn create_blit_pipeline(
+    device: &wgpu::Device,
+    format: wgpu::TextureFormat,
+    layout: &wgpu::BindGroupLayout,
+) -> wgpu::RenderPipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Blit Shader"),
+        source: wgpu::ShaderSource::Wgsl(BLIT_SHADER.into()),
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Blit Pipeline Layout"),
+        bind_group_layouts: &[Some(layout)],
+        immediate_size: 0,
+    });
+
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("Blit Pipeline"),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader,
+            entry_point: Some("vs"),
+            buffers: &[],
+            compilation_options: Default::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader,
+            entry_point: Some("fs"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: Default::default(),
+        }),
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: wgpu::FrontFace::Ccw,
+            cull_mode: None,
+            polygon_mode: wgpu::PolygonMode::Fill,
+            unclipped_depth: false,
+            conservative: false,
+        },
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    })
+}
+
 /// GPU resources initialized asynchronously on WASM.
 struct GpuState {
     _instance: wgpu::Instance,
@@ -895,7 +1059,10 @@ struct GpuState {
     device: wgpu::Device,
     queue: wgpu::Queue,
     config: wgpu::SurfaceConfiguration,
-    depth_view: wgpu::TextureView,
+    viewport: ViewportResources,
+    blit_pipeline: wgpu::RenderPipeline,
+    blit_layout: wgpu::BindGroupLayout,
+    blit_sampler: wgpu::Sampler,
     app: WebApp,
     window: Arc<Window>,
     egui_state: egui_winit::State,
@@ -1172,18 +1339,46 @@ impl ApplicationHandler for WebHandler {
             };
             surface.configure(&device, &config);
 
-            let depth_view = device
-                .create_texture(&wgpu::TextureDescriptor {
-                    label: Some("Depth"),
-                    size: screen_size,
-                    mip_level_count: 1,
-                    sample_count: 1,
-                    dimension: wgpu::TextureDimension::D2,
-                    format: DEPTH_FORMAT,
-                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                    view_formats: &[],
-                })
-                .create_view(&wgpu::TextureViewDescriptor::default());
+            let blit_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Viewport Blit Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            multisampled: false,
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            });
+            let blit_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+                label: Some("Viewport Blit Sampler"),
+                address_mode_u: wgpu::AddressMode::ClampToEdge,
+                address_mode_v: wgpu::AddressMode::ClampToEdge,
+                address_mode_w: wgpu::AddressMode::ClampToEdge,
+                mag_filter: wgpu::FilterMode::Nearest,
+                min_filter: wgpu::FilterMode::Nearest,
+                mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+                ..Default::default()
+            });
+            let blit_pipeline =
+                create_blit_pipeline(&device, config.format, &blit_layout);
+            let viewport = ViewportResources::new(
+                screen_size,
+                config.format,
+                &blit_layout,
+                &blit_sampler,
+                &device,
+            );
 
             let gfx = GraphicsContext {
                 downlevel_caps: adapter.get_downlevel_capabilities(),
@@ -1215,7 +1410,10 @@ impl ApplicationHandler for WebHandler {
                 device: gfx.device,
                 queue: gfx.queue,
                 config,
-                depth_view,
+                viewport,
+                blit_pipeline,
+                blit_layout,
+                blit_sampler,
                 app,
                 window,
                 egui_state,
@@ -1318,20 +1516,6 @@ impl ApplicationHandler for WebHandler {
                     gpu.config.width = size.width;
                     gpu.config.height = size.height;
                     gpu.surface.configure(&gpu.device, &gpu.config);
-                    gpu.depth_view = gpu
-                        .device
-                        .create_texture(&wgpu::TextureDescriptor {
-                            label: Some("Depth"),
-                            size: self.screen_size,
-                            mip_level_count: 1,
-                            sample_count: 1,
-                            dimension: wgpu::TextureDimension::D2,
-                            format: DEPTH_FORMAT,
-                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                            view_formats: &[],
-                        })
-                        .create_view(&wgpu::TextureViewDescriptor::default());
-                    gpu.app.resize(self.screen_size, &gpu.device);
                 }
             }
             WindowEvent::RedrawRequested => {
@@ -1381,28 +1565,26 @@ impl WebHandler {
         };
 
         // If the screen was resized while GPU was initializing asynchronously,
-        // the depth texture and surface config still have the old size.
-        // Reconfigure now before the first render.
+        // reconfigure the surface now before the first render.
         if gpu.config.width != self.screen_size.width
             || gpu.config.height != self.screen_size.height
         {
             gpu.config.width = self.screen_size.width;
             gpu.config.height = self.screen_size.height;
             gpu.surface.configure(&gpu.device, &gpu.config);
-            gpu.depth_view = gpu
-                .device
-                .create_texture(&wgpu::TextureDescriptor {
-                    label: Some("Depth"),
-                    size: self.screen_size,
-                    mip_level_count: 1,
-                    sample_count: 1,
-                    dimension: wgpu::TextureDimension::D2,
-                    format: DEPTH_FORMAT,
-                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                    view_formats: &[],
-                })
-                .create_view(&wgpu::TextureViewDescriptor::default());
-            gpu.app.resize(self.screen_size, &gpu.device);
+            let new_size = wgpu::Extent3d {
+                width: gpu.config.width,
+                height: gpu.config.height,
+                depth_or_array_layers: 1,
+            };
+            gpu.viewport.ensure_size(
+                new_size,
+                gpu.config.format,
+                &gpu.blit_layout,
+                &gpu.blit_sampler,
+                &gpu.device,
+            );
+            gpu.app.resize(new_size, &gpu.device);
         }
 
         // Compute delta time
@@ -1571,14 +1753,9 @@ impl WebHandler {
             _ => return,
         };
 
-        let view = frame
+        let surface_view = frame
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
-        let targets = ScreenTargets {
-            extent: self.screen_size,
-            color: &view,
-            depth: &gpu.depth_view,
-        };
 
         // --- egui UI pass (run first to get panel rect) ---
         let raw_input = gpu.egui_state.take_egui_input(&gpu.window);
@@ -1590,27 +1767,93 @@ impl WebHandler {
 
         // 3D viewport excludes the side panel.
         let screen = gpu.egui_state.egui_ctx().viewport_rect();
-        let panel = gpu.egui_state.egui_ctx().content_rect();
-        let panel_w = screen.width() - panel.width();
-        let viewport = if panel_w > 1.0 {
-            // Adjust camera aspect ratio to match the viewport width,
-            // not the full screen — prevents horizontal squishing.
-            let viewport_w = panel_w * gpu.window.scale_factor() as f32;
-            let viewport_h = self.screen_size.height as f32;
-            if let space::Projection::Perspective(ref mut p) = gpu.app.cam.proj {
-                p.aspect = viewport_w / viewport_h.max(1.0);
+        let content = gpu.egui_state.egui_ctx().content_rect();
+        let sidebar_w = screen.width() - content.width();
+        let scale = gpu.window.scale_factor() as f32;
+        let viewport_size = if sidebar_w > 1.0 {
+            let viewport_w = (content.width() * scale).max(1.0) as u32;
+            let viewport_h = (screen.height() * scale).max(1.0) as u32;
+            wgpu::Extent3d {
+                width: viewport_w,
+                height: viewport_h,
+                depth_or_array_layers: 1,
             }
-            Some(render::Rect {
-                x: 0,
-                y: 0,
-                w: panel_w as u16,
-                h: screen.height() as u16,
-            })
         } else {
-            None
+            self.screen_size
         };
 
-        let command_buffer = gpu.app.draw(&gpu.device, &gpu.queue, targets, viewport);
+        // Ensure offscreen textures match the viewport and update
+        // renderer/camera when the size changes.
+        let prev_size = gpu.viewport.size;
+        gpu.viewport.ensure_size(
+            viewport_size,
+            gpu.config.format,
+            &gpu.blit_layout,
+            &gpu.blit_sampler,
+            &gpu.device,
+        );
+        if gpu.viewport.size.width != prev_size.width
+            || gpu.viewport.size.height != prev_size.height
+        {
+            gpu.app.resize(viewport_size, &gpu.device);
+        }
+        if let space::Projection::Perspective(ref mut p) = gpu.app.cam.proj {
+            let aspect = viewport_size.width as f32 / viewport_size.height.max(1) as f32;
+            p.aspect = aspect;
+        }
+
+        // --- Render 3D scene to offscreen texture ---
+        let offscreen_targets = ScreenTargets {
+            extent: viewport_size,
+            color: &gpu.viewport.color_view,
+            depth: &gpu.viewport.depth_view,
+        };
+        let viewport_rect = render::Rect {
+            x: 0,
+            y: 0,
+            w: viewport_size.width as u16,
+            h: viewport_size.height as u16,
+        };
+        let world_cmd = gpu.app.draw(
+            &gpu.device,
+            &gpu.queue,
+            offscreen_targets,
+            Some(viewport_rect),
+        );
+
+        // --- Blit offscreen texture to surface ---
+        let mut blit_encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("Viewport Blit") });
+        {
+            let mut blit_pass = blit_encoder
+                .begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("Viewport Blit"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &surface_view,
+                        resolve_target: None,
+                        depth_slice: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    ..Default::default()
+                })
+                .forget_lifetime();
+            blit_pass.set_viewport(
+                0.0,
+                0.0,
+                viewport_size.width as f32,
+                viewport_size.height as f32,
+                0.0,
+                1.0,
+            );
+            blit_pass.set_pipeline(&gpu.blit_pipeline);
+            blit_pass.set_bind_group(0, &gpu.viewport.bind_group, &[]);
+            blit_pass.draw(0..3, 0..1);
+        }
 
         // --- egui render pass ---
         let paint_jobs = gpu
@@ -1646,7 +1889,7 @@ impl WebHandler {
                 .begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: Some("egui"),
                     color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &view,
+                        view: &surface_view,
                         resolve_target: None,
                         depth_slice: None,
                         ops: wgpu::Operations {
@@ -1663,7 +1906,7 @@ impl WebHandler {
         }
 
         gpu.queue
-            .submit(vec![command_buffer, egui_encoder.finish()]);
+            .submit(vec![world_cmd, blit_encoder.finish(), egui_encoder.finish()]);
         for &id in &full_output.textures_delta.free {
             gpu.egui_renderer.free_texture(&id);
         }

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -746,6 +746,7 @@ fn draw_ui(&mut self, ctx: &egui::Context) {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         targets: ScreenTargets,
+        viewport_rect: Option<render::Rect>,
     ) -> wgpu::CommandBuffer {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("World"),
@@ -763,7 +764,7 @@ fn draw_ui(&mut self, ctx: &egui::Context) {
             &self.level,
             &self.cam,
             targets,
-            None,
+            viewport_rect,
             device,
             queue,
         );
@@ -1578,9 +1579,8 @@ impl WebHandler {
             color: &view,
             depth: &gpu.depth_view,
         };
-        let command_buffer = gpu.app.draw(&gpu.device, &gpu.queue, targets);
 
-        // --- egui UI pass ---
+        // --- egui UI pass (run first to get panel rect) ---
         let raw_input = gpu.egui_state.take_egui_input(&gpu.window);
         let full_output = gpu.egui_state.egui_ctx().run_ui(raw_input, |ctx| {
             gpu.app.draw_ui(ctx);
@@ -1588,6 +1588,23 @@ impl WebHandler {
         gpu.egui_state
             .handle_platform_output(&gpu.window, full_output.platform_output);
 
+        // 3D viewport excludes the side panel.
+        let screen = gpu.egui_state.egui_ctx().viewport_rect();
+        let panel = gpu.egui_state.egui_ctx().content_rect();
+        let viewport = if panel.width() < screen.width() - 1.0 {
+            Some(render::Rect {
+                x: 0,
+                y: 0,
+                w: (screen.width() - panel.width()) as u16,
+                h: screen.height() as u16,
+            })
+        } else {
+            None
+        };
+
+        let command_buffer = gpu.app.draw(&gpu.device, &gpu.queue, targets, viewport);
+
+        // --- egui render pass ---
         let paint_jobs = gpu
             .egui_state
             .egui_ctx()

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -20,6 +20,19 @@ use vangers::{
 /// is missing (404) we fall back to the procedural test level.
 const DEFAULT_LEVEL: &str = "fostral";
 
+const LEVELS: &[&str] = &[
+    "fostral",
+    "glorx",
+    "necross",
+    "khox",
+    "boozeena",
+    "weexow",
+    "xplo",
+    "hmok",
+    "threall",
+    "ark-a-znoy",
+];
+
 /// INI path inside the per-level zip. Each `<id>.zip` stores the level
 /// files at the archive root (no `<id>/` prefix), so the INI key is
 /// just `"world.ini"`.
@@ -60,6 +73,9 @@ extern "C" {
 
     #[wasm_bindgen(js_namespace = window, js_name = vangeSelectedLevel, catch)]
     fn js_selected_level() -> Result<JsValue, JsValue>;
+
+    #[wasm_bindgen(js_namespace = window, js_name = vangeNavigateLevel)]
+    fn js_navigate_level(level_id: &str);
 }
 
 /// Khox is the smallest stock level (2048 × 8192) and the only one
@@ -348,8 +364,15 @@ struct WebApp {
     agent: Option<Agent>,
     /// Follow-camera parameters (radius/height/smoothing).
     follow: space::Follow,
+    /// If true, the follow camera anchors its height to the ground
+    /// beneath the agent rather than the agent's Z position.
+    ground_anchor: bool,
     /// True when running on WebGPU (vs WebGL2 fallback).
     is_webgpu: bool,
+    /// Currently loaded level id (for the level picker UI).
+    current_level: String,
+    /// Index into [`LEVELS`] for the level picker dropdown.
+    selected_level_idx: usize,
 }
 
 impl WebApp {
@@ -384,16 +407,16 @@ impl WebApp {
         let settings = Self::load_settings();
         let level_config = level::LevelConfig::new_test();
         let level = level::load(&level_config, &settings.game.geometry);
-        Self::build(gfx, level_config, level, None, is_webgpu, &settings)
+        Self::build(gfx, level_config, level, None, is_webgpu, &settings, DEFAULT_LEVEL)
     }
 
     /// Build the app from a real level in a [`Vfs`]. `ini_path` is the
     /// VFS key of the world INI (e.g. `"fostral/world.ini"`).
-    fn new_from_vfs(gfx: &GraphicsContext, vfs: &Vfs, ini_path: &str, is_webgpu: bool) -> Self {
+    fn new_from_vfs(gfx: &GraphicsContext, vfs: &Vfs, ini_path: &str, is_webgpu: bool, level_id: &str) -> Self {
         let settings = Self::load_settings();
         let level_config = level::LevelConfig::load_from_vfs(vfs, ini_path);
         let level = level::load_from_vfs(vfs, &level_config, &settings.game.geometry);
-        Self::build(gfx, level_config, level, Some(vfs), is_webgpu, &settings)
+        Self::build(gfx, level_config, level, Some(vfs), is_webgpu, &settings, level_id)
     }
 
     fn build(
@@ -403,6 +426,7 @@ impl WebApp {
         vfs: Option<&Vfs>,
         is_webgpu: bool,
         settings: &settings::Settings,
+        level_id: &str,
     ) -> Self {
         let objects_palette = vfs
             .and_then(|v| v.read("resource/pal/objects.pal"))
@@ -484,6 +508,7 @@ impl WebApp {
             offset: glam::vec3(0.0, cam_config.offset, cam_config.height),
             speed: cam_config.speed,
         };
+        let ground_anchor = follow.angle_x > 15.0f32.to_radians();
 
         // Settle the follow camera at the agent's spawn pose. Without
         // this, the camera starts at the placeholder above and the slow
@@ -505,35 +530,114 @@ impl WebApp {
             common,
             agent,
             follow,
+            ground_anchor,
             is_webgpu,
+            current_level: level_id.to_string(),
+            selected_level_idx: LEVELS.iter().position(|&l| l == level_id).unwrap_or(0),
         }
     }
 
-    fn draw_ui(&self, ctx: &egui::Context) {
-        egui::Window::new("Settings").show(ctx, |ui| {
-            ui.label(format!(
-                "Backend: {}",
-                if self.is_webgpu { "WebGPU" } else { "WebGL2" }
-            ));
-            if let Some(ref agent) = self.agent {
-                ui.separator();
-                ui.label("Vehicle");
-                let pos = agent.transform.disp;
-                ui.label(format!(
-                    "Position: ({:.0}, {:.0}, {:.0})",
-                    pos.x, pos.y, pos.z
-                ));
-                ui.label(format!(
-                    "Speed: {:.1}",
-                    agent.dynamo.linear_velocity.length()
-                ));
-            }
-            ui.separator();
-            ui.label("Camera");
-            ui.label(format!(
-                "Pos: ({:.0}, {:.0}, {:.0})",
-                self.cam.loc.x, self.cam.loc.y, self.cam.loc.z
-            ));
+fn draw_ui(&mut self, ctx: &egui::Context) {
+        #[allow(deprecated)]
+        egui::SidePanel::right("Tweaks")
+            .min_width(200.0)
+            .show(ctx, |ui| {
+            ui.vertical(|ui| {
+                ui.group(|ui| {
+                    ui.set_width(ui.available_width());
+                    ui.label(format!(
+                        "Backend: {}",
+                        if self.is_webgpu { "WebGPU" } else { "WebGL2" }
+                    ));
+                });
+                ui.group(|ui| {
+                    ui.set_width(ui.available_width());
+                    ui.label("Level:");
+                    let mut changed = false;
+                    egui::ComboBox::from_id_salt("level-select")
+                        .selected_text(LEVELS[self.selected_level_idx])
+                        .show_ui(ui, |ui| {
+                            for (i, name) in LEVELS.iter().enumerate() {
+                                if ui.selectable_label(i == self.selected_level_idx, *name).clicked() {
+                                    self.selected_level_idx = i;
+                                    changed = true;
+                                }
+                            }
+                        });
+                    if changed && LEVELS[self.selected_level_idx] != self.current_level {
+                        js_navigate_level(LEVELS[self.selected_level_idx]);
+                    }
+                    self.level.draw_ui(ui);
+                });
+                if let Some(ref mut agent) = self.agent {
+                    ui.group(|ui| {
+                        ui.set_width(ui.available_width());
+                        ui.label("Mechous:");
+                        egui::ComboBox::from_id_salt("color-select")
+                            .selected_text(agent.color.name())
+                            .show_ui(ui, |ui| {
+                                for &color in &[
+                                    render::object::BodyColor::Green,
+                                    render::object::BodyColor::Red,
+                                    render::object::BodyColor::Blue,
+                                    render::object::BodyColor::Yellow,
+                                    render::object::BodyColor::Gray,
+                                ] {
+                                    ui.selectable_value(&mut agent.color, color, color.name());
+                                }
+                            });
+                        ui.horizontal(|ui| {
+                            ui.label("Position");
+                            ui.add(egui::DragValue::new(&mut agent.transform.disp.x)
+                                .speed(1.0).prefix("x:"));
+                            ui.add(egui::DragValue::new(&mut agent.transform.disp.y)
+                                .speed(1.0).prefix("y:"));
+                        });
+                        ui.label(format!(
+                            "Speed: {:.1}",
+                            agent.dynamo.linear_velocity.length()
+                        ));
+                    });
+                }
+                ui.group(|ui| {
+                    ui.set_width(ui.available_width());
+                    ui.label("Camera:");
+                    self.cam.draw_ui(ui);
+                    let mut angle_deg = self.follow.angle_x.to_degrees();
+                    ui.add(egui::Slider::new(&mut angle_deg, -105.0..=0.0).text("Angle"));
+                    self.follow.angle_x = angle_deg.to_radians();
+                    ui.horizontal(|ui| {
+                        ui.add(egui::DragValue::new(&mut self.follow.offset.x)
+                            .speed(1.0).prefix("ox:"));
+                        ui.add(egui::DragValue::new(&mut self.follow.offset.y)
+                            .speed(1.0).prefix("oy:"));
+                        ui.add(egui::DragValue::new(&mut self.follow.offset.z)
+                            .speed(1.0).prefix("oz:"));
+                    });
+                    ui.add(egui::Slider::new(&mut self.follow.speed, 0.1..=10.0).text("Speed"));
+                    ui.checkbox(&mut self.ground_anchor, "Ground anchor");
+                });
+                ui.group(|ui| {
+                    ui.set_width(ui.available_width());
+                    ui.label("Renderer:");
+                    self.render.draw_ui(ui);
+                });
+                ui.group(|ui| {
+                    ui.set_width(ui.available_width());
+                    ui.label("Controls:");
+                    ui.label("WASD - drive");
+                    ui.label("Space - brake");
+                    ui.label("Q/E - roll");
+                    ui.label("Alt - jump");
+                    ui.label("Shift - turbo");
+                });
+                ui.group(|ui| {
+                    ui.set_width(ui.available_width());
+                    ui.label("Links:");
+                    ui.hyperlink_to("Blog", "/blog");
+                    ui.hyperlink_to("GitHub", "https://github.com/kvark/vange-rs");
+                });
+            });
         });
     }
 
@@ -938,6 +1042,7 @@ impl ApplicationHandler for WebHandler {
                                     screen_size: wgpu::Extent3d,
                                     vfs_level: Option<(Vfs, String)>,
                                     is_webgpu: bool,
+                                    level_id: String,
                                     window: Arc<Window>|
               -> GpuState {
             // winit's web backend manages canvas backing size via its
@@ -993,7 +1098,7 @@ impl ApplicationHandler for WebHandler {
                 queue,
             };
             let app = match vfs_level {
-                Some((vfs, ini_path)) => WebApp::new_from_vfs(&gfx, &vfs, &ini_path, is_webgpu),
+                Some((vfs, ini_path)) => WebApp::new_from_vfs(&gfx, &vfs, &ini_path, is_webgpu, &level_id),
                 None => WebApp::new(&gfx, is_webgpu),
             };
 
@@ -1061,6 +1166,7 @@ impl ApplicationHandler for WebHandler {
                 screen_size,
                 vfs_level,
                 is_webgpu,
+                level_id,
                 window.clone(),
             );
             *pending.borrow_mut() = Some(state);

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -1591,11 +1591,19 @@ impl WebHandler {
         // 3D viewport excludes the side panel.
         let screen = gpu.egui_state.egui_ctx().viewport_rect();
         let panel = gpu.egui_state.egui_ctx().content_rect();
-        let viewport = if panel.width() < screen.width() - 1.0 {
+        let panel_w = screen.width() - panel.width();
+        let viewport = if panel_w > 1.0 {
+            // Adjust camera aspect ratio to match the viewport width,
+            // not the full screen — prevents horizontal squishing.
+            let viewport_w = panel_w * gpu.window.scale_factor() as f32;
+            let viewport_h = self.screen_size.height as f32;
+            if let space::Projection::Perspective(ref mut p) = gpu.app.cam.proj {
+                p.aspect = viewport_w / viewport_h.max(1.0);
+            }
             Some(render::Rect {
                 x: 0,
                 y: 0,
-                w: (screen.width() - panel.width()) as u16,
+                w: panel_w as u16,
                 h: screen.height() as u16,
             })
         } else {

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,41 +6,28 @@
     <title>Vangers – Rust WebGPU</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font-family: 'Segoe UI', system-ui, sans-serif; background: #0d1117; color: #c9d1d9; }
-
-        /* Tab bar */
-        nav { display: flex; background: #161b22; border-bottom: 1px solid #30363d; }
-        nav button {
-            padding: 12px 24px; background: none; border: none; color: #8b949e;
-            font-size: 15px; cursor: pointer; border-bottom: 2px solid transparent;
-            transition: color 0.2s, border-color 0.2s;
-        }
-        nav button:hover { color: #c9d1d9; }
-        nav button.active { color: #58a6ff; border-bottom-color: #58a6ff; }
-
-        /* Panels */
-        .panel { display: none; }
-        .panel.active { display: block; }
-
-        /* Game tab */
-        #game-panel { position: relative; }
+        body { font-family: 'Segoe UI', system-ui, sans-serif; background: #282828; color: #e0e0e0; }
+        #game-panel { position: relative; width: 100vw; height: 100vh; }
         #game-panel canvas {
-            width: 100vw; height: calc(100vh - 47px); display: block; background: #1a1a2e;
+            width: 100%; height: 100%; display: block; background: #1a1a2e;
         }
         #loading {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
-            color: #e0e0e0; font-family: monospace; font-size: 18px; z-index: 10;
-            text-align: center; min-width: 280px;
+            background: #282828; border: 1px solid #444; border-radius: 8px;
+            padding: 24px 32px;
+            color: #e0e0e0; font-family: monospace; font-size: 15px; z-index: 10;
+            text-align: center; min-width: 300px;
             transition: opacity 0.4s ease-out;
         }
         #loading.fade-out { opacity: 0; }
-        #loading.error { color: #f85149; }
+        #loading.error { border-color: #f85149; }
+        #loading.error #status-text { color: #f85149; }
         #progress-bar {
-            margin-top: 12px; height: 6px; background: #21262d; border-radius: 3px;
+            margin-top: 12px; height: 6px; background: #3a3a3a; border-radius: 3px;
             overflow: hidden; position: relative;
         }
         #progress-fill {
-            height: 100%; width: 0%; background: #58a6ff;
+            height: 100%; width: 0%; background: #5c7c2f;
             transition: width 0.15s linear;
         }
         #progress-fill.indeterminate {
@@ -52,69 +39,19 @@
             100% { transform: translateX(400%); }
         }
         #progress-text {
-            margin-top: 8px; font-size: 13px; color: #8b949e;
+            margin-top: 8px; font-size: 13px; color: #999;
         }
         #phase-log {
-            margin-top: 14px; font-size: 12px; color: #6e7681;
+            margin-top: 14px; font-size: 12px; color: #777;
             text-align: left; max-height: 160px; overflow: hidden;
             font-family: 'Fira Code', monospace;
         }
         #phase-log div { padding: 1px 0; }
-        #phase-log div:last-child { color: #c9d1d9; }
-        #level-picker {
-            position: absolute; top: 12px; right: 12px; z-index: 10;
-            background: rgba(0,0,0,0.7); padding: 6px 10px; border-radius: 6px;
-            font-size: 13px; color: #c9d1d9; display: flex; gap: 8px; align-items: center;
-        }
-        #level-picker select {
-            background: #161b22; color: #c9d1d9; border: 1px solid #30363d;
-            padding: 4px 8px; border-radius: 4px; font-size: 13px; cursor: pointer;
-        }
-        #controls-hint {
-            position: absolute; bottom: 16px; left: 16px; background: rgba(0,0,0,0.7);
-            padding: 8px 14px; border-radius: 6px; font-size: 13px; color: #8b949e;
-            pointer-events: none;
-        }
-
-        /* Blog/About tabs */
-        .content { max-width: 720px; margin: 0 auto; padding: 40px 20px; line-height: 1.7; }
-        .content h1 { font-size: 2em; margin-bottom: 16px; color: #f0f6fc; }
-        .content h2 { font-size: 1.4em; margin: 32px 0 12px; color: #f0f6fc; }
-        .content p { margin-bottom: 16px; }
-        .content a { color: #58a6ff; text-decoration: none; }
-        .content a:hover { text-decoration: underline; }
-        .content code {
-            background: #161b22; padding: 2px 6px; border-radius: 4px;
-            font-family: 'Fira Code', monospace; font-size: 0.9em;
-        }
-        .content pre {
-            background: #161b22; padding: 16px; border-radius: 8px;
-            overflow-x: auto; margin-bottom: 16px;
-        }
-        .content pre code { padding: 0; }
-        .content img { max-width: 100%; border-radius: 8px; margin: 16px 0; }
-        .badge {
-            display: inline-block; padding: 4px 10px; border-radius: 12px;
-            font-size: 12px; font-weight: 600; margin-right: 6px;
-        }
-        .badge-green { background: #238636; color: #fff; }
-        .badge-blue { background: #1f6feb; color: #fff; }
-        .badge-orange { background: #9e6a03; color: #fff; }
+        #phase-log div:last-child { color: #e0e0e0; }
     </style>
 </head>
 <body>
-    <nav>
-        <button class="active" onclick="showTab('game')">Play</button>
-        <button onclick="showTab('blog')">Blog</button>
-        <button onclick="showTab('about')">About</button>
-    </nav>
-
-    <!-- Game Tab -->
-    <div id="game-panel" class="panel active">
-        <div id="level-picker">
-            <label for="level-select">Level:</label>
-            <select id="level-select" onchange="onLevelChange()"></select>
-        </div>
+    <div id="game-panel">
         <div id="loading">
             <div id="status-text">Starting…</div>
             <div id="progress-bar"><div id="progress-fill"></div></div>
@@ -122,90 +59,9 @@
             <div id="phase-log"></div>
         </div>
         <canvas id="canvas" tabindex="0"></canvas>
-        <div id="controls-hint">
-            WASD – drive &nbsp;|&nbsp; Space – brake &nbsp;|&nbsp; Q/E – roll &nbsp;|&nbsp; Alt – jump &nbsp;|&nbsp; Shift – turbo
-        </div>
-    </div>
-
-    <!-- Blog Tab -->
-    <div id="blog-panel" class="panel">
-        <div class="content">
-            <h1>Development Log</h1>
-            <p>Technical posts about the vange-rs rendering engine.</p>
-
-            <h2><a href="/2022/11/08/voxels.html">Voxel Tracing</a></h2>
-            <p>Nov 8, 2022 — Accelerating ray-terrain intersection with a voxel octree.</p>
-
-            <h2><a href="/2021/08/25/pure-rust.html">WGSL</a></h2>
-            <p>Aug 25, 2021 — Porting shaders to WGSL and removing the C dependency.</p>
-
-            <h2><a href="/2020/08/29/bar-painting.html">Bar Painting</a></h2>
-            <p>Aug 29, 2020 — A "true" 3D rendering method for the Vangers terrain.</p>
-
-            <h2><a href="/2020/08/04/shadows.html">Hybrid Shadows</a></h2>
-            <p>Aug 4, 2020 — Shadow mapping for the voxel terrain engine.</p>
-
-            <h2><a href="/2019/12/19/gpu-collisions.html">GPU Collisions</a></h2>
-            <p>Dec 19, 2019 — Moving the collision model to the GPU.</p>
-
-            <h2><a href="/2019/12/17/collision-model.html">Collision Model</a></h2>
-            <p>Dec 17, 2019 — How Vangers handles vehicle-terrain collisions.</p>
-
-            <h2><a href="/2019/12/12/data-formats.html">Data Formats</a></h2>
-            <p>Dec 12, 2019 — Reverse-engineering the original Vangers data files.</p>
-
-            <p style="margin-top: 32px;"><a href="/blog">View full blog &rarr;</a></p>
-        </div>
-    </div>
-
-    <!-- About Tab -->
-    <div id="about-panel" class="panel">
-        <div class="content">
-            <h1>About Vangers</h1>
-            <p>
-                <strong>Vangers</strong> (1998) is a legendary open-world racing/RPG game
-                by K-D Lab. It features a unique voxel-based terrain engine and a surreal
-                post-apocalyptic world.
-            </p>
-            <p>
-                <strong>vange-rs</strong> is a Rust reimplementation of the Vangers rendering
-                engine with modern hardware-accelerated graphics via
-                <a href="https://wgpu.rs">wgpu</a> (WebGPU/Vulkan/Metal/DX12).
-            </p>
-
-            <h2>Features</h2>
-            <p>
-                Multiple terrain rendering strategies: ray-traced, voxel-accelerated,
-                sliced, painted, and scattered. Full physics simulation ported from the
-                original game. Cross-platform: Windows, macOS, Linux, and now Web.
-            </p>
-
-            <h2>Requirements</h2>
-            <p>
-                The web demo uses a procedural test level and needs no external data.
-                The desktop version requires the original Vangers game data (available on
-                <a href="https://store.steampowered.com/app/264080/Vangers/">Steam</a> or
-                <a href="https://www.gog.com/game/vangers">GOG</a>).
-            </p>
-
-            <h2>Links</h2>
-            <p>
-                <a href="https://github.com/kvark/vange-rs">GitHub Repository</a><br>
-                <a href="https://github.com/KranX/Vangers">Original Vangers (open source)</a>
-            </p>
-
-            <h2>Technology</h2>
-            <pre><code>Rust + wgpu 29 + winit 0.30 + egui 0.34 + glam 0.29
-WebGPU for browser, Vulkan/Metal/DX12 for desktop
-WGSL shaders, compute-based voxel baking</code></pre>
-        </div>
     </div>
 
     <script>
-        // --- Level picker -----------------------------------------------
-        // Hardcoded list of known worlds. Each must correspond to a
-        // <id>.zip asset on the GitHub release; if the asset is missing
-        // the page falls back to the procedural test level.
         const LEVELS = [
             { id: 'fostral',    title: 'Fostral'    },
             { id: 'glorx',      title: 'Glorx'      },
@@ -229,37 +85,15 @@ WGSL shaders, compute-based voxel baking</code></pre>
             return null;
         }
 
-        function initLevelPicker() {
-            const select = document.getElementById('level-select');
-            for (const lvl of LEVELS) {
-                const opt = document.createElement('option');
-                opt.value = lvl.id;
-                opt.textContent = lvl.title;
-                select.appendChild(opt);
-            }
-            const initial = readHashLevel() || DEFAULT_LEVEL;
-            select.value = initial;
-            // Expose the choice to Rust (read once on startup).
-            window.vangeSelectedLevel = () => select.value;
-        }
+        window.vangeSelectedLevel = function() {
+            return readHashLevel() || DEFAULT_LEVEL;
+        };
 
-        function onLevelChange() {
-            const select = document.getElementById('level-select');
-            // Update URL fragment so the choice survives reloads + sharing.
-            window.location.hash = 'level=' + select.value;
-            // Switching levels requires reinitializing the world; full
-            // reload is the simplest correct option for now.
+        window.vangeNavigateLevel = function(levelId) {
+            window.location.hash = 'level=' + levelId;
             window.location.reload();
-        }
+        };
 
-        // --- Progress bar bridge ---------------------------------------
-        // The WASM loader drives three JS hooks:
-        //   vangePhase(label)          — start of an opaque step
-        //   vangeProgress(label, a, b) — byte progress within a step
-        //   vangeProgressDone()        — everything's ready
-        // A single event log shows the user what happened in order —
-        // useful because phases fly by when data is in the browser
-        // cache, and invisible otherwise.
         const phaseStart = performance.now();
         function logPhase(text) {
             const elapsed = ((performance.now() - phaseStart) / 1000).toFixed(1);
@@ -267,7 +101,6 @@ WGSL shaders, compute-based voxel baking</code></pre>
             const line = document.createElement('div');
             line.textContent = `[${elapsed}s] ${text}`;
             log.appendChild(line);
-            // Keep only the last 8 lines so the overlay stays compact.
             while (log.childElementCount > 8) log.removeChild(log.firstChild);
         }
 
@@ -294,10 +127,6 @@ WGSL shaders, compute-based voxel baking</code></pre>
             }
         };
 
-        // Minimum time the overlay is visible after "Ready" fires, so
-        // even a cached (instant) reload shows the phase log long
-        // enough to read. Measured from the moment the page scripts
-        // started.
         const MIN_OVERLAY_MS = 1500;
         const READY_HOLD_MS = 1200;
 
@@ -310,47 +139,15 @@ WGSL shaders, compute-based voxel baking</code></pre>
                 overlay.classList.add('fade-out');
                 setTimeout(() => {
                     overlay.style.display = 'none';
-                    // Focus the canvas so keyboard events reach winit.
-                    // Without this, focus stays on the level picker
-                    // <select> or a nav button, and WASD is swallowed.
                     const c = document.getElementById('canvas');
                     if (c) { c.focus(); c.click(); }
                 }, 400);
             }, wait);
         };
 
-        // Ensure clicking anywhere on the game panel gives focus to
-        // the canvas. Without this, clicking the surrounding area
-        // (e.g. the controls-hint or empty space) might defocus.
-        // Native <select> dropdowns collapse on focus loss, so we
-        // exempt #level-picker — otherwise clicking it to open the
-        // menu immediately re-focuses the canvas and closes it.
-        document.addEventListener('click', function(e) {
-            if (e.target.closest('#level-picker')) return;
-            const panel = document.getElementById('game-panel');
-            const canvas = document.getElementById('canvas');
-            if (panel?.contains(e.target) && canvas && e.target !== canvas) {
-                canvas.focus();
-            }
-        });
-
-        // winit attaches keydown/keyup listeners to the <canvas>, so
-        // keys only arrive when it has focus. This global interceptor
-        // auto-focuses the canvas on any keypress while the game tab
-        // is active, and re-dispatches the event so winit sees it
-        // immediately (no "press twice" issue).
-        //
-        // Firefox ignores synthetic KeyboardEvents dispatched via
-        // dispatchEvent for security reasons (isTrusted=false), so
-        // the re-dispatch doesn't work there. As a fallback, we also
-        // focus the canvas on the first mouse movement over the game
-        // panel, which covers the typical "move mouse then press key"
-        // flow.
         document.addEventListener('keydown', function(e) {
             const canvas = document.getElementById('canvas');
             if (!canvas || document.activeElement === canvas) return;
-            const panel = document.getElementById('game-panel');
-            if (!panel?.classList.contains('active')) return;
             canvas.focus();
             canvas.dispatchEvent(new KeyboardEvent('keydown', {
                 code: e.code, key: e.key, keyCode: e.keyCode,
@@ -358,21 +155,11 @@ WGSL shaders, compute-based voxel baking</code></pre>
             }));
         });
 
-        // Focus canvas when mouse enters the game area — covers the
-        // common case where the user moves the mouse over the game
-        // before pressing keys. On Firefox this is more reliable than
-        // the keydown re-dispatch above.
-        // Skip while a form control inside the panel has focus (e.g.
-        // the level picker is open) — otherwise the dropdown closes
-        // the instant the cursor moves while picking a level.
         document.getElementById('game-panel')?.addEventListener(
             'mousemove',
             function(e) {
-                if (e.target.closest('#level-picker')) return;
-                const active = document.activeElement;
-                if (active && active.tagName === 'SELECT') return;
                 const c = document.getElementById('canvas');
-                if (c && active !== c) c.focus();
+                if (c && document.activeElement !== c) c.focus();
             },
             { passive: true }
         );
@@ -384,7 +171,6 @@ WGSL shaders, compute-based voxel baking</code></pre>
                 'Could not load level data — using procedural fallback.';
             document.getElementById('progress-text').textContent = message;
             logPhase('Error: ' + message);
-            // Keep the message visible briefly, then hide so the canvas shows.
             setTimeout(() => { loading.style.display = 'none'; }, 4000);
         };
 
@@ -394,33 +180,12 @@ WGSL shaders, compute-based voxel baking</code></pre>
             return (n / 1024 / 1024).toFixed(1) + ' MiB';
         }
 
-        // --- Tabs / WASM bootstrap -------------------------------------
-        function showTab(name) {
-            document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
-            document.querySelectorAll('nav button').forEach(b => b.classList.remove('active'));
-            document.getElementById(name + '-panel').classList.add('active');
-            event.target.classList.add('active');
-
-            // Lazy-load the WASM module when the game tab is first shown
-            if (name === 'game' && !window._wasmLoaded) {
-                window._wasmLoaded = true;
-                loadGame();
-            }
-        }
-
         async function loadGame() {
             try {
                 const { default: init } = await import('./web.js');
                 await init();
-                // Don't hide the overlay here. The WASM loader's own
-                // `vangeProgressDone()` hook does that once the async
-                // spawn_local pipeline finishes (fetch → mount →
-                // build_gpu_state). Hiding here would race ahead of
-                // the phases the user is supposed to see.
             } catch (err) {
                 const msg = String(err);
-                // winit uses exceptions for control flow on WASM;
-                // this is expected and not an actual error.
                 if (msg.includes('Using exceptions for control flow')) {
                     return;
                 }
@@ -434,9 +199,6 @@ WGSL shaders, compute-based voxel baking</code></pre>
             }
         }
 
-        // Set up UI before the WASM module starts so its initial
-        // `vangeSelectedLevel()` call sees the populated <select>.
-        initLevelPicker();
         loadGame();
     </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,8 +20,8 @@
             transition: opacity 0.4s ease-out;
         }
         #loading.fade-out { opacity: 0; }
-        #loading.error { border-color: #f85149; }
-        #loading.error #status-text { color: #f85149; }
+        #loading.error { border-color: #888; }
+        #loading.error #status-text { color: #aaa; }
         #progress-bar {
             margin-top: 10px; height: 3px; background: #444; border-radius: 0;
             overflow: hidden; position: relative;

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,21 +13,21 @@
         }
         #loading {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
-            background: #282828; border: 1px solid #444; border-radius: 8px;
-            padding: 24px 32px;
-            color: #e0e0e0; font-family: monospace; font-size: 15px; z-index: 10;
-            text-align: center; min-width: 300px;
+            background: #282828; border: 1px solid #555; border-radius: 0;
+            padding: 20px 28px;
+            color: #ccc; font-family: monospace; font-size: 13px; z-index: 10;
+            text-align: center; min-width: 260px;
             transition: opacity 0.4s ease-out;
         }
         #loading.fade-out { opacity: 0; }
         #loading.error { border-color: #f85149; }
         #loading.error #status-text { color: #f85149; }
         #progress-bar {
-            margin-top: 12px; height: 6px; background: #3a3a3a; border-radius: 3px;
+            margin-top: 10px; height: 3px; background: #444; border-radius: 0;
             overflow: hidden; position: relative;
         }
         #progress-fill {
-            height: 100%; width: 0%; background: #5c7c2f;
+            height: 100%; width: 0%; background: #888;
             transition: width 0.15s linear;
         }
         #progress-fill.indeterminate {
@@ -39,15 +39,14 @@
             100% { transform: translateX(400%); }
         }
         #progress-text {
-            margin-top: 8px; font-size: 13px; color: #999;
+            margin-top: 6px; font-size: 12px; color: #888;
         }
         #phase-log {
-            margin-top: 14px; font-size: 12px; color: #777;
-            text-align: left; max-height: 160px; overflow: hidden;
-            font-family: 'Fira Code', monospace;
+            margin-top: 10px; font-size: 12px; color: #777;
+            text-align: left; max-height: 120px; overflow: hidden;
         }
         #phase-log div { padding: 1px 0; }
-        #phase-log div:last-child { color: #e0e0e0; }
+        #phase-log div:last-child { color: #aaa; }
     </style>
 </head>
 <body>

--- a/src/config/car.rs
+++ b/src/config/car.rs
@@ -175,6 +175,44 @@ pub fn first_main_entry<R: Read>(reader: R) -> (String, Vec<u32>) {
     (name.to_owned(), data)
 }
 
+/// Parse `car.prm` and return a list of all vehicle names in order.
+/// Suitable for populating a car-selection UI without loading GPU
+/// resources.
+pub fn list_car_names<R: Read>(reader: R) -> Vec<String> {
+    let mut fi = Reader::new(reader);
+    fi.advance();
+    assert_eq!(fi.cur(), "uniVang-ParametersFile_Ver_1");
+    let num_main: u8 = fi.next_value();
+    let num_ruffa: u8 = fi.next_value();
+    let num_const: u8 = fi.next_value();
+    let total = (num_main + num_ruffa + num_const) as usize;
+    let mut names = Vec::with_capacity(total);
+    for _ in 0..total {
+        let (name, _) = fi.next_entry::<u32>();
+        names.push(name.to_owned());
+    }
+    names
+}
+
+/// Parse `car.prm` and return the stats data (`Vec<u32>`) for a named
+/// vehicle. Returns `None` if the name is not found.
+pub fn stats_for_name<R: Read>(name: &str, reader: R) -> Option<Vec<u32>> {
+    let mut fi = Reader::new(reader);
+    fi.advance();
+    assert_eq!(fi.cur(), "uniVang-ParametersFile_Ver_1");
+    let num_main: u8 = fi.next_value();
+    let num_ruffa: u8 = fi.next_value();
+    let num_const: u8 = fi.next_value();
+    let total = (num_main + num_ruffa + num_const) as usize;
+    for _ in 0..total {
+        let (entry_name, data) = fi.next_entry::<u32>();
+        if entry_name == name {
+            return Some(data);
+        }
+    }
+    None
+}
+
 pub fn load_registry(
     settings: &Settings,
     reg: &super::game::Registry,


### PR DESCRIPTION
## Summary

- **Native road binary**: Move multiplayer panel from floating `egui::Window` into the right `SidePanel` as a group under Renderer, matching the existing panel layout
- **Web binary**: Replace floating Settings window with a full right sidebar matching native layout — level selector, mechous color picker, camera follow controls (angle/offset/speed/ground anchor), renderer controls, controls reference, and links
- **Web HTML**: Remove nav header, level picker overlay, and controls hint (all functionality moved to the egui sidebar). Restyle loading screen to match egui dark theme (#282828 bg, #5c7c2f progress bar)
- **Vertical extrusion**: Change `geometry.height` from `0x100` (256) to `0x80` (128) — matches the web build's existing override and corrects the 2x vertical exaggeration vs the original 1998 game look
- **All sidebar groups** span full panel width via `ui.set_width(ui.available_width())`

## Changes

| File | Change |
|------|--------|
| `bin/road/game.rs` | Multiplayer moved from Window to SidePanel group; borrow fix with pre-cloned car info |
| `bin/web/main.rs` | Full right panel with Level/Mechous/Camera/Renderer/Controls/Links groups; level ComboBox with page-reload navigation; camera follow controls; `ground_anchor` field added; color picker for mechous |
| `docs/index.html` | Removed nav, blog/about panels, level picker overlay, controls hint; added `vangeNavigateLevel` JS bridge; restyled loading screen to egui dark theme |
| `config/settings.ron` | `geometry.height: 0x80` (was `0x100`) |