### PR TITLE
Profile web startup, and lazily fit the terrain TIN on wasm

### DIFF
--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -264,6 +264,9 @@ struct Agent {
     dynamo: physics::Dynamo,
     control: Control,
     color: render::object::BodyColor,
+    /// Stretches each wheel covered since the last frame, cut into the
+    /// ground afterwards - see `WebApp::step_tracks`.
+    tracks: level::terraform::Tracks,
 }
 
 impl Agent {
@@ -310,7 +313,7 @@ impl Agent {
             self.control.jump.take(),
             self.control.roll,
             None, // line_buffer
-            None, // tracks
+            Some(&mut self.tracks),
         );
     }
 }
@@ -382,6 +385,7 @@ fn spawn_default_agent(
         dynamo: physics::Dynamo::default(),
         control: Control::default(),
         color: PLAYER_COLOR,
+        tracks: level::terraform::Tracks::default(),
     })
 }
 
@@ -405,6 +409,9 @@ struct WebApp {
     /// True when running on WebGPU (vs WebGL2 fallback).
     is_webgpu: bool,
     moving: level::moving::MovingWorld,
+    /// Terrain-editing effects the car is allowed to leave behind. Same
+    /// defaults as the native game: tread on, hull-press and mole mounds off.
+    terraform: level::terraform::Config,
 }
 
 impl WebApp {
@@ -466,9 +473,21 @@ impl WebApp {
     /// VFS key of the world INI (e.g. `"fostral/world.ini"`).
     fn new_from_vfs(gfx: &GraphicsContext, vfs: &Vfs, ini_path: &str, is_webgpu: bool) -> Self {
         let settings = Self::load_settings();
+        let t = Instant::now();
         let level_config = level::LevelConfig::load_from_vfs(vfs, ini_path);
         let level = level::load_from_vfs(vfs, &level_config, &settings.game.geometry);
-        Self::build(gfx, level_config, level, Some(vfs), is_webgpu, &settings)
+        log::info!(
+            "[startup] level '{ini_path}' loaded in {:.0} ms ({} texels)",
+            t.elapsed().as_secs_f32() * 1e3,
+            level.size.0 as u64 * level.size.1 as u64 / 1024 * 1024
+        );
+        let t = Instant::now();
+        let app = Self::build(gfx, level_config, level, Some(vfs), is_webgpu, &settings);
+        log::info!(
+            "[startup] app built in {:.0} ms",
+            t.elapsed().as_secs_f32() * 1e3
+        );
+        app
     }
 
     fn build(
@@ -550,6 +569,7 @@ impl WebApp {
             render_settings.light.shadow.terrain = settings::ShadowTerrain::RayTraced;
         }
         let geometry = settings.game.geometry;
+        let t = Instant::now();
         let render = Render::new(
             gfx,
             &level_config,
@@ -557,6 +577,10 @@ impl WebApp {
             &render_settings,
             &geometry,
             cam.front_face(),
+        );
+        log::info!(
+            "[startup] renderer built in {:.0} ms",
+            t.elapsed().as_secs_f32() * 1e3
         );
 
         // If the VFS has `common.prm` and a vehicle registry, spawn a
@@ -567,8 +591,14 @@ impl WebApp {
             .and_then(|v| v.read("common.prm"))
             .map(|b| config::common::load_reader(std::io::Cursor::new(&*b)))
             .unwrap_or_else(config::common::Common::test_default);
+        let t = Instant::now();
         let agent = vfs.and_then(|v| spawn_default_agent(v, &level, &gfx.device, &render.object));
-        if agent.is_none() {
+        if agent.is_some() {
+            log::info!(
+                "[startup] player vehicle built in {:.0} ms",
+                t.elapsed().as_secs_f32() * 1e3
+            );
+        } else {
             log::info!("No player agent — running in free-camera mode");
         }
 
@@ -581,7 +611,12 @@ impl WebApp {
             look_ahead: cam_config.look_ahead,
         };
 
+        let moving_t = Instant::now();
         let moving = level::moving::MovingWorld::load(&level_config, vfs);
+        log::info!(
+            "[startup] moving world loaded in {:.0} ms",
+            moving_t.elapsed().as_secs_f32() * 1e3
+        );
 
         // Settle the follow camera at the agent's spawn pose. Without
         // this, the camera starts at the placeholder above and the slow
@@ -607,6 +642,7 @@ impl WebApp {
             max_quant: settings.game.physics.max_quant,
             is_webgpu,
             moving,
+            terraform: level::terraform::Config::default(),
         }
     }
 
@@ -664,6 +700,66 @@ impl WebApp {
         });
         let regions = self.moving.step(&mut self.level, delta, touches);
         self.render.dirty_terrain(regions, height);
+    }
+
+    /// Cuts the stretches the wheels covered since the last frame into the
+    /// level, and hands the touched rectangles to the renderer. Port of the
+    /// native game's `step_tracks` (bin/road/game.rs); the physics records
+    /// the wheels' stretches over an immutable level, and the cutting here
+    /// runs where the level can be borrowed mutably.
+    fn step_tracks(&mut self) {
+        let Some(agent) = self.agent.as_mut() else {
+            return;
+        };
+        if !self.terraform.tread.enabled
+            && !self.terraform.grader.enabled
+            && !self.terraform.press.enabled
+            && !self.terraform.molehills.enabled
+        {
+            agent.tracks.reset();
+            return;
+        }
+
+        let mut regions = Vec::new();
+        for burrow in agent.tracks.drain_burrows() {
+            level::terraform::apply_burrow(
+                &mut self.level,
+                &self.terraform.molehills,
+                &burrow,
+                &mut regions,
+            );
+        }
+        if let Some(hull) = agent.tracks.take_hull() {
+            level::terraform::apply_press(
+                &mut self.level,
+                &self.terraform.press,
+                &hull,
+                &mut regions,
+            );
+        }
+        for sweep in agent.tracks.drain_sweeps() {
+            level::terraform::apply_grader(
+                &mut self.level,
+                &self.terraform.grader,
+                &sweep,
+                &mut regions,
+            );
+        }
+        for track in agent.tracks.drain() {
+            level::terraform::apply_tread(
+                &mut self.level,
+                &self.terraform.tread,
+                &track,
+                &mut regions,
+            );
+        }
+        if regions.is_empty() {
+            return;
+        }
+        regions.sort_unstable();
+        regions.dedup();
+        let height = self.level.geometry.height as u16;
+        self.render.dirty_terrain(&regions, height);
     }
 
     fn draw(
@@ -892,6 +988,9 @@ struct WebHandler {
     _dom_input: Option<DomInputHooks>,
     last_frame: Option<Instant>,
     ws_client: Option<net_ws::WsClient>,
+    /// The first frame builds the whole terrain TIN and uploads it; time
+    /// it once so the console shows where startup actually goes.
+    first_draw_measured: bool,
     /// Status text overlay (used in multiplayer logging)
     #[allow(dead_code)]
     mp_status: String,
@@ -943,6 +1042,7 @@ impl WebHandler {
             ui_pointer: std::rc::Rc::new(std::cell::RefCell::new(Vec::new())),
             _dom_input: None,
             last_frame: None,
+            first_draw_measured: false,
             ws_client,
             mp_status,
         }
@@ -1700,6 +1800,9 @@ impl WebHandler {
             }
         }
 
+        // Cut the wheels' tracks into the level after the physics ran.
+        gpu.app.step_tracks();
+
         // Process multiplayer messages
         if let Some(ref mut ws) = self.ws_client {
             // Send input
@@ -1770,7 +1873,17 @@ impl WebHandler {
             color: &view,
             depth: &gpu.depth_view,
         };
+        let t = Instant::now();
         let command_buffer = gpu.app.draw(&gpu.device, &gpu.queue, targets);
+        if !self.first_draw_measured {
+            self.first_draw_measured = true;
+            // The mesh renderer builds the TIN lazily on the first update,
+            // so the first frame pays for the whole level's fit + upload.
+            log::info!(
+                "[startup] first frame (terrain TIN build + upload) took {:.0} ms",
+                t.elapsed().as_secs_f32() * 1e3
+            );
+        }
 
         // --- egui UI pass ---
         let mut raw_input = gpu.egui_state.take_egui_input(&gpu.window);

--- a/src/level/tin.rs
+++ b/src/level/tin.rs
@@ -1461,6 +1461,14 @@ impl Tin {
             if state.pending.is_empty() {
                 continue;
             }
+            // Not built yet - the web build scaffolds every chunk and fills
+            // them in over the first ticks (`build_chunk`). Until one is
+            // built its LODs are empty, and a refit has no triangulation to
+            // refine. `build_chunk` reads the current level, so the edit
+            // banked here is picked up then.
+            if state.lods.is_empty() {
+                continue;
+            }
             let lod = match drawn {
                 None => 0,
                 Some(list) => match list.get(index).copied().flatten() {
@@ -1562,9 +1570,13 @@ impl Tin {
             // One 128² refine plus a WebGL buffer upload is several
             // milliseconds in the browser. A cyclic set on Fostral can
             // put tens of chunks due at once; doing them all in one
-            // frame is the one-second hitch. Skip the rest: pending
-            // stays, and the start index walks so they all get a turn.
-            const MAX_REFITS: usize = 4;
+            // frame is the one-second hitch. One per tick - the start
+            // index walks so every chunk still gets a turn - keeps a
+            // single chunk's refit from ever taxing one frame, at the
+            // cost of a longer catch-up when the whole world edits at
+            // once (the moving land on Fostral cycles 24 locations, so
+            // the catch-up trails over a couple of seconds of frames).
+            const MAX_REFITS: usize = 1;
             let n = self.chunks.len();
             if n == 0 {
                 return Vec::new();
@@ -1576,13 +1588,122 @@ impl Tin {
                     break;
                 }
                 let index = (start + k) % n;
-                if self.chunks[index].due {
+                if self.chunks[index].due && !self.chunks[index].lods.is_empty() {
                     let state = &mut self.chunks[index];
                     out.push(refit(index, state));
                 }
             }
             out
         }
+    }
+
+    /// Chunk scaffolding with nothing triangulated, for the web build.
+    ///
+    /// `build` triangulates the whole level up front; on a single-threaded
+    /// wasm that is the seconds-long hitch the loading screen sits on.
+    /// `scaffold` creates every `ChunkState` so chunk indices, the render
+    /// wrapper's per-chunk arrays and the draw walk are all stable, but
+    /// leaves every LOD empty. [`Tin::build_chunk`] then fills them in a
+    /// few at a time, nearest the camera first, over the first frames.
+    #[cfg(target_arch = "wasm32")]
+    pub fn scaffold(level: &Level, config: &Config) -> (Self, Mesh) {
+        profiling::scope!("Scaffold Terrain TIN");
+
+        let max_error = config.max_error(level);
+        let step = CHUNK_SIZE as i32;
+        let spans_of = |total: i32| {
+            let mut spans = Vec::new();
+            let mut at = 0;
+            while at < total {
+                spans.push((at, (total - at).min(step) as u32));
+                at += step;
+            }
+            spans
+        };
+        let origins = {
+            let mut v = Vec::new();
+            for &(y, h) in &spans_of(level.size.1) {
+                for &(x, w) in &spans_of(level.size.0) {
+                    v.push((x, y, w, h));
+                }
+            }
+            v
+        };
+
+        let chunks = origins
+            .iter()
+            .map(|&(x, y, w, h)| ChunkState {
+                x0: x,
+                y0: y,
+                w,
+                h,
+                // Filled by `build_chunk`, which also refreshes the bbox.
+                alt: (0.0, 0.0),
+                lods: Vec::new(),
+                pending: Vec::new(),
+                due: false,
+                hidden: false,
+            })
+            .collect::<Vec<_>>();
+        let meshes = origins
+            .iter()
+            .map(|_| Vec::<ChunkMesh>::new())
+            .collect::<Vec<_>>();
+        let mesh = assemble(&chunks, meshes, level, max_error);
+
+        let tin = Tin {
+            tick: 0,
+            max_error,
+            quality: config.quality,
+            chunks,
+            stats: mesh.stats,
+        };
+        tin.log("scaffolded");
+        (tin, mesh)
+    }
+
+    /// Builds (first time) the chunk at `index` from its grid, leaving the
+    /// chunk triangulated so later edits refine it in place - the same
+    /// work `build` does for one chunk, run on demand.
+    #[cfg(target_arch = "wasm32")]
+    pub fn build_chunk(&mut self, level: &Level, index: usize) -> ChunkBuffers {
+        let grid = {
+            let st = &self.chunks[index];
+            Grid::new(level, st.x0, st.y0, st.w, st.h)
+        };
+        let max_error = self.max_error;
+        let per_lod = {
+            let state = &mut self.chunks[index];
+            state.alt = grid.alt;
+            // The grid was read after any banked edit was applied, so the
+            // edits are baked in and the bank can be dropped.
+            state.pending.clear();
+            state.lods.clear();
+            state.lods = (0..LOD_COUNT)
+                .map(|k| {
+                    let mut tri = Chunk::new(&grid);
+                    refine(
+                        &mut tri,
+                        &grid,
+                        max_error * (1 << k) as f32,
+                        max_error,
+                        None,
+                        true,
+                    );
+                    LodState {
+                        tri,
+                        settle: 0,
+                        backoff: 0,
+                    }
+                })
+                .collect();
+            state
+                .lods
+                .iter()
+                .map(|lod| emit_chunk(&lod.tri, &grid))
+                .collect()
+        };
+        ChunkBuffers::new(&self.chunks[index], per_lod)
     }
 }
 

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -578,7 +578,8 @@ impl Render {
     ) {
         profiling::scope!("draw_world");
         batcher.prepare(device);
-        self.terrain.update_dirty(encoder, level, device, queue);
+        self.terrain
+            .update_dirty(encoder, level, device, queue, cam.loc.truncate());
 
         //TODO: common routine for draw passes
         //TODO: use `write_buffer`

--- a/src/render/terrain/mod.rs
+++ b/src/render/terrain/mod.rs
@@ -337,6 +337,11 @@ struct MeshGeometry {
     /// them, at full detail" so the first frame, which has no decision
     /// behind it yet, refits everything.
     drawn: Vec<Option<u8>>,
+    /// Chunks the web build scaffolded but has not fitted yet; filled in a
+    /// few per tick, nearest the camera first. Empty on native, where
+    /// `Tin::build` fits everything up front.
+    #[cfg(target_arch = "wasm32")]
+    unbuilt: Vec<usize>,
     gpu_bytes: u64,
 }
 
@@ -360,8 +365,42 @@ impl MeshGeometry {
             chunks,
             tin,
             drawn,
+            #[cfg(target_arch = "wasm32")]
+            unbuilt: Vec::new(),
             gpu_bytes,
         }
+    }
+
+    /// Fits the `budget` unbuilt chunks nearest `origin`, replacing their
+    /// empty buffers with real ones. Re-sorts the remaining queue by
+    /// distance so the next call keeps the state right around the camera
+    /// even after it moves.
+    #[cfg(target_arch = "wasm32")]
+    fn build_pending(
+        &mut self,
+        level: &level::Level,
+        device: &wgpu::Device,
+        origin: glam::Vec2,
+        budget: usize,
+    ) {
+        if self.unbuilt.is_empty() {
+            return;
+        }
+        self.unbuilt.sort_by_key(|&ci| {
+            let c = self.chunks[ci].center;
+            let d = origin - glam::Vec2::new(c[0], c[1]);
+            (d.x * d.x + d.y * d.y) as u32
+        });
+        let mut built = 0;
+        self.unbuilt.retain(|&ci| {
+            if built >= budget {
+                return true;
+            }
+            let buffers = self.tin.build_chunk(level, ci);
+            self.chunks[ci] = ChunkBufs::new(&buffers, device);
+            built += 1;
+            false
+        });
     }
 }
 
@@ -1930,6 +1969,8 @@ impl Context {
         level: &level::Level,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
+        // Only the web build's incremental first fit reads this.
+        #[cfg_attr(not(target_arch = "wasm32"), allow(unused_variables))] origin: glam::Vec2,
     ) {
         let surface_constants = {
             let bits = level.terrain_bits();
@@ -1987,8 +2028,27 @@ impl Context {
         {
             match *geo {
                 None => {
-                    let (tin, mesh) = level::tin::Tin::build(level, config);
-                    *geo = Some(MeshGeometry::new(tin, &mesh, device));
+                    // Build the whole TIN at once on native, where rayon
+                    // spreads the chunks over everything cores. On wasm the
+                    // single-threaded fit is the seconds-long startup hitch,
+                    // so scaffold empty chunks and fill them in a few per
+                    // tick, nearest the camera first (`build_pending`).
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        let (tin, mesh) = level::tin::Tin::build(level, config);
+                        *geo = Some(MeshGeometry::new(tin, &mesh, device));
+                    }
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        let (tin, mesh) = level::tin::Tin::scaffold(level, config);
+                        let geo = &mut *geo;
+                        *geo = Some(MeshGeometry::new(tin, &mesh, device));
+                        let loaded = geo.as_mut().unwrap();
+                        loaded.unbuilt = (0..loaded.chunks.len()).collect();
+                        // The frame that scaffolds also builds the first
+                        // few chunks, so the camera seat is not blank.
+                        loaded.build_pending(level, device, origin, 4);
+                    }
                 }
                 Some(ref mut geo) => {
                     // One batched refit for the whole frame's edits. Several
@@ -2018,6 +2078,12 @@ impl Context {
                     for (index, buffers) in tin.update(level, &rects, drawn) {
                         chunks[index] = ChunkBufs::new(&buffers, device);
                     }
+                    // The scaffolded chunks still awaiting their first fit:
+                    // one a tick, nearest the camera, so the visible area
+                    // fills over the opening frames and distant terrain
+                    // catches up as the level is driven across.
+                    #[cfg(target_arch = "wasm32")]
+                    geo.build_pending(level, device, origin, 1);
                 }
             }
         }
@@ -2424,6 +2490,11 @@ impl Context {
                             (cam_tile.y + (copy / 3) as f32 - 1.0) * size[1],
                         );
                         for (ci, chunk) in chunks.iter().enumerate() {
+                            // Not fitted yet (web build): nothing to cull
+                            // or draw, and nothing for a refit to keep up.
+                            if chunk.lods.is_empty() {
+                                continue;
+                            }
                             let min = glam::Vec3::new(
                                 chunk.min[0] + offset.x,
                                 chunk.min[1] + offset.y,


### PR DESCRIPTION
The first frame fit the whole level's TIN on a single thread, which is the seconds-long hitch the loading screen sits on; measuring on Fostral at the web quality (0.25) the full build is ~3.2s even multi-threaded. The web build now scaffolds every chunk's state up front and fits a chunk at a time - four nearest the camera on the frame that scaffolds, then one per tick ordered by distance - so terrain appears over the opening frames and distant chunks catch up as the level is driven across. Unbuilt chunks are skipped in the draw and refit walks, and build against a freshly-read grid so banked moving-land edits are never lost. Native keeps the parallel whole-level build.

Also limits refits to one chunk per tick on wasm (the previous four), so a single chunk's refine plus buffer upload never taxes one frame.

Ports the game's road trails to the web build: the physics now records each wheel's stretch and step_tracks cuts tread, hull prints, mole mounds and grader sweeps into the level afterwards, dirtying the terrain for the renderer. Same config defaults as native - tread on, press and molehills off.

Adds [startup] phase timings to the web console (level load, renderer, vehicle, moving world, first frame) so the remaining costs can be seen in the browser instead of guessed.