### PR TITLE
UI: translucent nav, nav status, glass-blur controls, WGSL fix, cached DOM updates

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -505,32 +505,20 @@ impl WebApp {
         }
     }
 
-    fn draw_ui(&self, ctx: &egui::Context) {
-        egui::Window::new("Settings").show(ctx, |ui| {
-            ui.label(format!(
-                "Backend: {}",
-                if self.is_webgpu { "WebGPU" } else { "WebGL2" }
-            ));
-            if let Some(ref agent) = self.agent {
-                ui.separator();
-                ui.label("Vehicle");
-                let pos = agent.transform.disp;
-                ui.label(format!(
-                    "Position: ({:.0}, {:.0}, {:.0})",
-                    pos.x, pos.y, pos.z
-                ));
-                ui.label(format!(
-                    "Speed: {:.1}",
-                    agent.dynamo.linear_velocity.length()
-                ));
+    fn draw_ui(&self, _ctx: &egui::Context) {
+        if let Some(document) = web_sys::window()
+            .and_then(|w| w.document())
+        {
+            if let Some(el) = document.get_element_by_id("nav-backend") {
+                el.set_text_content(Some(if self.is_webgpu { "WebGPU" } else { "WebGL2" }));
             }
-            ui.separator();
-            ui.label("Camera");
-            ui.label(format!(
-                "Pos: ({:.0}, {:.0}, {:.0})",
-                self.cam.loc.x, self.cam.loc.y, self.cam.loc.z
-            ));
-        });
+            if let Some(el) = document.get_element_by_id("nav-camera") {
+                el.set_text_content(Some(&format!(
+                    "({:.0}, {:.0}, {:.0})",
+                    self.cam.loc.x, self.cam.loc.y, self.cam.loc.z
+                )));
+            }
+        }
     }
 
     fn resize(&mut self, extent: wgpu::Extent3d, device: &wgpu::Device) {

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -7,8 +7,6 @@
 
 use wasm_bindgen::prelude::*;
 
-use std::cell::RefCell;
-
 use vangers::{
     config::{self, settings},
     data, level, model, physics,
@@ -352,9 +350,6 @@ struct WebApp {
     follow: space::Follow,
     /// True when running on WebGPU (vs WebGL2 fallback).
     is_webgpu: bool,
-    /// Cached DOM elements for nav status updates.
-    nav_els: RefCell<Option<(web_sys::Element, web_sys::Element)>>,
-    nav_text: RefCell<(String, String)>,
 }
 
 impl WebApp {
@@ -507,36 +502,21 @@ impl WebApp {
             agent,
             follow,
             is_webgpu,
-            nav_els: RefCell::new(None),
-            nav_text: RefCell::new((String::new(), String::new())),
         }
     }
 
     fn draw_ui(&self, _ctx: &egui::Context) {
-        let mut els = self.nav_els.borrow_mut();
-        if els.is_none() {
-            if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
-                let backend = doc.get_element_by_id("nav-backend");
-                let camera = doc.get_element_by_id("nav-camera");
-                if let (Some(be), Some(ce)) = (backend, camera) {
-                    *els = Some((be, ce));
-                }
+        if let Some(document) = web_sys::window()
+            .and_then(|w| w.document())
+        {
+            if let Some(el) = document.get_element_by_id("nav-backend") {
+                el.set_text_content(Some(if self.is_webgpu { "WebGPU" } else { "WebGL2" }));
             }
-        }
-        if let Some((ref backend_el, ref camera_el)) = *els {
-            let backend_text = if self.is_webgpu { "WebGPU" } else { "WebGL2" };
-            let camera_text = format!(
-                "({:.0}, {:.0}, {:.0})",
-                self.cam.loc.x, self.cam.loc.y, self.cam.loc.z
-            );
-            let mut last = self.nav_text.borrow_mut();
-            if last.0 != backend_text {
-                backend_el.set_text_content(Some(backend_text));
-                last.0 = backend_text.to_string();
-            }
-            if last.1 != camera_text {
-                camera_el.set_text_content(Some(&camera_text));
-                last.1 = camera_text;
+            if let Some(el) = document.get_element_by_id("nav-camera") {
+                el.set_text_content(Some(&format!(
+                    "({:.0}, {:.0}, {:.0})",
+                    self.cam.loc.x, self.cam.loc.y, self.cam.loc.z
+                )));
             }
         }
     }

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -7,6 +7,8 @@
 
 use wasm_bindgen::prelude::*;
 
+use std::cell::RefCell;
+
 use vangers::{
     config::{self, settings},
     data, level, model, physics,
@@ -350,6 +352,9 @@ struct WebApp {
     follow: space::Follow,
     /// True when running on WebGPU (vs WebGL2 fallback).
     is_webgpu: bool,
+    /// Cached DOM elements for nav status updates.
+    nav_els: RefCell<Option<(web_sys::Element, web_sys::Element)>>,
+    nav_text: RefCell<(String, String)>,
 }
 
 impl WebApp {
@@ -502,21 +507,36 @@ impl WebApp {
             agent,
             follow,
             is_webgpu,
+            nav_els: RefCell::new(None),
+            nav_text: RefCell::new((String::new(), String::new())),
         }
     }
 
     fn draw_ui(&self, _ctx: &egui::Context) {
-        if let Some(document) = web_sys::window()
-            .and_then(|w| w.document())
-        {
-            if let Some(el) = document.get_element_by_id("nav-backend") {
-                el.set_text_content(Some(if self.is_webgpu { "WebGPU" } else { "WebGL2" }));
+        let mut els = self.nav_els.borrow_mut();
+        if els.is_none() {
+            if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+                let backend = doc.get_element_by_id("nav-backend");
+                let camera = doc.get_element_by_id("nav-camera");
+                if let (Some(be), Some(ce)) = (backend, camera) {
+                    *els = Some((be, ce));
+                }
             }
-            if let Some(el) = document.get_element_by_id("nav-camera") {
-                el.set_text_content(Some(&format!(
-                    "({:.0}, {:.0}, {:.0})",
-                    self.cam.loc.x, self.cam.loc.y, self.cam.loc.z
-                )));
+        }
+        if let Some((ref backend_el, ref camera_el)) = *els {
+            let backend_text = if self.is_webgpu { "WebGPU" } else { "WebGL2" };
+            let camera_text = format!(
+                "({:.0}, {:.0}, {:.0})",
+                self.cam.loc.x, self.cam.loc.y, self.cam.loc.z
+            );
+            let mut last = self.nav_text.borrow_mut();
+            if last.0 != backend_text {
+                backend_el.set_text_content(Some(backend_text));
+                last.0 = backend_text.to_string();
+            }
+            if last.1 != camera_text {
+                camera_el.set_text_content(Some(&camera_text));
+                last.1 = camera_text;
             }
         }
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,7 +102,7 @@
         }
 
         /* Blog/About tabs */
-        .content { max-width: 720px; margin: 0 auto; padding: 40px 20px; line-height: 1.7; }
+        .content { max-width: 720px; margin: 0 auto; padding: 87px 20px 40px; line-height: 1.7; }
         .content h1 { font-size: 2em; margin-bottom: 16px; color: #f0f6fc; }
         .content h2 { font-size: 1.4em; margin: 32px 0 12px; color: #f0f6fc; }
         .content p { margin-bottom: 16px; }

--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,14 @@
         body { font-family: 'Segoe UI', system-ui, sans-serif; background: #0d1117; color: #c9d1d9; }
 
         /* Tab bar */
-        nav { display: flex; background: #161b22; border-bottom: 1px solid #30363d; }
+        nav {
+            position: fixed; top: 0; left: 0; right: 0; z-index: 10;
+            display: flex; align-items: center;
+            background: rgba(22, 27, 34, 0.65);
+            border-bottom: 1px solid rgba(48, 54, 61, 0.5);
+            backdrop-filter: blur(6px);
+            -webkit-backdrop-filter: blur(6px);
+        }
         nav button {
             padding: 12px 24px; background: none; border: none; color: #8b949e;
             font-size: 15px; cursor: pointer; border-bottom: 2px solid transparent;
@@ -17,6 +24,11 @@
         }
         nav button:hover { color: #c9d1d9; }
         nav button.active { color: #58a6ff; border-bottom-color: #58a6ff; }
+        #nav-status {
+            margin-left: auto; display: flex; align-items: center; gap: 16px;
+            font-size: 12px; color: #8b949e; padding-right: 14px;
+        }
+        #nav-status span { font-family: 'Fira Code', monospace; color: #c9d1d9; }
 
         /* Panels */
         .panel { display: none; }
@@ -25,7 +37,7 @@
         /* Game tab */
         #game-panel { position: relative; }
         #game-panel canvas {
-            width: 100vw; height: calc(100vh - 47px); display: block; background: #1a1a2e;
+            width: 100vw; height: 100vh; display: block; background: #1a1a2e;
         }
         #loading {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);
@@ -62,16 +74,29 @@
         #phase-log div { padding: 1px 0; }
         #phase-log div:last-child { color: #c9d1d9; }
         #level-picker {
-            position: absolute; top: 12px; right: 12px; z-index: 10;
-            background: rgba(0,0,0,0.7); padding: 6px 10px; border-radius: 6px;
-            font-size: 13px; color: #c9d1d9; display: flex; gap: 8px; align-items: center;
+            position: absolute; bottom: 16px; left: 16px; z-index: 10;
+            display: flex; gap: 8px; align-items: center;
+            background: rgba(0,0,0,0.5);
+            backdrop-filter: blur(6px);
+            -webkit-backdrop-filter: blur(6px);
+            padding: 6px 10px; border-radius: 6px;
+            font-size: 13px; color: #c9d1d9;
         }
         #level-picker select {
-            background: #161b22; color: #c9d1d9; border: 1px solid #30363d;
-            padding: 4px 8px; border-radius: 4px; font-size: 13px; cursor: pointer;
+            appearance: none; -webkit-appearance: none;
+            background-color: rgba(255,255,255,0.08);
+            background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%238b949e' d='M3 8h6L6 3z'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 6px center;
+            color: #c9d1d9; border: 1px solid rgba(48,54,61,0.5);
+            padding: 4px 22px 4px 8px; border-radius: 4px;
+            font-size: 13px; cursor: pointer;
         }
         #controls-hint {
-            position: absolute; bottom: 16px; left: 16px; background: rgba(0,0,0,0.7);
+            position: absolute; bottom: 16px; right: 16px; z-index: 10;
+            background: rgba(0,0,0,0.5);
+            backdrop-filter: blur(6px);
+            -webkit-backdrop-filter: blur(6px);
             padding: 8px 14px; border-radius: 6px; font-size: 13px; color: #8b949e;
             pointer-events: none;
         }
@@ -107,23 +132,28 @@
         <button class="active" onclick="showTab('game')">Play</button>
         <button onclick="showTab('blog')">Blog</button>
         <button onclick="showTab('about')">About</button>
+        <div id="nav-status">
+            Backend: <span id="nav-backend">…</span>
+            &nbsp;|&nbsp;
+            Camera: <span id="nav-camera">…</span>
+        </div>
     </nav>
 
     <!-- Game Tab -->
     <div id="game-panel" class="panel active">
-        <div id="level-picker">
-            <label for="level-select">Level:</label>
-            <select id="level-select" onchange="onLevelChange()"></select>
-        </div>
         <div id="loading">
             <div id="status-text">Starting…</div>
             <div id="progress-bar"><div id="progress-fill"></div></div>
             <div id="progress-text"></div>
             <div id="phase-log"></div>
         </div>
+        <div id="level-picker">
+            <label for="level-select">Level:</label>
+            <select id="level-select" onchange="onLevelChange()"></select>
+        </div>
         <canvas id="canvas" tabindex="0"></canvas>
         <div id="controls-hint">
-            WASD – drive &nbsp;|&nbsp; Space – brake &nbsp;|&nbsp; Q/E – roll &nbsp;|&nbsp; Alt – jump &nbsp;|&nbsp; Shift – turbo
+            WASD – drive &nbsp;|&nbsp; Space – brake &nbsp;|&nbsp; Q/E – roll &nbsp;|&nbsp; Alt – jump &nbsp;|&nbsp; Shift – turbo &nbsp;|&nbsp; Z/X – zoom
         </div>
     </div>
 

--- a/res/shader/object.wgsl
+++ b/res/shader/object.wgsl
@@ -62,7 +62,7 @@ struct Varyings {
     @location(0) palette_range: vec2<f32>,
     @location(1) position: vec3<f32>,
     @location(2) normal: vec3<f32>,
-    @location(3) color_id: u32,
+    @location(3) @interpolate(flat) color_id: u32,
 };
 
 @vertex


### PR DESCRIPTION
## Changes

### Web UI layout ()
- **Translucent nav bar**: `position: fixed` over canvas, `rgba(22,27,34,0.65)` + `backdrop-filter: blur(6px)`
- **Nav right side**: live `Backend: WebGPU | Camera: (x, y, z)` status
- **Canvas**: full `100vh` since nav floats over it
- **Level picker**: bottom-left, upward-pointing custom SVG arrow, glass blur background
- **Drive controls**: bottom-right, same glass blur, added Z/X zoom hint
- **Content panels**: 87px top padding to clear the fixed nav

### Rust ()
- Removed egui settings popup; `draw_ui` writes backend/camera into DOM elements
- DOM elements cached once via `RefCell`, only `set_text_content` when values actually change

### WGSL ()
- Added `@interpolate(flat)` to `color_id: u32` vertex output