### PR TITLE
Shadow: tight projection around camera + edge fade

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -132,6 +132,8 @@ jobs:
       run: rustup target add wasm32-unknown-unknown
     - name: Install wasm-bindgen-cli
       run: cargo install wasm-bindgen-cli --version 0.2.117
+    - name: Copy settings template
+      run: cp config/settings.template.ron config/settings.ron
     - name: Build WASM binary
       run: cargo build --target wasm32-unknown-unknown --features web --bin web --release
     - name: Generate JS bindings

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -449,10 +449,6 @@ impl WebApp {
             };
         } else {
             render_settings.terrain = settings::Terrain::RayTraced;
-            // The WebGL2 fallback is fragment-bound; halving the shadow
-            // map (1024 → 512) gives back ~75% of the shadow-pass cost
-            // and the difference at this view distance is invisible.
-            render_settings.light.shadow.size = 512;
         }
         let geometry = settings.game.geometry;
         let render = Render::new(

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=config/settings.template.ron");
+}

--- a/res/shader/shadow.inc.wgsl
+++ b/res/shader/shadow.inc.wgsl
@@ -31,7 +31,12 @@ fn fetch_shadow_visibility(pos: vec3<f32>) -> f32 {
     shadow += textureSampleCompareLevel(t_Shadow, s_Shadow, light_local + texel * vec2<f32>( 0.5, -0.5), depth);
     shadow += textureSampleCompareLevel(t_Shadow, s_Shadow, light_local + texel * vec2<f32>(-0.5,  0.5), depth);
     shadow += textureSampleCompareLevel(t_Shadow, s_Shadow, light_local + texel * vec2<f32>( 0.5,  0.5), depth);
-    return 0.25 * shadow;
+    // Fade shadows near the edge of the shadow map so they don't
+    // cut off abruptly. `fade` goes from 1 (fully shadowed) at the
+    // interior to 0 (fully lit) at the boundary.
+    let edge = min(light_local, vec2<f32>(1.0) - light_local);
+    let fade = saturate(min(edge.x, edge.y) * 10.0);
+    return mix(1.0, 0.25 * shadow, fade);
 }
 
 // Convenience wrapper: visibility mixed with the ambient floor. Object

--- a/src/render/shadow.rs
+++ b/src/render/shadow.rs
@@ -82,21 +82,25 @@ impl Shadow {
             far: 0.0,
         };
 
-        // in addition to the camera bound, we need to include
-        // all the potential occluders nearby — extend the bounds in the
-        // to-sun direction so a tall column behind the visible region
-        // can still cast a shadow into it.
-        let mut offset = to_sun * (max_height / to_sun.z);
-        offset.z = 0.0;
+        // Limit the shadow region to a box around the camera center
+        // rather than covering the entire view frustum. This keeps
+        // shadow texel density high near the player where it matters.
+        // The radius is capped so that cameras with very long far
+        // planes don't produce continent-sized shadow maps.
+        let shadow_radius = 600.0f32;
+        let center = self.cam.loc;
+        let corners = [
+            Vec3::new(center.x - shadow_radius, center.y - shadow_radius, 0.0),
+            Vec3::new(center.x + shadow_radius, center.y - shadow_radius, 0.0),
+            Vec3::new(center.x + shadow_radius, center.y + shadow_radius, 0.0),
+            Vec3::new(center.x - shadow_radius, center.y + shadow_radius, 0.0),
+            Vec3::new(center.x - shadow_radius, center.y - shadow_radius, max_height),
+            Vec3::new(center.x + shadow_radius, center.y - shadow_radius, max_height),
+            Vec3::new(center.x + shadow_radius, center.y + shadow_radius, max_height),
+            Vec3::new(center.x - shadow_radius, center.y + shadow_radius, max_height),
+        ];
 
-        let points_lo = cam.bound_points(0.0);
-        let points_hi = cam.bound_points(max_height);
-        for pt in points_lo
-            .iter()
-            .cloned()
-            .chain(points_hi.iter().cloned())
-            .chain(points_hi.iter().map(|&pp| pp + offset))
-        {
+        for pt in corners {
             let local = self.get_local_point(pt);
             p.left = p.left.min(local.x);
             p.bottom = p.bottom.min(local.y);


### PR DESCRIPTION
- Limit shadow ortho frustum to a 600-unit radius box around the camera center instead of covering the entire view frustum. Keeps shadow texel density high near the player regardless of far plane.
- Fade shadows at the shadow map boundary instead of hard cutoff.
- Remove WebGL2 shadow size override (no longer needed).
- CI: copy settings.template.ron for WASM build.
- Add build.rs for rerun-if-changed on settings template.