### PR TITLE
Draw packed caves on web and restack the shop

### DIFF
--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -847,7 +847,7 @@ impl Game {
             escave_note: None,
             escave_selected: None,
             cave_boot: CaveBoot {
-                render: settings.render.clone(),
+                render: escave::cave::render_settings(&settings.render),
                 geometry: settings.game.geometry,
                 downlevel_caps: gfx.downlevel_caps.clone(),
                 color_format: gfx.color_format,
@@ -1001,7 +1001,13 @@ impl Game {
         }
         if let Some(ref mut cave) = self.cave {
             cave.yaw += delta * 0.12;
-            escave::cave::orbit(&mut cave.cam, cave.target, cave.distance, cave.yaw, 0.55);
+            escave::cave::orbit(
+                &mut cave.cam,
+                cave.target,
+                cave.distance,
+                cave.yaw,
+                escave::cave::ELEVATION,
+            );
         }
     }
 
@@ -1421,15 +1427,9 @@ impl Application for Game {
                 KeyCode::ShiftLeft => self.input.turbo = true,
                 KeyCode::KeyM => self.input.mole = true,
                 KeyCode::KeyC => {
-                    if let Physics::Cpu {
-                        ref mut dynamo, ..
-                    } = player.physics
-                    {
+                    if let Physics::Cpu { ref mut dynamo, .. } = player.physics {
                         dynamo.flotator = !dynamo.flotator;
-                        log::info!(
-                            "cutterig {}",
-                            if dynamo.flotator { "on" } else { "off" }
-                        );
+                        log::info!("cutterig {}", if dynamo.flotator { "on" } else { "off" });
                     }
                 }
                 KeyCode::Space => self.input.use_entrance = true,

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -493,6 +493,29 @@ struct WebApp {
     escave_note: Option<String>,
     escave_selected: Option<String>,
     data_path: std::path::PathBuf,
+    /// Packed `resource/iscreen/ldata/` from the world zip. Empty when the
+    /// release has no cave maps (open-source tree, test level).
+    iscreen: Vfs,
+    cave_boot: CaveBoot,
+    cave: Option<CaveView>,
+}
+
+struct CaveBoot {
+    render: settings::Render,
+    geometry: settings::Geometry,
+    downlevel_caps: wgpu::DownlevelCapabilities,
+    color_format: wgpu::TextureFormat,
+    front_face: wgpu::FrontFace,
+}
+
+struct CaveView {
+    name: String,
+    level: level::Level,
+    render: Render,
+    cam: space::Camera,
+    target: glam::Vec3,
+    distance: f32,
+    yaw: f32,
 }
 
 struct Ride {
@@ -802,11 +825,31 @@ impl WebApp {
             escave_note: None,
             escave_selected: None,
             data_path: std::path::PathBuf::new(),
+            iscreen: {
+                let slice = vfs
+                    .map(|v| v.prefix("resource/iscreen/ldata"))
+                    .unwrap_or_default();
+                if slice.is_empty() {
+                    log::info!("No iscreen ldata in VFS; escave interiors stay 2D");
+                } else {
+                    log::info!("Kept {} iscreen file(s) for escave voxels", slice.len());
+                }
+                slice
+            },
+            cave_boot: CaveBoot {
+                render: escave::cave::render_settings(&render_settings),
+                geometry,
+                downlevel_caps: gfx.downlevel_caps.clone(),
+                color_format: gfx.color_format,
+                front_face: cam.front_face(),
+            },
+            cave: None,
         }
     }
 
     fn draw_ui(&mut self, ctx: &egui::Context) {
         if let Some(visit) = self.screen.visit() {
+            let see_through = self.cave.is_some();
             let action = escave::draw_interior(
                 ctx,
                 visit,
@@ -816,7 +859,7 @@ impl WebApp {
                 self.escave_note.as_deref(),
                 &mut self.escave_selected,
                 &self.spin_meshes,
-                false,
+                see_through,
             );
             if let Some(visit) = self.screen.visit_mut() {
                 let (note, _slots) = action.apply(
@@ -887,6 +930,12 @@ impl WebApp {
         self.render.resize(extent, device);
         if let space::Projection::Perspective(ref mut p) = self.cam.proj {
             p.aspect = extent.width as f32 / extent.height.max(1) as f32;
+        }
+        if let Some(ref mut cave) = self.cave {
+            cave.cam
+                .proj
+                .update(extent.width as u16, extent.height as u16);
+            cave.render.resize(extent, device);
         }
     }
 
@@ -978,6 +1027,62 @@ impl WebApp {
         if leaving && self.screen.is_world() {
             self.approach_cam = None;
         }
+        if let Some(ref mut cave) = self.cave {
+            cave.yaw += delta * 0.12;
+            escave::cave::orbit(
+                &mut cave.cam,
+                cave.target,
+                cave.distance,
+                cave.yaw,
+                escave::cave::ELEVATION,
+            );
+        }
+    }
+
+    fn ensure_cave(
+        &mut self,
+        name: &str,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        extent: wgpu::Extent3d,
+    ) {
+        if self.cave.as_ref().is_some_and(|c| c.name == name) {
+            return;
+        }
+        let Some((config, level)) =
+            escave::cave::load_from_vfs(&self.iscreen, name, &self.cave_boot.geometry)
+        else {
+            self.cave = None;
+            return;
+        };
+        let gfx = GraphicsContext {
+            device: device.clone(),
+            queue: queue.clone(),
+            downlevel_caps: self.cave_boot.downlevel_caps.clone(),
+            color_format: self.cave_boot.color_format,
+            screen_size: extent,
+        };
+        let pal = level.palette;
+        let render = Render::new(
+            &gfx,
+            &config,
+            &pal,
+            &self.cave_boot.render,
+            &self.cave_boot.geometry,
+            self.cave_boot.front_face,
+        );
+        let (mut cam, target, distance) = escave::cave::camera(&level, self.cam.proj);
+        cam.proj.update(extent.width as u16, extent.height as u16);
+        log::info!("escave iscreen {name} {}x{}", level.size.0, level.size.1);
+        self.cave = Some(CaveView {
+            name: name.to_string(),
+            level,
+            render,
+            cam,
+            target,
+            distance,
+            yaw: 0.35,
+        });
     }
 
     fn try_use(&mut self) {
@@ -1102,6 +1207,32 @@ impl WebApp {
         queue: &wgpu::Queue,
         targets: ScreenTargets,
     ) -> wgpu::CommandBuffer {
+        if let Some(name) = self.screen.cave_name().map(str::to_string) {
+            self.ensure_cave(&name, device, queue, targets.extent);
+        }
+        if self.screen.visit().is_some()
+            && let Some(ref mut cave) = self.cave
+        {
+            self.batcher.clear();
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Escave"),
+            });
+            cave.render
+                .set_local_light(cave.target, 280.0, [1.0, 0.82, 0.52]);
+            cave.render.draw_world(
+                &mut encoder,
+                &mut self.batcher,
+                &cave.level,
+                &cave.cam,
+                targets,
+                None,
+                device,
+                queue,
+                None,
+            );
+            return encoder.finish();
+        }
+
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("World"),
         });

--- a/src/escave/cave.rs
+++ b/src/escave/cave.rs
@@ -7,6 +7,7 @@
 use crate::config::settings;
 use crate::level::{self, Level, LevelConfig, Texel};
 use crate::space::Camera;
+use crate::vfs::Vfs;
 use glam::{Quat, Vec3};
 use std::path::{Path, PathBuf};
 
@@ -29,6 +30,11 @@ pub fn ini_path(data_path: &Path, name: &str) -> Option<PathBuf> {
     Some(data_path.join(ldata_dir(name)?).join("escave.ini"))
 }
 
+/// VFS key of this escave's `escave.ini`, matching the packed level zip.
+pub fn ini_key(name: &str) -> Option<String> {
+    Some(format!("{}/escave.ini", ldata_dir(name)?))
+}
+
 /// Load the iscreen height map if the purchased data is on disk.
 pub fn load(
     data_path: &Path,
@@ -45,6 +51,22 @@ pub fn load(
     Some((config, level))
 }
 
+/// Same map, from a VFS (web packs `resource/iscreen/ldata/lN/` into the world zip).
+pub fn load_from_vfs(
+    vfs: &Vfs,
+    name: &str,
+    geometry: &settings::Geometry,
+) -> Option<(LevelConfig, Level)> {
+    let ini = ini_key(name)?;
+    if !vfs.contains(&ini) {
+        log::info!("escave iscreen missing at {ini}");
+        return None;
+    }
+    let config = LevelConfig::load_from_vfs(vfs, &ini);
+    let level = level::load_from_vfs(vfs, &config, geometry);
+    Some((config, level))
+}
+
 pub fn look_target(level: &Level) -> Vec3 {
     let cx = level.size.0 as f32 * 0.5;
     let cy = level.size.1 as f32 * 0.5;
@@ -56,8 +78,12 @@ pub fn look_target(level: &Level) -> Vec3 {
 }
 
 pub fn look_distance(level: &Level) -> f32 {
-    (level.size.0.min(level.size.1) as f32 * 0.42).max(64.0)
+    (level.size.0.min(level.size.1) as f32 * 0.48).max(64.0)
 }
+
+/// Radians above the XY plane. 90° is straight down; this is 30° off vertical
+/// so the living thing reads as a shape instead of a cliff face.
+pub const ELEVATION: f32 = std::f32::consts::FRAC_PI_3;
 
 pub fn orbit(cam: &mut Camera, target: Vec3, distance: f32, yaw: f32, elevation: f32) {
     let ce = elevation.cos();
@@ -76,8 +102,17 @@ pub fn camera(level: &Level, proj: crate::space::Projection) -> (Camera, Vec3, f
         scale: Vec3::new(1.0, -1.0, 1.0),
         proj,
     };
-    orbit(&mut cam, target, distance, 0.35, 0.55);
+    orbit(&mut cam, target, distance, 0.35, ELEVATION);
     (cam, target, distance)
+}
+
+/// Cave interiors are a 2048×1024 height field. Mesh TIN chunks tile that
+/// at 128 px and show as a grid; the height-field march does not.
+pub fn render_settings(world: &settings::Render) -> settings::Render {
+    let mut render = world.clone();
+    render.terrain = settings::Terrain::RayTraced;
+    render.light.shadow.terrain = settings::ShadowTerrain::RayTraced;
+    render
 }
 
 #[cfg(test)]
@@ -91,5 +126,20 @@ mod tests {
         assert!(ldata_dir("MysteryHole").is_none());
         let path = ini_path(Path::new("/data"), "Podish").unwrap();
         assert!(path.ends_with("resource/iscreen/ldata/l0/escave.ini"));
+        assert_eq!(
+            ini_key("Podish").as_deref(),
+            Some("resource/iscreen/ldata/l0/escave.ini")
+        );
+        assert!(
+            ((std::f32::consts::FRAC_PI_2 - ELEVATION).to_degrees() - 30.0).abs() < 0.05,
+            "cave view should sit 30° off vertical, got {}°",
+            (std::f32::consts::FRAC_PI_2 - ELEVATION).to_degrees()
+        );
+    }
+
+    #[test]
+    fn missing_iscreen_in_vfs_is_none() {
+        let vfs = Vfs::new();
+        assert!(load_from_vfs(&vfs, "Podish", &settings::Geometry::default()).is_none());
     }
 }

--- a/src/escave/mod.rs
+++ b/src/escave/mod.rs
@@ -11,13 +11,16 @@ pub mod preview;
 pub mod screen;
 pub mod shop;
 
+#[cfg(test)]
+mod shot;
+
 pub use dialog::{Room, Session, find_room};
 pub use layout::{Catalog, Cell, Layout};
 pub use preview::{SpinMesh, description_for, display_name, mesh_id};
 pub use screen::{InteriorAction, Screen, draw_interior, draw_shutters};
 pub use shop::{
-    BAY_COUNT, DropTarget, Good, Hand, Inventory, Kind, Placed, Preview,
-    Shop, ShopError, drop_held, equipped_slot_ids, mounted_meshes, preview, preview_good,
+    BAY_COUNT, DropTarget, Good, Hand, Inventory, Kind, Placed, Preview, Shop, ShopError,
+    drop_held, equipped_slot_ids, mounted_meshes, preview, preview_good,
 };
 
 use crate::level::vlc::sensor_kind;

--- a/src/escave/preview.rs
+++ b/src/escave/preview.rs
@@ -5,6 +5,7 @@
 //! `game.lst` `.m3d`, turned on a turntable each frame.
 
 use glam::{Quat, Vec3};
+use std::cell::RefCell;
 use std::path::Path;
 
 /// English names from `ITM*_NAME1`. Ids that already match stay as-is.
@@ -57,6 +58,8 @@ pub struct SpinMesh {
     positions: Vec<[f32; 3]>,
     faces: Vec<Face>,
     radius: f32,
+    /// Last raster, kept alive so egui does not free the texture mid-frame.
+    tex: RefCell<Option<egui::TextureHandle>>,
 }
 
 impl SpinMesh {
@@ -93,6 +96,7 @@ impl SpinMesh {
             positions,
             faces,
             radius,
+            tex: RefCell::new(None),
         }
     }
 
@@ -119,10 +123,15 @@ impl SpinMesh {
                 normal: [0.0, -1.0, 0.0],
             }],
             radius: 12.0,
+            tex: RefCell::new(None),
         }
     }
 
-    /// Turntable: Z-up, spin around Z, slight nod, Lambert faces.
+    /// Turntable: Z-up, spin around Z, look down a bit, Lambert faces.
+    ///
+    /// egui's painter has no depth attachment, so this is a software
+    /// z-buffer (closer pixel wins) rather than GPU `depth_compare`.
+    /// Triangle order does not matter.
     pub fn paint(
         &self,
         painter: &egui::Painter,
@@ -133,50 +142,111 @@ impl SpinMesh {
         if self.positions.is_empty() || rect.width() < 8.0 || rect.height() < 8.0 {
             return;
         }
-        let rot = Quat::from_rotation_z(angle) * Quat::from_rotation_x(-0.55);
+        let w = rect.width().round().max(1.0) as i32;
+        let h = rect.height().round().max(1.0) as i32;
+        let mut pixels = vec![0u8; (w * h * 4) as usize];
+        let mut zbuf = vec![f32::INFINITY; (w * h) as usize];
+        let rot = Quat::from_rotation_z(angle) * Quat::from_rotation_x(-0.85);
         let light = Vec3::new(0.35, -0.8, 0.45).normalize();
-        let dist = self.radius * 2.6;
-        let cx = rect.center().x;
-        let cy = rect.center().y;
-        let scale = rect.height().min(rect.width()) * 0.42 / self.radius;
-        let mut order: Vec<(f32, usize)> = self
-            .faces
-            .iter()
-            .enumerate()
-            .filter_map(|(i, face)| {
-                let n = rot * Vec3::from(face.normal);
-                if n.y > 0.2 {
-                    return None;
-                }
-                let a = rot * Vec3::from(self.positions[face.verts[0]]);
-                let b = rot * Vec3::from(self.positions[face.verts[1]]);
-                let c = rot * Vec3::from(self.positions[face.verts[2]]);
-                Some(((a.y + b.y + c.y) / 3.0, i))
-            })
-            .collect();
-        order.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-        for &(_, i) in &order {
-            let face = &self.faces[i];
-            let n = (rot * Vec3::from(face.normal)).normalize_or(Vec3::Z);
+        let dist = self.radius * 2.8;
+        let scale = rect.height().min(rect.width()) * 0.46 / self.radius;
+        let cx = w as f32 * 0.5;
+        let cy = h as f32 * 0.5;
+        for face in &self.faces {
+            let n = rot * Vec3::from(face.normal);
+            if n.y >= 0.0 {
+                continue;
+            }
+            let n = n.normalize_or(Vec3::NEG_Y);
             let lambert = (0.22 + 0.78 * n.dot(light).clamp(0.0, 1.0)).clamp(0.0, 1.0);
-            let fill = egui::Color32::from_rgba_unmultiplied(
+            let fill = [
                 (color.r() as f32 * lambert) as u8,
                 (color.g() as f32 * lambert) as u8,
                 (color.b() as f32 * lambert) as u8,
                 255,
-            );
+            ];
             let pts = face.verts.map(|vi| {
                 let p = rot * Vec3::from(self.positions[vi]);
                 let z = (p.y + dist).max(1.0);
                 let px = cx + p.x * scale * dist / z;
                 let py = cy - p.z * scale * dist / z;
-                egui::pos2(px, py)
+                [px, py, z]
             });
-            painter.add(egui::Shape::convex_polygon(
-                pts.to_vec(),
-                fill,
-                egui::Stroke::NONE,
-            ));
+            raster_ztest(&mut pixels, &mut zbuf, w, h, pts, fill);
+        }
+        let image = egui::ColorImage::from_rgba_unmultiplied([w as usize, h as usize], &pixels);
+        let options = egui::TextureOptions::LINEAR;
+        let tex_id = {
+            let mut slot = self.tex.borrow_mut();
+            match slot.as_mut() {
+                Some(handle) => {
+                    handle.set(image, options);
+                    handle.id()
+                }
+                None => {
+                    let handle = painter.ctx().load_texture("shop-spin", image, options);
+                    let id = handle.id();
+                    *slot = Some(handle);
+                    id
+                }
+            }
+        };
+        painter.image(
+            tex_id,
+            rect,
+            egui::Rect::from_min_max(egui::pos2(0.0, 0.0), egui::pos2(1.0, 1.0)),
+            egui::Color32::WHITE,
+        );
+    }
+}
+
+fn raster_ztest(
+    pixels: &mut [u8],
+    zbuf: &mut [f32],
+    width: i32,
+    height: i32,
+    pts: [[f32; 3]; 3],
+    fill: [u8; 4],
+) {
+    let area = (pts[1][0] - pts[0][0]) * (pts[2][1] - pts[0][1])
+        - (pts[2][0] - pts[0][0]) * (pts[1][1] - pts[0][1]);
+    if area.abs() < 0.5 {
+        return;
+    }
+    let min_x = pts[0][0].min(pts[1][0]).min(pts[2][0]).max(0.0);
+    let max_x = pts[0][0].max(pts[1][0]).max(pts[2][0]).min(width as f32);
+    let min_y = pts[0][1].min(pts[1][1]).min(pts[2][1]).max(0.0);
+    let max_y = pts[0][1].max(pts[1][1]).max(pts[2][1]).min(height as f32);
+    if min_x >= max_x || min_y >= max_y {
+        return;
+    }
+    let x0 = min_x.floor() as i32;
+    let x1 = max_x.ceil() as i32;
+    let y0 = min_y.floor() as i32;
+    let y1 = max_y.ceil() as i32;
+    for y in y0..y1 {
+        for x in x0..x1 {
+            if x < 0 || y < 0 || x >= width || y >= height {
+                continue;
+            }
+            let px = x as f32 + 0.5;
+            let py = y as f32 + 0.5;
+            let w0 =
+                ((pts[1][0] - px) * (pts[2][1] - py) - (pts[2][0] - px) * (pts[1][1] - py)) / area;
+            let w1 =
+                ((pts[2][0] - px) * (pts[0][1] - py) - (pts[0][0] - px) * (pts[2][1] - py)) / area;
+            let w2 = 1.0 - w0 - w1;
+            if w0 < 0.0 || w1 < 0.0 || w2 < 0.0 {
+                continue;
+            }
+            let z = pts[0][2] * w0 + pts[1][2] * w1 + pts[2][2] * w2;
+            let i = (y * width + x) as usize;
+            if z >= zbuf[i] {
+                continue;
+            }
+            zbuf[i] = z;
+            let o = i * 4;
+            pixels[o..o + 4].copy_from_slice(&fill);
         }
     }
 }
@@ -208,11 +278,11 @@ mod tests {
         }
     }
 
-    fn painted_paths(output: &egui::FullOutput) -> usize {
+    fn painted_images(output: &egui::FullOutput) -> usize {
         output
             .shapes
             .iter()
-            .filter(|clipped| matches!(clipped.shape, egui::Shape::Path(_)))
+            .filter(|clipped| matches!(clipped.shape, egui::Shape::Mesh(_)))
             .count()
     }
 
@@ -230,8 +300,20 @@ mod tests {
             );
         });
         assert!(
-            painted_paths(&output) > 0,
+            painted_images(&output) > 0,
             "a visible face must hit the painter"
         );
+    }
+
+    #[test]
+    fn a_near_face_wins_the_z_buffer() {
+        let mut pixels = vec![0u8; 64 * 64 * 4];
+        let mut zbuf = vec![f32::INFINITY; 64 * 64];
+        let near = [[20.0, 20.0, 2.0], [44.0, 20.0, 2.0], [32.0, 44.0, 2.0]];
+        let far = [[8.0, 8.0, 9.0], [56.0, 8.0, 9.0], [32.0, 56.0, 9.0]];
+        raster_ztest(&mut pixels, &mut zbuf, 64, 64, far, [10, 10, 10, 255]);
+        raster_ztest(&mut pixels, &mut zbuf, 64, 64, near, [200, 140, 48, 255]);
+        let i = (32 * 64 + 32) * 4;
+        assert_eq!(&pixels[i..i + 3], &[200, 140, 48]);
     }
 }

--- a/src/escave/screen.rs
+++ b/src/escave/screen.rs
@@ -352,7 +352,11 @@ fn drop_note(hand: &Hand, target: &DropTarget) -> String {
     }
 }
 
