### PR TITLE
Reuse GPU buffers and drain the web TIN harder

### DIFF
--- a/bin/model/app.rs
+++ b/bin/model/app.rs
@@ -191,7 +191,7 @@ impl Application for ResourceView {
         };
         let mut batcher = render::Batcher::new();
         batcher.add_model(&self.model, &self.transform, bound, color);
-        batcher.prepare(device);
+        batcher.prepare(device, _queue);
 
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("Draw"),

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -9,9 +9,10 @@ use wasm_bindgen::prelude::*;
 
 use vangers::{
     config::{self, settings},
-    data, escave, level, life, model, physics,
+    creature, data, escave, level, life, model, physics,
     render::{
         self, Batcher, DEPTH_FORMAT, GraphicsContext, Render, ScreenTargets, debug::LineBuffer,
+        object::Instance,
     },
     space,
     vfs::Vfs,
@@ -396,6 +397,28 @@ fn spawn_default_agent(
     })
 }
 
+fn load_bug(
+    vfs: &Vfs,
+    device: &wgpu::Device,
+    object: &render::object::Context,
+) -> Option<(Vec<std::sync::Arc<model::Mesh>>, f32)> {
+    use std::io::Cursor;
+
+    let game_lst = vfs.read("game.lst")?;
+    let registry = config::game::Registry::load_reader(Cursor::new(&*game_lst));
+    let info = registry.model_infos.get("Bug")?;
+    let bytes = vfs.read(&info.path)?;
+    let frames = if info.path.rsplit('.').next() == Some("a3d") {
+        model::load_a3d_frames_bytes(&bytes, device)
+    } else {
+        vec![model::load_m3d_bytes(&bytes, device, object, SHAPE_SAMPLING).body]
+    };
+    if frames.is_empty() {
+        return None;
+    }
+    Some((frames, info.scale.max(0.2) / 3.0))
+}
+
 struct WebApp {
     render: Render,
     level: level::Level,
@@ -423,6 +446,8 @@ struct WebApp {
     line_buffer: LineBuffer,
     space_held: bool,
     ride: Option<Ride>,
+    /// Original Bug `.a3d` frames, if `game.lst` has one in the VFS.
+    bug: Option<(Vec<std::sync::Arc<model::Mesh>>, f32)>,
     inventory: escave::Inventory,
     shop: escave::Shop,
     screen: escave::Screen,
@@ -583,9 +608,10 @@ impl WebApp {
             other => other,
         };
         if choice == TerrainChoice::Mesh {
-            // Quality 0.25 is the cheapest setting that still matches the
-            // other renderers on open ground; see the terrain-mesh post.
-            render_settings.terrain = settings::Terrain::Mesh { quality: 0.25 };
+            // Same quality as native `tin::Config` default. Wasm still
+            // scaffolds and drains instead of blocking startup on a full
+            // parallel fit; the drain is sized so nearby chunks catch up.
+            render_settings.terrain = settings::Terrain::Mesh { quality: 0.75 };
             // Ray-traced shadows work on both backends and do not depend
             // on the terrain renderer.
             render_settings.light.shadow.terrain = settings::ShadowTerrain::RayTraced;
@@ -679,6 +705,10 @@ impl WebApp {
 
         let mut life = life::World::spawn(world, &level, std::path::Path::new(""));
         life.beebs = 500;
+        let bug = vfs.and_then(|v| load_bug(v, &gfx.device, &render.object));
+        if bug.is_none() {
+            log::info!("No Bug model in the VFS; beebs draw as ticks");
+        }
         WebApp {
             render,
             level,
@@ -695,6 +725,7 @@ impl WebApp {
             line_buffer: LineBuffer::new(),
             space_held: false,
             ride: None,
+            bug,
             inventory: escave::Inventory::default(),
             shop: escave::Shop::fostral(),
             screen: escave::Screen::new(),
@@ -976,7 +1007,25 @@ impl WebApp {
                 .add_model(&agent.car.model, &agent.transform, None, agent.color);
         }
         let eye = self.cam.loc;
-        self.life.draw_fx(&mut self.line_buffer, eye, true);
+        if let Some((ref frames, scale)) = self.bug {
+            for insect in self.life.swarm.near(eye, creature::ACTIVE_RADIUS) {
+                let mesh = &frames[insect.frame(frames.len())];
+                let transform = space::Transform {
+                    scale,
+                    disp: self.level.display_pos(insect.pos, eye),
+                    rot: insect.rotation(),
+                };
+                let color = match insect.tier {
+                    0 => m3d::ColorId::Custom1 as u8,
+                    1 => m3d::ColorId::Custom2 as u8,
+                    _ => m3d::ColorId::Custom4 as u8,
+                };
+                self.batcher
+                    .add_mesh(mesh, Instance::new(&transform, 0.0, color));
+            }
+        }
+        self.life
+            .draw_fx(&mut self.line_buffer, eye, self.bug.is_none());
 
         self.render.draw_world(
             &mut encoder,
@@ -1124,6 +1173,8 @@ struct DomInputHooks {
     _pointerdown: Closure<dyn FnMut(web_sys::PointerEvent)>,
     _pointerup: Closure<dyn FnMut(web_sys::PointerEvent)>,
     _pointermove: Closure<dyn FnMut(web_sys::PointerEvent)>,
+    _blur: Closure<dyn FnMut(web_sys::Event)>,
+    _visibility: Closure<dyn FnMut(web_sys::Event)>,
 }
 
 fn key_from_code(code: &str) -> Option<KeyCode> {
@@ -1189,6 +1240,9 @@ struct WebHandler {
     /// `document` instead.
     _dom_input: Option<DomInputHooks>,
     last_frame: Option<Instant>,
+    /// Set when the tab hides so the next frame does not inherit a huge
+    /// pause or a stuck Ctrl (brake) from Ctrl+Tab.
+    clock_stale: std::rc::Rc<std::cell::Cell<bool>>,
     ws_client: Option<net_ws::WsClient>,
     /// The first frame builds the whole terrain TIN and uploads it; time
     /// it once so the console shows where startup actually goes.
@@ -1244,6 +1298,7 @@ impl WebHandler {
             ui_pointer: std::rc::Rc::new(std::cell::RefCell::new(Vec::new())),
             _dom_input: None,
             last_frame: None,
+            clock_stale: std::rc::Rc::new(std::cell::Cell::new(false)),
             first_draw_measured: false,
             ws_client,
             mp_status,
@@ -1338,14 +1393,49 @@ impl WebHandler {
             capture,
         );
 
+        let keys = self.keys_pressed.clone();
+        let stale = self.clock_stale.clone();
+        let on_blur = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+            release_held_keys(&mut keys.borrow_mut());
+            stale.set(true);
+        }) as Box<dyn FnMut(web_sys::Event)>);
+
+        let keys = self.keys_pressed.clone();
+        let stale = self.clock_stale.clone();
+        let on_visibility = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+            let hidden = web_sys::window()
+                .and_then(|w| w.document())
+                .is_some_and(|d| d.hidden());
+            if hidden {
+                release_held_keys(&mut keys.borrow_mut());
+                stale.set(true);
+            }
+        }) as Box<dyn FnMut(web_sys::Event)>);
+
+        let win = web_sys::window().expect("no window");
+        let _ = win.add_event_listener_with_callback("blur", on_blur.as_ref().unchecked_ref());
+        let _ = document.add_event_listener_with_callback(
+            "visibilitychange",
+            on_visibility.as_ref().unchecked_ref(),
+        );
+
         self._dom_input = Some(DomInputHooks {
             _keydown: on_keydown,
             _keyup: on_keyup,
             _pointerdown: on_pointerdown,
             _pointerup: on_pointerup,
             _pointermove: on_pointermove,
+            _blur: on_blur,
+            _visibility: on_visibility,
         });
     }
+}
+
+/// Ctrl+Tab (and any other chord the browser eats) never delivers keyup.
+/// ControlLeft is brake, so a leftover Ctrl parks the car until something
+/// clears it. Jump still works because Alt is a fresh press.
+fn release_held_keys(keys: &mut std::collections::HashSet<KeyCode>) {
+    keys.clear();
 }
 
 impl ApplicationHandler for WebHandler {
@@ -1739,6 +1829,10 @@ impl ApplicationHandler for WebHandler {
         }
 
         match event {
+            WindowEvent::Focused(false) => {
+                release_held_keys(&mut self.keys_pressed.borrow_mut());
+                self.last_frame = None;
+            }
             WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::KeyboardInput {
                 event:
@@ -1853,6 +1947,10 @@ impl WebHandler {
         }
 
         // Compute delta time
+        if self.clock_stale.get() {
+            self.clock_stale.set(false);
+            self.last_frame = None;
+        }
         let now = Instant::now();
         let dt = match self.last_frame {
             Some(prev) => (now - prev).as_secs_f32(),
@@ -2213,4 +2311,16 @@ pub fn web_main() {
 
 fn main() {
     web_main();
+}
+
+#[cfg(test)]
+mod input_tests {
+    use super::*;
+
+    #[test]
+    fn hiding_the_tab_releases_brake_and_drive() {
+        let mut keys = std::collections::HashSet::from([KeyCode::ControlLeft, KeyCode::KeyW]);
+        release_held_keys(&mut keys);
+        assert!(keys.is_empty());
+    }
 }

--- a/src/level/tin.rs
+++ b/src/level/tin.rs
@@ -89,6 +89,12 @@ impl Default for Config {
     }
 }
 
+/// Delaunay insertions one wasm quant may spend on a chunk. Native
+/// `build` / `update` ignore this and drain the fit on rayon. Keep the
+/// initial-fit step and the edit refit on the same budget.
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+pub(crate) const WASM_DRAIN_INSERTIONS: usize = 128;
+
 impl Config {
     /// Vertical tolerance in world altitude units, for this level's height
     /// scale.
@@ -1858,10 +1864,11 @@ impl Tin {
         {
             // A chunk is not a useful web budget: its topology and all three
             // emitted LOD buffers can differ by orders of magnitude. Work on
-            // one LOD and cap the actual Delaunay insertions instead. Vertex
-            // heights come straight from the terrain texture, so an
-            // unfinished topology refinement never delays the animation.
-            const INSERTION_BUDGET: usize = 4;
+            // one LOD and cap Delaunay insertions instead. Vertex heights
+            // come from the terrain texture, so an unfinished topology
+            // never delays the animation. The cap matches the initial-fit
+            // drain so tyre tracks catch up as fast as nearby chunks.
+            const INSERTION_BUDGET: usize = WASM_DRAIN_INSERTIONS;
             let n = self.chunks.len();
             if n == 0 {
                 return Vec::new();
@@ -2416,6 +2423,29 @@ mod tests {
             assert_eq!(a.pos, b.pos);
             assert_eq!(a.layer, b.layer);
         }
+    }
+
+    #[test]
+    fn a_wide_wasm_drain_matches_the_parallel_builder() {
+        let level = make_level(64);
+        let config = Config { quality: 0.75 };
+        let (_full_tin, full_mesh) = Tin::build(&level, &config);
+        let (mut incremental, _) = Tin::scaffold(&level, &config);
+        let mut final_buffers = None;
+        for _ in 0..level.height.len() * LOD_COUNT {
+            if !incremental.needs_build(0, 1) {
+                break;
+            }
+            if let Some(buffers) = incremental.build_chunk_step(&level, 0, 1, WASM_DRAIN_INSERTIONS)
+            {
+                final_buffers = Some(buffers);
+            }
+        }
+        assert!(!incremental.needs_build(0, 1), "wide drain stalled");
+        let actual = final_buffers.expect("no completed TIN was published");
+        let expected = &full_mesh.chunks[0];
+        assert_eq!(actual.indices, expected.indices);
+        assert_eq!(actual.lods, expected.lods);
     }
 
     #[test]

--- a/src/model.rs
+++ b/src/model.rs
@@ -369,7 +369,22 @@ pub fn load_a3d_body(file: File, device: &wgpu::Device) -> Arc<Mesh> {
 
 /// Every frame of an `.a3d`, for walking insects.
 pub fn load_a3d_frames(file: File, device: &wgpu::Device) -> Vec<Arc<Mesh>> {
-    m3d::DrawAnimatedMesh::load(file)
+    load_a3d_frames_bytes_inner(m3d::DrawAnimatedMesh::load(file), device)
+}
+
+/// Byte-slice variant of [`load_a3d_frames`], for the web VFS.
+pub fn load_a3d_frames_bytes(bytes: &[u8], device: &wgpu::Device) -> Vec<Arc<Mesh>> {
+    load_a3d_frames_bytes_inner(
+        m3d::DrawAnimatedMesh::load(std::io::Cursor::new(bytes)),
+        device,
+    )
+}
+
+fn load_a3d_frames_bytes_inner(
+    animated: m3d::DrawAnimatedMesh,
+    device: &wgpu::Device,
+) -> Vec<Arc<Mesh>> {
+    animated
         .meshes
         .into_iter()
         .map(|mesh| load_c3d(mesh, device))

--- a/src/particle.rs
+++ b/src/particle.rs
@@ -394,4 +394,19 @@ mod tests {
             "a second redraw appended instead of replacing"
         );
     }
+
+    #[test]
+    fn a_bug_mesh_means_insects_are_not_drawn_as_ticks() {
+        let particles = System::new();
+        let mut swarm = crate::creature::Swarm::new((64, 64));
+        swarm.push(crate::creature::Insect::at(Vec3::new(8.0, 8.0, 10.0), 0));
+        let mut lines = LineBuffer::new();
+        refresh_fx_lines(&mut lines, &particles, &swarm, Vec3::ZERO, false);
+        assert!(
+            lines.is_empty(),
+            "ticks should stay off when the Bug mesh is instanced"
+        );
+        refresh_fx_lines(&mut lines, &particles, &swarm, Vec3::ZERO, true);
+        assert!(!lines.is_empty(), "ticks are the fallback without a mesh");
+    }
 }

--- a/src/render/debug.rs
+++ b/src/render/debug.rs
@@ -343,23 +343,40 @@ impl Context {
         &'a mut self,
         pass: &mut wgpu::RenderPass<'a>,
         device: &wgpu::Device,
+        queue: &wgpu::Queue,
         linebuf: &LineBuffer,
     ) {
-        self.vertex_buf = Some(
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("debug-vertices"),
-                contents: bytemuck::cast_slice(&linebuf.vertices),
-                usage: wgpu::BufferUsages::VERTEX,
-            }),
-        );
-        self.color_buf = Some(
-            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                label: Some("debug-colors"),
-                contents: bytemuck::cast_slice(&linebuf.colors),
-                usage: wgpu::BufferUsages::VERTEX,
-            }),
-        );
         assert_eq!(linebuf.vertices.len(), linebuf.colors.len());
+        if linebuf.is_empty() {
+            return;
+        }
+        let n = linebuf.vertices.len();
+        let v_bytes = bytemuck::cast_slice(&linebuf.vertices);
+        let c_bytes = bytemuck::cast_slice(&linebuf.colors);
+        let v_need = v_bytes.len() as u64;
+        let c_need = c_bytes.len() as u64;
+        let v_have = self.vertex_buf.as_ref().map(|b| b.size()).unwrap_or(0);
+        if v_have < v_need {
+            let v_size = super::grow_buffer_bytes(v_have, v_need);
+            let c_size = super::grow_buffer_bytes(
+                self.color_buf.as_ref().map(|b| b.size()).unwrap_or(0),
+                c_need,
+            );
+            self.vertex_buf = Some(device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("debug-vertices"),
+                size: v_size,
+                usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }));
+            self.color_buf = Some(device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("debug-colors"),
+                size: c_size,
+                usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            }));
+        }
+        queue.write_buffer(self.vertex_buf.as_ref().unwrap(), 0, v_bytes);
+        queue.write_buffer(self.color_buf.as_ref().unwrap(), 0, c_bytes);
 
         pass.set_bind_group(1, &self.bind_group_line, &[]);
         self.draw_liner(
@@ -367,7 +384,7 @@ impl Context {
             self.vertex_buf.as_ref().unwrap(),
             self.color_buf.as_ref().unwrap(),
             wgpu::VertexStepMode::Vertex,
-            linebuf.vertices.len(),
+            n,
             particle_line_visibilities(),
         );
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 
 use bytemuck::{Pod, Zeroable};
-use wgpu::util::DeviceExt as _;
 
 use std::{collections::HashMap, io::Error as IoError, mem, ops::Range, sync::Arc};
 
@@ -332,17 +331,24 @@ impl Batcher {
         }
     }
 
-    pub fn prepare(&mut self, device: &wgpu::Device) {
+    pub fn prepare(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) {
         for array in self.instances.values_mut() {
-            if !array.data.is_empty() {
-                array.buffer = Some(
-                    device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                        label: Some("instance"),
-                        contents: bytemuck::cast_slice(&array.data),
-                        usage: wgpu::BufferUsages::VERTEX,
-                    }),
-                );
+            if array.data.is_empty() {
+                continue;
             }
+            let bytes = bytemuck::cast_slice(&array.data);
+            let need = bytes.len() as u64;
+            let have = array.buffer.as_ref().map(|b| b.size()).unwrap_or(0);
+            if have < need {
+                let size = grow_buffer_bytes(have, need);
+                array.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("instance"),
+                    size,
+                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                }));
+            }
+            queue.write_buffer(array.buffer.as_ref().unwrap(), 0, bytes);
         }
     }
 