-/// Full-screen talk/trade. The road is covered; this is the visit.
+/// Talk/trade overlay. Background order so Tweaks/Settings stay clickable.
+///
+/// Original 800×600 shop: spinning AVI top-left, item list under it,
+/// mechos matrix on the right, price/info along the bottom. Scaled to
+/// the current window; the cave map shows through the gaps.
 pub fn draw_interior(
     ctx: &egui::Context,
     visit: &Visit,
@@ -371,25 +375,25 @@ pub fn draw_interior(
     let mut action = InteriorAction::default();
     let rect = ctx.content_rect();
     let veil = if see_through {
-        egui::Color32::from_rgba_unmultiplied(8, 6, 4, 70)
+        egui::Color32::from_rgba_unmultiplied(8, 6, 4, 40)
     } else {
         BG
     };
     let panel = if see_through {
-        egui::Color32::from_rgba_unmultiplied(36, 26, 16, 210)
+        egui::Color32::from_rgba_unmultiplied(36, 26, 16, 220)
     } else {
         PANEL
     };
     egui::Area::new(egui::Id::new("escave-interior"))
         .fixed_pos(rect.left_top())
-        .order(egui::Order::Middle)
+        .order(egui::Order::Background)
         .show(ctx, |ui| {
             ui.painter().rect_filled(rect, 0.0, veil);
             ui.set_min_size(rect.size());
             egui::Frame::new()
-                .inner_margin(egui::Margin::same(16))
+                .inner_margin(egui::Margin::same(12))
                 .show(ui, |ui| {
-                    ui.spacing_mut().item_spacing = egui::vec2(10.0, 8.0);
+                    ui.spacing_mut().item_spacing = egui::vec2(8.0, 6.0);
                     ui.horizontal(|ui| {
                         if ui.add(egui::Button::new(rich("Leave", ACCENT))).clicked() {
                             action.leave = true;
@@ -397,34 +401,47 @@ pub fn draw_interior(
                         ui.label(
                             egui::RichText::new(visit.name.to_uppercase())
                                 .color(ACCENT)
-                                .size(22.0),
+                                .size(20.0),
                         );
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             ui.label(rich(format!("Beebs: {beebs}"), INK));
+                            if let Some(note) = note {
+                                ui.label(rich(note, MUTED));
+                            }
                         });
                     });
-                    if let Some(note) = note {
-                        ui.label(rich(note, MUTED));
-                    }
-                    ui.add_space(4.0);
-                    ui.columns(2, |cols| {
-                        egui::Frame::new()
-                            .fill(panel)
-                            .inner_margin(egui::Margin::same(10))
-                            .show(&mut cols[0], |ui| {
-                                draw_shop(ui, shop, inventory, selected, spin, &mut action);
-                            });
-                        egui::Frame::new()
-                            .fill(panel)
-                            .inner_margin(egui::Margin::same(10))
-                            .show(&mut cols[1], |ui| {
-                                draw_mechos(ui, inventory, selected, &mut action);
-                            });
+                    let avail = ui.available_size();
+                    let talk_h = 96.0;
+                    let body_h = (avail.y - talk_h - 8.0).max(220.0);
+                    let left_w = (avail.x * 0.36).clamp(280.0, 440.0);
+                    let mech = mechos_panel_size(inventory.layout());
+                    let gap = (avail.x - left_w - mech.x - 12.0).max(16.0);
+                    ui.horizontal(|ui| {
+                        ui.allocate_ui_with_layout(
+                            egui::vec2(left_w, body_h),
+                            egui::Layout::top_down(egui::Align::Min),
+                            |ui| {
+                                draw_shop(ui, panel, shop, inventory, selected, spin, &mut action);
+                            },
+                        );
+                        ui.add_space(gap);
+                        ui.allocate_ui_with_layout(
+                            egui::vec2(mech.x, body_h),
+                            egui::Layout::top_down(egui::Align::Min),
+                            |ui| {
+                                egui::Frame::new()
+                                    .fill(panel)
+                                    .inner_margin(egui::Margin::same(10))
+                                    .show(ui, |ui| {
+                                        draw_mechos(ui, inventory, selected, &mut action);
+                                    });
+                            },
+                        );
                     });
                     ui.add_space(6.0);
                     egui::Frame::new()
                         .fill(panel)
-                        .inner_margin(egui::Margin::same(10))
+                        .inner_margin(egui::Margin::same(8))
                         .show(ui, |ui| {
                             draw_talk(ui, visit, &mut action);
                         });
@@ -438,33 +455,15 @@ fn rich(text: impl Into<String>, color: egui::Color32) -> egui::RichText {
 }
 
 fn draw_talk(ui: &mut egui::Ui, visit: &Visit, action: &mut InteriorAction) {
-    ui.label(rich("Counselor", ACCENT).size(16.0));
-    ui.add_space(6.0);
-    let Some(ref session) = visit.session else {
-        ui.label(rich("The counselor is silent.", MUTED));
-        return;
-    };
-    let phrase = session.last_phrase().unwrap_or("");
-    egui::ScrollArea::vertical()
-        .max_height(140.0)
-        .id_salt("escave-phrase")
-        .show(ui, |ui| {
-            ui.add(
-                egui::Label::new(rich(phrase, INK).size(15.0))
-                    .wrap()
-                    .selectable(false),
-            );
-        });
-    ui.add_space(8.0);
-    if !session.ended() && ui.button(rich("Next", INK)).clicked() {
-        action.next_phrase = true;
-    }
-    if session.queries().is_empty() {
-        return;
-    }
-    ui.add_space(8.0);
-    ui.label(rich("Ask", ACCENT));
-    ui.horizontal_wrapped(|ui| {
+    ui.horizontal(|ui| {
+        ui.label(rich("Counselor", ACCENT).size(14.0));
+        let Some(ref session) = visit.session else {
+            ui.label(rich("The counselor is silent.", MUTED));
+            return;
+        };
+        if !session.ended() && ui.button(rich("Next", INK)).clicked() {
+            action.next_phrase = true;
+        }
         for q in session.queries() {
             let label = session.query_prompt(q);
             if ui.button(rich(label, INK)).clicked() {
@@ -472,202 +471,185 @@ fn draw_talk(ui: &mut egui::Ui, visit: &Visit, action: &mut InteriorAction) {
             }
         }
     });
+    let Some(ref session) = visit.session else {
+        return;
+    };
+    let phrase = session.last_phrase().unwrap_or("");
+    egui::ScrollArea::vertical()
+        .max_height(52.0)
+        .id_salt("escave-phrase")
+        .show(ui, |ui| {
+            ui.add(
+                egui::Label::new(rich(phrase, INK).size(14.0))
+                    .wrap()
+                    .selectable(false),
+            );
+        });
 }
 
-const CELL: f32 = 22.0;
-const CELL_EMPTY: egui::Color32 = egui::Color32::from_rgb(24, 18, 12);
-const CELL_FULL: egui::Color32 = egui::Color32::from_rgb(72, 52, 28);
-const CELL_BAY: egui::Color32 = egui::Color32::from_rgb(48, 36, 22);
-const CELL_DEAD: egui::Color32 = egui::Color32::from_rgb(12, 9, 6);
+/// Pointy-top hex radius in UI points. Original matrix sat ~300 px wide
+/// for 8 columns on an 800-wide screen.
+const HEX_R: f32 = 18.0;
+const CELL_EMPTY: egui::Color32 = egui::Color32::from_rgb(42, 30, 18);
+const CELL_BAY: egui::Color32 = egui::Color32::from_rgb(64, 46, 26);
+const CELL_DEAD: egui::Color32 = egui::Color32::from_rgb(22, 16, 12);
+
+fn hex_pitch() -> (f32, f32) {
+    (HEX_R * 3.0_f32.sqrt(), HEX_R * 1.5)
+}
+
+/// Inclusive (min_x, min_y, max_x, max_y) of cells that are part of the mechos.
+fn layout_bounds(layout: &Layout) -> Option<(i32, i32, i32, i32)> {
+    let mut min_x = layout.width;
+    let mut min_y = layout.height;
+    let mut max_x = -1;
+    let mut max_y = -1;
+    for y in 0..layout.height {
+        for x in 0..layout.width {
+            if layout.cell(x, y) == Cell::Empty {
+                continue;
+            }
+            min_x = min_x.min(x);
+            min_y = min_y.min(y);
+            max_x = max_x.max(x);
+            max_y = max_y.max(y);
+        }
+    }
+    if max_x < 0 {
+        None
+    } else {
+        Some((min_x, min_y, max_x, max_y))
+    }
+}
+
+fn mechos_panel_size(layout: &Layout) -> egui::Vec2 {
+    let Some((x0, y0, x1, y1)) = layout_bounds(layout) else {
+        return egui::vec2(220.0, 220.0);
+    };
+    let cols = (x1 - x0 + 1) as f32;
+    let rows = (y1 - y0 + 1) as f32;
+    let (dx, dy) = hex_pitch();
+    egui::vec2(
+        HEX_R * 2.0 + (cols - 1.0) * dx + dx * 0.5 + 28.0,
+        HEX_R * 2.0 + (rows - 1.0) * dy + 56.0,
+    )
+}
+
+fn hex_center(origin: egui::Pos2, x: i32, y: i32) -> egui::Pos2 {
+    let (dx, dy) = hex_pitch();
+    let odd = Layout::row_offset(y);
+    egui::pos2(
+        origin.x + HEX_R + x as f32 * dx + if odd { dx * 0.5 } else { 0.0 },
+        origin.y + HEX_R + y as f32 * dy,
+    )
+}
+
+fn hex_points(center: egui::Pos2) -> Vec<egui::Pos2> {
+    (0..6)
+        .map(|i| {
+            let a = (i as f32 + 0.5) * std::f32::consts::FRAC_PI_3;
+            egui::pos2(center.x + HEX_R * a.cos(), center.y + HEX_R * a.sin())
+        })
+        .collect()
+}
+
+fn ware_fill(id: &str) -> egui::Color32 {
+    let mut h = 0u32;
+    for b in id.bytes() {
+        h = h.wrapping_mul(16777619) ^ u32::from(b);
+    }
+    let r = 70 + (h & 0x3f) as u8;
+    let g = 42 + ((h >> 6) & 0x2f) as u8;
+    let b = 20 + ((h >> 12) & 0x1f) as u8;
+    egui::Color32::from_rgb(r, g, b)
+}
 
 fn draw_shop(
     ui: &mut egui::Ui,
+    panel: egui::Color32,
     shop: &Shop,
     inventory: &Inventory,
     selected: &mut Option<String>,
     spin: Option<&SpinMesh>,
     action: &mut InteriorAction,
 ) {
-    ui.label(rich("Shop", ACCENT).size(16.0));
-    ui.label(rich(
-        "Drag a ware onto the mechos to buy. Drag cargo here to sell.",
-        MUTED,
-    ));
-    ui.add_space(4.0);
-    let shop_frame = egui::Frame::new()
-        .fill(egui::Color32::from_rgb(28, 20, 12))
-        .inner_margin(egui::Margin::same(6));
-    let (inner, dropped) = ui.dnd_drop_zone::<Hand, ()>(shop_frame, |ui| {
-        if shop.stock().is_empty() {
-            ui.label(rich("Nothing on the counter.", MUTED));
-            return;
-        }
-        for good in shop.stock() {
-            let id = egui::Id::new(("shop-stock", good.id.as_str()));
-            let payload = Hand::Shop {
-                id: good.id.clone(),
-            };
-            let response = ui
-                .dnd_drag_source(id, payload, |ui| {
-                    let kind = if good.is_weapon() { "gun" } else { "ware" };
-                    let marked = selected.as_deref() == Some(good.id.as_str());
-                    let color = if marked { ACCENT } else { INK };
-                    ui.label(rich(
-                        format!("{} ({kind})  {} beebs", good.display_name(), good.buy_price),
-                        color,
-                    ));
-                })
-                .response;
-            if response.clicked() {
-                *selected = Some(good.id.clone());
-            }
-        }
-    });
-    let _ = inner;
-    if let Some(hand) = dropped.as_deref() {
-        action.drop = Some((hand.clone(), DropTarget::Shop));
-    }
-
-    ui.add_space(10.0);
-    draw_preview(ui, shop, inventory, selected.as_deref(), spin);
-}
-
-fn draw_mechos(
-    ui: &mut egui::Ui,
-    inventory: &Inventory,
-    selected: &mut Option<String>,
-    action: &mut InteriorAction,
-) {
-    ui.label(rich("Mechos", ACCENT).size(16.0));
-    ui.label(rich("Hex board of this vehicle.", MUTED));
-    ui.add_space(4.0);
-    let layout = inventory.layout();
-    let cell_size = egui::vec2(CELL, CELL);
-    for y in 0..layout.height {
-        ui.horizontal(|ui| {
-            ui.spacing_mut().item_spacing = egui::vec2(2.0, 2.0);
-            if Layout::row_offset(y) {
-                ui.add_space(CELL * 0.5);
-            }
-            for x in 0..layout.width {
-                draw_board_cell(
-                    ui,
-                    inventory,
-                    layout.cell(x, y),
-                    (x, y),
-                    cell_size,
-                    selected,
-                    action,
-                );
-            }
+    let inner = ui.available_size();
+    let video_h = (inner.x * 0.72).clamp(200.0, 280.0);
+    egui::Frame::new()
+        .fill(panel)
+        .inner_margin(egui::Margin::same(8))
+        .show(ui, |ui| {
+            draw_video(ui, selected.as_deref(), spin, video_h);
+            ui.add_space(6.0);
+            draw_stats(ui, shop, inventory, selected.as_deref());
         });
+    ui.add_space(8.0);
+    egui::Frame::new()
+        .fill(panel)
+        .inner_margin(egui::Margin::same(8))
+        .show(ui, |ui| {
+            draw_stock_list(ui, shop, selected, action);
+        });
+}
+
+fn draw_video(ui: &mut egui::Ui, selected: Option<&str>, spin: Option<&SpinMesh>, height: f32) {
+    let width = ui.available_width();
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(width, height), egui::Sense::hover());
+    ui.painter()
+        .rect_filled(rect, 6.0, egui::Color32::from_rgb(28, 20, 12));
+    ui.painter().rect_stroke(
+        rect,
+        6.0,
+        egui::Stroke::new(1.0_f32, ACCENT.gamma_multiply(0.5)),
+        egui::StrokeKind::Inside,
+    );
+    if let Some(mesh) = spin {
+        let angle = ui.input(|i| i.time) as f32;
+        mesh.paint(ui.painter(), rect.shrink(10.0), angle, ACCENT);
+        ui.ctx().request_repaint();
+    } else if selected.is_some() {
+        ui.painter().text(
+            rect.center(),
+            egui::Align2::CENTER_CENTER,
+            "No mesh",
+            egui::FontId::proportional(14.0),
+            MUTED,
+        );
     }
 }
 
-fn draw_board_cell(
-    ui: &mut egui::Ui,
-    inventory: &Inventory,
-    cell: Cell,
-    origin: (i32, i32),
-    cell_size: egui::Vec2,
-    selected: &mut Option<String>,
-    action: &mut InteriorAction,
-) {
-    match cell {
-        Cell::Empty => {
-            let (rect, _) = ui.allocate_exact_size(cell_size, egui::Sense::hover());
-            ui.painter().rect_filled(rect, 2.0, CELL_DEAD);
-        }
-        Cell::Cargo => {
-            let occupant = inventory.occupant(origin);
-            let is_origin = occupant.is_some_and(|(_, p)| p.origin == origin);
-            let fill = if occupant.is_some() {
-                CELL_FULL
-            } else {
-                CELL_EMPTY
-            };
-            let frame = egui::Frame::new().inner_margin(egui::Margin::same(1));
-            let (inner, dropped) = ui.dnd_drop_zone::<Hand, ()>(frame, |ui| {
-                let (rect, _) = ui.allocate_exact_size(cell_size, egui::Sense::hover());
-                ui.painter().rect_filled(rect, 2.0, fill);
-                ui.scope_builder(egui::UiBuilder::new().max_rect(rect), |ui| {
-                    if let Some((index, placed)) = occupant {
-                        let payload = Hand::Cargo { index };
-                        let id = egui::Id::new(("cargo-cell", origin.0, origin.1, index));
-                        let response = ui
-                            .dnd_drag_source(id, payload, |ui| {
-                                if is_origin {
-                                    let marked =
-                                        selected.as_deref() == Some(placed.good.id.as_str());
-                                    let color = if marked { ACCENT } else { INK };
-                                    ui.label(
-                                        rich(short_id(placed.good.display_name()), color).small(),
-                                    );
-                                }
-                            })
-                            .response;
-                        if response.clicked() {
-                            *selected = Some(placed.good.id.clone());
-                        }
-                    }
-                });
-            });
-            let _ = inner;
-            if let Some(hand) = dropped.as_deref() {
-                action.drop = Some((hand.clone(), DropTarget::Cargo { origin }));
-            }
-        }
-        Cell::Bay(index) => {
-            let good = inventory.bay(index);
-            let fill = if good.is_some() { CELL_FULL } else { CELL_BAY };
-            let frame = egui::Frame::new()
-                .fill(fill)
-                .inner_margin(egui::Margin::same(1));
-            let (inner, dropped) = ui.dnd_drop_zone::<Hand, ()>(frame, |ui| {
-                let (rect, _) = ui.allocate_exact_size(cell_size, egui::Sense::hover());
-                ui.painter().rect_filled(rect, 2.0, fill);
-                ui.scope_builder(egui::UiBuilder::new().max_rect(rect), |ui| match good {
-                    Some(good) => {
-                        let payload = Hand::Bay { index };
-                        let id = egui::Id::new(("bay-cell", origin.0, origin.1, index));
-                        let response = ui
-                            .dnd_drag_source(id, payload, |ui| {
-                                let marked = selected.as_deref() == Some(good.id.as_str());
-                                let color = if marked { ACCENT } else { INK };
-                                ui.label(rich(short_id(good.display_name()), color).small());
-                            })
-                            .response;
-                        if response.clicked() {
-                            *selected = Some(good.id.clone());
-                        }
-                    }
-                    None => {
-                        ui.label(rich(format!("W{index}"), MUTED).small());
-                    }
-                });
-            });
-            let _ = inner;
-            if let Some(hand) = dropped.as_deref() {
-                action.drop = Some((hand.clone(), DropTarget::Bay { index }));
-            }
-        }
-    }
-}
-
-fn draw_preview(
-    ui: &mut egui::Ui,
-    shop: &Shop,
-    inventory: &Inventory,
-    selected: Option<&str>,
-    spin: Option<&SpinMesh>,
-) {
-    ui.label(rich("Preview", ACCENT));
+fn draw_stats(ui: &mut egui::Ui, shop: &Shop, inventory: &Inventory, selected: Option<&str>) {
     let Some(id) = selected else {
-        ui.label(rich("Select a ware to see its stats.", MUTED));
+        ui.label(rich("Select a ware.", MUTED));
         return;
     };
-    let live = shop
-        .stock()
+    let stats = lookup_stats(shop, inventory, id);
+    let kind = if stats.kind == Kind::Weapon {
+        "gun"
+    } else {
+        "ware"
+    };
+    ui.label(rich(format!("{}  ·  {kind}", stats.name), INK).size(16.0));
+    ui.label(rich(
+        format!(
+            "Buy {} beebs    Sell {} beebs",
+            stats.buy_price, stats.sell_price
+        ),
+        ACCENT,
+    ));
+    if stats.description.is_empty() {
+        ui.label(rich("No description.", MUTED));
+    } else {
+        ui.add(
+            egui::Label::new(rich(&stats.description, INK).size(13.0))
+                .wrap()
+                .selectable(false),
+        );
+    }
+}
+
+fn lookup_stats(shop: &Shop, inventory: &Inventory, id: &str) -> Preview {
+    shop.stock()
         .iter()
         .find(|g| g.id == id)
         .or_else(|| {
@@ -683,54 +665,272 @@ fn draw_preview(
                 .iter()
                 .filter_map(Option::as_ref)
                 .find(|g| g.id == id)
-        });
-    let stats = match live {
-        Some(good) => preview_good(good),
-        None => match preview(id) {
-            Some(p) => p,
-            None => Preview {
-                id: id.to_string(),
-                name: id.to_string(),
-                kind: Kind::Ware,
-                buy_price: 0,
-                sell_price: 0,
-                description: String::new(),
-            },
-        },
-    };
-    let kind = if stats.kind == Kind::Weapon {
-        "gun"
-    } else {
-        "ware"
-    };
-    ui.label(rich(format!("{} ({kind})", stats.name), INK));
+        })
+        .map(preview_good)
+        .or_else(|| preview(id))
+        .unwrap_or_else(|| Preview {
+            id: id.to_string(),
+            name: id.to_string(),
+            kind: Kind::Ware,
+            buy_price: 0,
+            sell_price: 0,
+            description: String::new(),
+        })
+}
+
+fn draw_stock_list(
+    ui: &mut egui::Ui,
+    shop: &Shop,
+    selected: &mut Option<String>,
+    action: &mut InteriorAction,
+) {
+    ui.label(rich("Shop", ACCENT).size(14.0));
     ui.label(rich(
-        format!("Buy {}   Sell {}", stats.buy_price, stats.sell_price),
+        "Click to preview. Drag onto the mechos to buy.",
         MUTED,
     ));
-    if let Some(mesh) = spin {
-        let (rect, _) = ui.allocate_exact_size(egui::vec2(180.0, 140.0), egui::Sense::hover());
-        ui.painter()
-            .rect_filled(rect, 4.0, egui::Color32::from_rgb(20, 14, 10));
-        let angle = ui.input(|i| i.time) as f32;
-        let painter = ui.painter();
-        mesh.paint(painter, rect, angle, ACCENT);
-        ui.ctx().request_repaint();
+    let shop_frame = egui::Frame::new()
+        .fill(egui::Color32::from_rgb(22, 16, 10))
+        .inner_margin(egui::Margin::same(4));
+    let (inner, dropped) = ui.dnd_drop_zone::<Hand, ()>(shop_frame, |ui| {
+        if shop.stock().is_empty() {
+            ui.label(rich("Nothing on the counter.", MUTED));
+            return;
+        }
+        egui::ScrollArea::vertical()
+            .id_salt("escave-stock")
+            .max_height(ui.available_height().max(80.0))
+            .show(ui, |ui| {
+                for good in shop.stock() {
+                    let marked = selected.as_deref() == Some(good.id.as_str());
+                    let id = egui::Id::new(("shop-stock", good.id.as_str()));
+                    let payload = Hand::Shop {
+                        id: good.id.clone(),
+                    };
+                    let response = ui
+                        .dnd_drag_source(id, payload, |ui| {
+                            let color = if marked { ACCENT } else { INK };
+                            let kind = if good.is_weapon() { "gun" } else { "ware" };
+                            let label = format!(
+                                "{}  {} · {} beebs",
+                                good.display_name(),
+                                kind,
+                                good.buy_price
+                            );
+                            let fill = if marked {
+                                egui::Color32::from_rgb(56, 38, 18)
+                            } else {
+                                egui::Color32::TRANSPARENT
+                            };
+                            egui::Frame::new()
+                                .fill(fill)
+                                .inner_margin(egui::Margin::symmetric(6, 4))
+                                .show(ui, |ui| {
+                                    ui.set_min_width(ui.available_width());
+                                    ui.label(rich(label, color));
+                                });
+                        })
+                        .response;
+                    if response.clicked() {
+                        *selected = Some(good.id.clone());
+                    }
+                }
+            });
+    });
+    let _ = inner;
+    if let Some(hand) = dropped.as_deref() {
+        action.drop = Some((hand.clone(), DropTarget::Shop));
     }
-    if stats.description.is_empty() {
-        ui.label(rich("No description.", MUTED));
-    } else {
-        ui.add(
-            egui::Label::new(rich(&stats.description, INK))
-                .wrap()
-                .selectable(false),
-        );
+}
+
+fn draw_mechos(
+    ui: &mut egui::Ui,
+    inventory: &Inventory,
+    selected: &mut Option<String>,
+    action: &mut InteriorAction,
+) {
+    ui.label(rich("Mechos", ACCENT).size(16.0));
+    ui.label(rich("Drag a shop ware onto a hex to buy.", MUTED));
+    ui.add_space(6.0);
+    let layout = inventory.layout();
+    let Some((x0, y0, x1, y1)) = layout_bounds(layout) else {
+        ui.label(rich("No board for this mechos.", MUTED));
+        return;
+    };
+    let (dx, dy) = hex_pitch();
+    let cols = (x1 - x0 + 1) as f32;
+    let rows = (y1 - y0 + 1) as f32;
+    let board_w = HEX_R * 2.0 + (cols - 1.0) * dx + dx * 0.5;
+    let board_h = HEX_R * 2.0 + (rows - 1.0) * dy;
+    let (board, _) = ui.allocate_exact_size(egui::vec2(board_w, board_h), egui::Sense::hover());
+    let painter = ui.painter().with_clip_rect(board);
+    for y in y0..=y1 {
+        for x in x0..=x1 {
+            let cell = layout.cell(x, y);
+            if cell == Cell::Empty {
+                continue;
+            }
+            let center = hex_center(board.min, x - x0, y - y0);
+            let points = hex_points(center);
+            let bbox = egui::Rect::from_center_size(
+                center,
+                egui::vec2(dx.max(HEX_R * 2.0) - 1.0, dy + HEX_R * 0.2),
+            )
+            .intersect(board);
+            draw_hex_cell(
+                ui,
+                &painter,
+                inventory,
+                cell,
+                (x, y),
+                points,
+                bbox,
+                selected,
+                action,
+            );
+        }
     }
+}
+
+fn draw_hex_cell(
+    ui: &mut egui::Ui,
+    painter: &egui::Painter,
+    inventory: &Inventory,
+    cell: Cell,
+    origin: (i32, i32),
+    points: Vec<egui::Pos2>,
+    bbox: egui::Rect,
+    selected: &mut Option<String>,
+    action: &mut InteriorAction,
+) {
+    if bbox.width() < 4.0 || bbox.height() < 4.0 {
+        return;
+    }
+    match cell {
+        Cell::Empty => {
+            painter.add(egui::Shape::convex_polygon(
+                points,
+                CELL_DEAD,
+                egui::Stroke::new(1.0_f32, egui::Color32::from_rgb(40, 28, 18)),
+            ));
+        }
+        Cell::Cargo => {
+            let occupant = inventory.occupant(origin);
+            let is_origin = occupant.is_some_and(|(_, p)| p.origin == origin);
+            let marked = occupant
+                .map(|(_, p)| selected.as_deref() == Some(p.good.id.as_str()))
+                .unwrap_or(false);
+            let fill = occupant
+                .map(|(_, p)| ware_fill(&p.good.id))
+                .unwrap_or(CELL_EMPTY);
+            let stroke = if marked {
+                egui::Stroke::new(2.0_f32, ACCENT)
+            } else {
+                egui::Stroke::new(1.0_f32, egui::Color32::from_rgb(60, 42, 26))
+            };
+            painter.add(egui::Shape::convex_polygon(points, fill, stroke));
+            if let Some((_, placed)) = occupant
+                && is_origin
+            {
+                painter.text(
+                    bbox.center(),
+                    egui::Align2::CENTER_CENTER,
+                    short_id(placed.good.display_name()),
+                    egui::FontId::proportional(11.0),
+                    if marked { ACCENT } else { INK },
+                );
+            }
+            ui.scope_builder(egui::UiBuilder::new().max_rect(bbox), |ui| {
+                let frame = egui::Frame::new().inner_margin(0);
+                let (inner, dropped) = ui.dnd_drop_zone::<Hand, ()>(frame, |ui| {
+                    if let Some((index, placed)) = occupant {
+                        let payload = Hand::Cargo { index };
+                        let id = egui::Id::new(("cargo-hex", origin.0, origin.1, index));
+                        let response = ui
+                            .dnd_drag_source(id, payload, |ui| {
+                                ui.allocate_exact_size(bbox.size(), egui::Sense::click());
+                            })
+                            .response;
+                        response.clone().on_hover_text(placed.good.display_name());
+                        if response.clicked() {
+                            *selected = Some(placed.good.id.clone());
+                        }
+                    } else {
+                        ui.allocate_exact_size(bbox.size(), egui::Sense::hover());
+                    }
+                });
+                let _ = inner;
+                if let Some(hand) = dropped.as_deref() {
+                    action.drop = Some((hand.clone(), DropTarget::Cargo { origin }));
+                }
+            });
+        }
+        Cell::Bay(index) => {
+            let good = inventory.bay(index);
+            let marked = good
+                .map(|g| selected.as_deref() == Some(g.id.as_str()))
+                .unwrap_or(false);
+            let fill = good.map(|g| ware_fill(&g.id)).unwrap_or(CELL_BAY);
+            let stroke = if marked {
+                egui::Stroke::new(2.0_f32, ACCENT)
+            } else {
+                egui::Stroke::new(1.5_f32, egui::Color32::from_rgb(180, 140, 48))
+            };
+            painter.add(egui::Shape::convex_polygon(points, fill, stroke));
+            let label = match good {
+                Some(g) => short_id(g.display_name()),
+                None => format!("W{}", index + 1),
+            };
+            painter.text(
+                bbox.center(),
+                egui::Align2::CENTER_CENTER,
+                label,
+                egui::FontId::proportional(11.0),
+                if marked { ACCENT } else { INK },
+            );
+            ui.scope_builder(egui::UiBuilder::new().max_rect(bbox), |ui| {
+                let frame = egui::Frame::new().inner_margin(0);
+                let (inner, dropped) = ui.dnd_drop_zone::<Hand, ()>(frame, |ui| {
+                    if let Some(good) = good {
+                        let payload = Hand::Bay { index };
+                        let id = egui::Id::new(("bay-hex", origin.0, origin.1, index));
+                        let response = ui
+                            .dnd_drag_source(id, payload, |ui| {
+                                ui.allocate_exact_size(bbox.size(), egui::Sense::click());
+                            })
+                            .response;
+                        response.clone().on_hover_text(good.display_name());
+                        if response.clicked() {
+                            *selected = Some(good.id.clone());
+                        }
+                    } else {
+                        ui.allocate_exact_size(bbox.size(), egui::Sense::hover());
+                    }
+                });
+                let _ = inner;
+                if let Some(hand) = dropped.as_deref() {
+                    action.drop = Some((hand.clone(), DropTarget::Bay { index }));
+                }
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+fn draw_preview(
+    ui: &mut egui::Ui,
+    shop: &Shop,
+    inventory: &Inventory,
+    selected: Option<&str>,
+    spin: Option<&SpinMesh>,
+) {
+    draw_video(ui, selected, spin, 140.0);
+    draw_stats(ui, shop, inventory, selected);
 }
 
 fn short_id(id: &str) -> String {
     let mut chars = id.chars();
-    let take: String = chars.by_ref().take(4).collect();
+    let take: String = chars.by_ref().take(5).collect();
     if chars.next().is_some() {
         format!("{take}…")
     } else {
@@ -861,29 +1061,31 @@ mod tests {
         }
     }
 
-    fn is_cell_rect(shape: &egui::Shape) -> bool {
+    fn is_hex_path(shape: &egui::Shape) -> bool {
         #[allow(clippy::pattern_type_mismatch)]
         match shape {
-            egui::Shape::Rect(rect) => {
-                (rect.rect.width() - CELL).abs() < 1.0 && (rect.rect.height() - CELL).abs() < 1.0
+            egui::Shape::Path(path) => {
+                path.points.len() >= 6
+                    && path.points.len() <= 7
+                    && (path.points[0] - path.points[1]).length() > 4.0
             }
             _ => false,
         }
     }
 
-    fn cell_sized_rects(output: &egui::FullOutput) -> usize {
+    fn hex_paths(output: &egui::FullOutput) -> usize {
         output
             .shapes
             .iter()
-            .filter(|clipped| is_cell_rect(&clipped.shape))
+            .filter(|clipped| is_hex_path(&clipped.shape))
             .count()
     }
 
-    fn painted_paths(output: &egui::FullOutput) -> usize {
+    fn painted_images(output: &egui::FullOutput) -> usize {
         output
             .shapes
             .iter()
-            .filter(|clipped| matches!(clipped.shape, egui::Shape::Path(_)))
+            .filter(|clipped| matches!(clipped.shape, egui::Shape::Mesh(_)))
             .count()
     }
 
@@ -901,7 +1103,7 @@ mod tests {
         let inventory = Inventory::default();
         assert!(inventory.layout().width > 0);
         let output = paint_mechos(&inventory);
-        let cells = cell_sized_rects(&output);
+        let cells = hex_paths(&output);
         assert!(
             cells >= (inventory.layout().width * inventory.layout().height) as usize,
             "expected a painted hex cell per board slot, got {cells}"
@@ -912,7 +1114,7 @@ mod tests {
     fn an_empty_board_paints_no_hex_cells() {
         let inventory = Inventory::for_car("Nobody", &super::super::Catalog::default());
         assert_eq!(inventory.layout().width, 0);
-        assert_eq!(cell_sized_rects(&paint_mechos(&inventory)), 0);
+        assert_eq!(hex_paths(&paint_mechos(&inventory)), 0);
     }
 
     #[test]
@@ -925,7 +1127,7 @@ mod tests {
             draw_preview(ui, &shop, &inventory, Some("Nymbos"), Some(&mesh));
         });
         assert!(
-            painted_paths(&output) > 0,
+            painted_images(&output) > 0,
             "the shop preview must paint the spinning mesh"
         );
     }
@@ -983,5 +1185,85 @@ mod tests {
         let preview = preview("Nymbos").unwrap();
         assert_eq!(preview.kind, Kind::Ware);
         assert!(!preview.description.is_empty());
+    }
+
+    fn data_root() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../Vangers/data")
+    }
+
+    fn preview_mesh() -> SpinMesh {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+        for rel in [
+            "../Vangers/data/resource/m3d/items/i4.m3d",
+            "../VangersData/resource/m3d/items/i4.m3d",
+        ] {
+            if let Some(mesh) = SpinMesh::load_path(&root.join(rel)) {
+                return mesh;
+            }
+        }
+        SpinMesh::triangle()
+    }
+
+    #[test]
+    fn shop_layout_preview_png() {
+        let visit = Visit {
+            name: "Podish".into(),
+            session: None,
+        };
+        let shop = Shop::fostral();
+        let mut inventory = {
+            let cat = super::super::Catalog::load(&data_root());
+            if cat.is_empty() {
+                Inventory::default()
+            } else {
+                Inventory::for_car("OxidizeMonk", &cat)
+            }
+        };
+        if let Some(origin) = inventory.first_fit(shop.stock()[0].shape()) {
+            let _ = inventory.place(shop.stock()[0].clone(), origin);
+        }
+        let mut selected = Some("Nymbos".into());
+        let mut spins = HashMap::new();
+        spins.insert("Nymbos".into(), preview_mesh());
+        let ctx = egui::Context::default();
+        let mut input = viewport_input();
+        input.time = Some(0.8);
+        #[expect(deprecated)]
+        let _ = ctx.run(input.clone(), |ctx| {
+            let _ = draw_interior(
+                ctx,
+                &visit,
+                &shop,
+                &inventory,
+                188,
+                Some("Bought Nymbos"),
+                &mut selected,
+                &spins,
+                true,
+            );
+        });
+        input.time = Some(0.8);
+        #[expect(deprecated)]
+        let output = ctx.run(input, |ctx| {
+            let _ = draw_interior(
+                ctx,
+                &visit,
+                &shop,
+                &inventory,
+                188,
+                Some("Bought Nymbos"),
+                &mut selected,
+                &spins,
+                true,
+            );
+        });
+        let primitives = ctx.tessellate(output.shapes.clone(), output.pixels_per_point);
+        let pixels = crate::escave::shot::rasterize(1280, 800, &output, &primitives);
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("target/shop-preview.png");
+        crate::escave::shot::write_png(&path, 1280, 800, &pixels).expect("write shop preview");
+        assert!(
+            path.metadata().map(|m| m.len()).unwrap_or(0) > 8_000,
+            "shop preview png should have pixels"
+        );
     }
 }

--- a/src/escave/shot.rs
+++ b/src/escave/shot.rs
@@ -1,0 +1,233 @@
+//! CPU snapshot of the shop overlay, so layout can be iterated without
+//! booting the game. Library tests write `target/shop-preview.png`.
+
+use egui::epaint::{ClippedPrimitive, ImageDelta, Primitive, Vertex};
+use egui::{ColorImage, ImageData, TextureId};
+use std::collections::HashMap;
+use std::io::BufWriter;
+use std::path::Path;
+
+struct Atlas {
+    width: usize,
+    height: usize,
+    rgba: Vec<u8>,
+}
+
+impl Atlas {
+    fn color(image: &ColorImage) -> Self {
+        let mut rgba = Vec::with_capacity(image.pixels.len() * 4);
+        for c in &image.pixels {
+            rgba.extend_from_slice(&c.to_array());
+        }
+        Atlas {
+            width: image.width(),
+            height: image.height(),
+            rgba,
+        }
+    }
+
+    fn sample(&self, uv: [f32; 2]) -> [f32; 4] {
+        if self.width == 0 || self.height == 0 {
+            return [1.0, 1.0, 1.0, 1.0];
+        }
+        let x = (uv[0] * self.width as f32).clamp(0.0, (self.width - 1) as f32) as usize;
+        let y = (uv[1] * self.height as f32).clamp(0.0, (self.height - 1) as f32) as usize;
+        let i = (y * self.width + x) * 4;
+        [
+            self.rgba[i] as f32 / 255.0,
+            self.rgba[i + 1] as f32 / 255.0,
+            self.rgba[i + 2] as f32 / 255.0,
+            self.rgba[i + 3] as f32 / 255.0,
+        ]
+    }
+
+    fn patch_color(&mut self, img: &ColorImage, pos: Option<[usize; 2]>) {
+        let (ox, oy) = pos.map(|p| (p[0], p[1])).unwrap_or((0, 0));
+        for y in 0..img.height() {
+            for x in 0..img.width() {
+                let c = img.pixels[y * img.width() + x].to_array();
+                let dx = ox + x;
+                let dy = oy + y;
+                if dx < self.width && dy < self.height {
+                    let i = (dy * self.width + dx) * 4;
+                    self.rgba[i..i + 4].copy_from_slice(&c);
+                }
+            }
+        }
+    }
+}
+
+fn apply_delta(textures: &mut HashMap<TextureId, Atlas>, id: TextureId, delta: &ImageDelta) {
+    #[allow(clippy::infallible_destructuring_match, clippy::pattern_type_mismatch)]
+    let img = match &delta.image {
+        ImageData::Color(img) => img.as_ref(),
+    };
+    if let Some(pos) = delta.pos
+        && let Some(atlas) = textures.get_mut(&id)
+    {
+        atlas.patch_color(img, Some(pos));
+        return;
+    }
+    textures.insert(id, Atlas::color(img));
+}
+
+fn blend(dst: &mut [u8], src_premul: [f32; 4]) {
+    let sa = src_premul[3].clamp(0.0, 1.0);
+    let da = dst[3] as f32 / 255.0;
+    let out_a = sa + da * (1.0 - sa);
+    if out_a <= 0.0 {
+        dst.copy_from_slice(&[0, 0, 0, 0]);
+        return;
+    }
+    for c in 0..3 {
+        let s = src_premul[c];
+        let d = dst[c] as f32 / 255.0 * da;
+        dst[c] = ((s + d * (1.0 - sa)) / out_a * 255.0).clamp(0.0, 255.0) as u8;
+    }
+    dst[3] = (out_a * 255.0).clamp(0.0, 255.0) as u8;
+}
+
+fn vertex_rgba(v: Vertex) -> [f32; 4] {
+    let c = v.color.to_array();
+    [
+        c[0] as f32 / 255.0,
+        c[1] as f32 / 255.0,
+        c[2] as f32 / 255.0,
+        c[3] as f32 / 255.0,
+    ]
+}
+
+fn raster_triangle(
+    pixels: &mut [u8],
+    width: i32,
+    height: i32,
+    clip: egui::Rect,
+    verts: [Vertex; 3],
+    atlas: Option<&Atlas>,
+) {
+    let pts = verts.map(|v| v.pos);
+    let min_x = pts[0]
+        .x
+        .min(pts[1].x)
+        .min(pts[2].x)
+        .max(clip.left())
+        .max(0.0);
+    let max_x = pts[0]
+        .x
+        .max(pts[1].x)
+        .max(pts[2].x)
+        .min(clip.right())
+        .min(width as f32);
+    let min_y = pts[0]
+        .y
+        .min(pts[1].y)
+        .min(pts[2].y)
+        .max(clip.top())
+        .max(0.0);
+    let max_y = pts[0]
+        .y
+        .max(pts[1].y)
+        .max(pts[2].y)
+        .min(clip.bottom())
+        .min(height as f32);
+    if min_x >= max_x || min_y >= max_y {
+        return;
+    }
+    let area = (pts[1].x - pts[0].x) * (pts[2].y - pts[0].y)
+        - (pts[2].x - pts[0].x) * (pts[1].y - pts[0].y);
+    if area.abs() < 0.25 {
+        return;
+    }
+    let x0 = min_x.floor() as i32;
+    let x1 = max_x.ceil() as i32;
+    let y0 = min_y.floor() as i32;
+    let y1 = max_y.ceil() as i32;
+    let colors = verts.map(vertex_rgba);
+    for y in y0..y1 {
+        for x in x0..x1 {
+            if x < 0 || y < 0 || x >= width || y >= height {
+                continue;
+            }
+            let px = x as f32 + 0.5;
+            let py = y as f32 + 0.5;
+            let w0 = ((pts[1].x - px) * (pts[2].y - py) - (pts[2].x - px) * (pts[1].y - py)) / area;
+            let w1 = ((pts[2].x - px) * (pts[0].y - py) - (pts[0].x - px) * (pts[2].y - py)) / area;
+            let w2 = 1.0 - w0 - w1;
+            if w0 < 0.0 || w1 < 0.0 || w2 < 0.0 {
+                continue;
+            }
+            let mut src = [
+                colors[0][0] * w0 + colors[1][0] * w1 + colors[2][0] * w2,
+                colors[0][1] * w0 + colors[1][1] * w1 + colors[2][1] * w2,
+                colors[0][2] * w0 + colors[1][2] * w1 + colors[2][2] * w2,
+                colors[0][3] * w0 + colors[1][3] * w1 + colors[2][3] * w2,
+            ];
+            if let Some(atlas) = atlas {
+                let uv = [
+                    verts[0].uv[0] * w0 + verts[1].uv[0] * w1 + verts[2].uv[0] * w2,
+                    verts[0].uv[1] * w0 + verts[1].uv[1] * w1 + verts[2].uv[1] * w2,
+                ];
+                let texel = atlas.sample(uv);
+                src[0] *= texel[0];
+                src[1] *= texel[1];
+                src[2] *= texel[2];
+                src[3] *= texel[3];
+            }
+            if src[3] <= 0.001 {
+                continue;
+            }
+            let i = ((y * width + x) * 4) as usize;
+            blend(&mut pixels[i..i + 4], src);
+        }
+    }
+}
+
+/// Paint tessellated egui output into an RGBA buffer.
+pub fn rasterize(
+    width: u32,
+    height: u32,
+    output: &egui::FullOutput,
+    primitives: &[ClippedPrimitive],
+) -> Vec<u8> {
+    let mut textures = HashMap::new();
+    for pair in &output.textures_delta.set {
+        apply_delta(&mut textures, pair.0, &pair.1);
+    }
+    let mut pixels = vec![0u8; width as usize * height as usize * 4];
+    for prim in primitives {
+        let mesh = match prim.primitive {
+            Primitive::Mesh(ref mesh) => mesh,
+            Primitive::Callback(_) => continue,
+        };
+        let atlas = textures.get(&mesh.texture_id);
+        for tri in mesh.indices.as_chunks::<3>().0 {
+            let verts = [
+                mesh.vertices[tri[0] as usize],
+                mesh.vertices[tri[1] as usize],
+                mesh.vertices[tri[2] as usize],
+            ];
+            raster_triangle(
+                &mut pixels,
+                width as i32,
+                height as i32,
+                prim.clip_rect,
+                verts,
+                atlas,
+            );
+        }
+    }
+    pixels
+}
+
+pub fn write_png(path: &Path, width: u32, height: u32, rgba: &[u8]) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::File::create(path)?;
+    let mut encoder = png::Encoder::new(BufWriter::new(file), width, height);
+    encoder.set_color(png::ColorType::Rgba);
+    encoder.set_depth(png::BitDepth::Eight);
+    let mut writer = encoder.write_header()?;
+    writer.write_image_data(rgba)?;
+    Ok(())
+}

--- a/src/vfs.rs
+++ b/src/vfs.rs
@@ -85,6 +85,21 @@ impl Vfs {
         self.entries.is_empty()
     }
 
+    /// Clone the entries whose path is `prefix` or lives under it.
+    /// `Arc` payloads are shared, so this is cheap on the bytes.
+    pub fn prefix(&self, prefix: &str) -> Self {
+        let prefix = normalize(prefix);
+        let prefix = prefix.trim_end_matches('/');
+        let under = format!("{prefix}/");
+        let mut out = Self::new();
+        for (key, bytes) in &self.entries {
+            if key == prefix || key.starts_with(&under) {
+                out.entries.insert(key.clone(), Arc::clone(bytes));
+            }
+        }
+        out
+    }
+
     pub fn paths(&self) -> impl Iterator<Item = &str> {
         self.entries.keys().map(String::as_str)
     }
@@ -152,5 +167,20 @@ mod tests {
         );
         assert_eq!(vfs.files_in("data.vot/"), vfs.files_in("DATA.VOT"));
         assert_eq!(vfs.files_in(""), vec!["location.lst".to_string()]);
+    }
+
+    #[test]
+    fn prefix_keeps_only_that_tree() {
+        let mut vfs = Vfs::new();
+        vfs.insert("resource/iscreen/ldata/l0/escave.ini", b"ini".to_vec());
+        vfs.insert("resource/iscreen/ldata/l0/escave.vmc", b"vmc".to_vec());
+        vfs.insert("world.ini", b"world".to_vec());
+        vfs.insert("resource/m3d/car.m3d", b"car".to_vec());
+        let slice = vfs.prefix("resource/iscreen/ldata");
+        assert_eq!(slice.len(), 2);
+        assert!(slice.contains("resource/iscreen/ldata/l0/escave.ini"));
+        assert!(slice.contains("RESOURCE/ISCREEN/LDATA/L0/ESCAVE.VMC"));
+        assert!(!slice.contains("world.ini"));
+        assert!(!slice.contains("resource/m3d/car.m3d"));
     }
 }


### PR DESCRIPTION
Keep iscreen ldata in a VFS slice so a Fostral zip can voxelize Podish behind the counter. The shop matches the 1998 layout (video, list, stats, hex board), the turntable uses a z-buffer, and Tweaks stays clickable. Cave view sits 30° off vertical and height-field marches so TIN tiles do not grid the creature.