@@ -363,10 +369,29 @@ impl Batcher {
     pub fn clear(&mut self) {
         for array in self.instances.values_mut() {
             array.data.clear();
-            array.buffer = None;
         }
         self.debug_shapes.clear();
         self.debug_instances.clear();
+    }
+}
+
+/// Next GPU buffer size: keep slack, grow by powers of two.
+pub(crate) fn grow_buffer_bytes(current: u64, needed: u64) -> u64 {
+    if needed <= current {
+        current
+    } else {
+        needed.next_power_of_two().max(256)
+    }
+}
+
+#[cfg(test)]
+mod buffer_tests {
+    #[test]
+    fn gpu_storage_grows_in_powers_of_two_and_keeps_slack() {
+        assert_eq!(super::grow_buffer_bytes(0, 10), 256);
+        assert_eq!(super::grow_buffer_bytes(256, 10), 256);
+        assert_eq!(super::grow_buffer_bytes(256, 257), 512);
+        assert_eq!(super::grow_buffer_bytes(1024, 1024), 1024);
     }
 }
 
@@ -616,7 +641,7 @@ impl Render {
         lines: Option<&debug::LineBuffer>,
     ) {
         profiling::scope!("draw_world");
-        batcher.prepare(device);
+        batcher.prepare(device, queue);
         self.terrain.update_dirty(encoder, level, device, queue);
 
         //TODO: common routine for draw passes
@@ -752,7 +777,7 @@ impl Render {
                 && !lines.is_empty()
             {
                 pass.push_debug_group("particles");
-                self.debug.draw_lines(&mut pass, device, lines);
+                self.debug.draw_lines(&mut pass, device, queue, lines);
                 pass.pop_debug_group();
             }
         }

--- a/src/render/terrain/mod.rs
+++ b/src/render/terrain/mod.rs
@@ -483,9 +483,9 @@ impl MeshGeometry {
     /// Advances the shared TIN builder within a small wall-clock budget.
     ///
     /// Native drains the same fits in parallel during `Tin::build`; wasm
-    /// resumes one sampled chunk here. A completed coarse TIN remains
-    /// drawable while finer LODs are fitted, and at most one mesh upload is
-    /// published per frame.
+    /// resumes sampled chunks here. A completed coarse TIN remains
+    /// drawable while finer LODs are fitted. Several chunks may publish
+    /// in one frame as long as the CPU budget holds.
     #[cfg(target_arch = "wasm32")]
     fn build_pending(
         &mut self,
@@ -495,8 +495,8 @@ impl MeshGeometry {
     ) -> Vec<level::tin::Rect> {
         use std::time::Duration;
 
-        const CPU_BUDGET: Duration = Duration::from_millis(4);
-        const INSERTIONS_PER_STEP: usize = 4;
+        const CPU_BUDGET: Duration = Duration::from_millis(8);
+        const INSERTIONS_PER_STEP: usize = level::tin::WASM_DRAIN_INSERTIONS;
         let start = web_time::Instant::now();
         let mut attempted = false;
         let mut refresh = Vec::new();
@@ -543,7 +543,6 @@ impl MeshGeometry {
                     .gpu_bytes
                     .saturating_sub(old_bytes)
                     .saturating_add(self.chunks[ci].gpu_bytes());
-                break;
             }
         }
         refresh


### PR DESCRIPTION
Instance and line draws write into grown buffers instead of creating a new WebGL object every frame. Web also instances the Bug mesh, drops held keys (Ctrl is brake) when the tab hides, and drains 128 Delaunay insertions per quant at native quality so nearby chunks catch up without a full startup fit.