### PR TITLE
Clip the cave to one iscreen tile and drive it from a phone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ egui = "0.34"
 # web
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
-web-sys = { version = "0.3", optional = true, features = ["Window", "Document", "Element", "HtmlCanvasElement", "HtmlElement", "Location", "Navigator", "WebSocket", "BinaryType", "MessageEvent", "ErrorEvent", "CloseEvent", "Blob", "FileReader", "Request", "RequestInit", "RequestMode", "Response", "Headers", "ReadableStream", "ReadableStreamDefaultReader", "KeyboardEvent", "PointerEvent", "DomRect", "EventTarget"] }
+web-sys = { version = "0.3", optional = true, features = ["Window", "Document", "Element", "HtmlCanvasElement", "HtmlElement", "Location", "Navigator", "MediaQueryList", "WebSocket", "BinaryType", "MessageEvent", "ErrorEvent", "CloseEvent", "Blob", "FileReader", "Request", "RequestInit", "RequestMode", "Response", "Headers", "ReadableStream", "ReadableStreamDefaultReader", "KeyboardEvent", "PointerEvent", "DomRect", "EventTarget"] }
 console_log = { version = "1", optional = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 getrandom_02 = { package = "getrandom", version = "0.2", optional = true, features = ["js"] }

--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -1021,8 +1021,9 @@ impl Game {
         if self.cave.as_ref().is_some_and(|c| c.name == name) {
             return;
         }
+        let situation = escave::cave::Situation::Shop;
         let Some((config, level)) =
-            escave::cave::load(&self.data_path, name, &self.cave_boot.geometry)
+            escave::cave::load(&self.data_path, name, &self.cave_boot.geometry, situation)
         else {
             self.cave = None;
             return;
@@ -1043,9 +1044,18 @@ impl Game {
             &self.cave_boot.geometry,
             self.cave_boot.front_face,
         );
-        let (mut cam, target, distance) = escave::cave::camera(&level, self.cam.proj);
+        let (mut cam, target, distance) = escave::cave::camera(&level, self.cam.proj, situation);
         cam.proj.update(extent.width as u16, extent.height as u16);
-        log::info!("escave iscreen {name} {}x{}", level.size.0, level.size.1);
+        let tile = situation.region();
+        log::info!(
+            "escave iscreen {name} {}x{} from {}x{}+{},{}",
+            level.size.0,
+            level.size.1,
+            tile.w,
+            tile.h,
+            tile.x,
+            tile.y
+        );
         self.cave = Some(CaveView {
             name: name.to_string(),
             level,
@@ -1184,22 +1194,16 @@ impl Game {
     }
 
     fn resolve_escave_name(&self, sensor: &str, pos: (i32, i32)) -> String {
-        const REACH2: i32 = 256 * 256;
-        self.db
+        let pads: Vec<escave::cave::Pad> = self
+            .db
             .escaves
             .iter()
-            .filter(|e| {
-                let dx = e.coordinates.0 - pos.0;
-                let dy = e.coordinates.1 - pos.1;
-                dx * dx + dy * dy <= REACH2
+            .map(|e| escave::cave::Pad {
+                name: e.name.clone(),
+                pos: e.coordinates,
             })
-            .min_by_key(|e| {
-                let dx = e.coordinates.0 - pos.0;
-                let dy = e.coordinates.1 - pos.1;
-                dx * dx + dy * dy
-            })
-            .map(|e| e.name.clone())
-            .unwrap_or_else(|| sensor.to_string())
+            .collect();
+        escave::cave::resolve_name(sensor, pos, &pads)
     }
 
     /// Close the hatch and kick the car out, `ImpulseEscave::Active`.

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -498,6 +498,14 @@ struct WebApp {
     iscreen: Vfs,
     cave_boot: CaveBoot,
     cave: Option<CaveView>,
+    /// `escaves.prm` + `spots.prm` so VLC names like `Escave1` map to VigBoo.
+    cave_pads: Vec<escave::cave::Pad>,
+    /// On-screen stick (motor, rudder), only while a thumb is on it.
+    stick: (f32, f32),
+    /// On-screen Use, same edge as Space.
+    use_held: bool,
+    /// Phone / tablet: coarse pointer or a narrow touch screen.
+    touch_stick: bool,
 }
 
 struct CaveBoot {
@@ -554,8 +562,10 @@ impl WebApp {
             // Close third-person chase cam. The mechos is roughly 30 world
             // units long; with the wide focal-512 FOV a long chase shrinks
             // it into the screen, so this sits under a body length behind
-            // the centre and looks just beyond the nose. `angle` is unused
-            // once `look_ahead` is set and remains a fallback pitch.
+            // the centre and looks just beyond the nose. `height` is the
+            // base; `build` then adds one body height so the view sits
+            // over the hull instead of staring at the dirt under it.
+            // `angle` is unused once `look_ahead` is set.
             s.game.camera.angle = 12;
             s.game.camera.offset = 24.0;
             s.game.camera.height = 9.0;
@@ -738,12 +748,23 @@ impl WebApp {
 
         // Camera follow params from settings.ron, same conversion as
         // native (bin/road/game.rs CameraStyle::new).
-        let follow = space::Follow {
+        let mut follow = space::Follow {
             angle_x: (cam_config.angle as f32).to_radians() - std::f32::consts::FRAC_PI_2,
             offset: glam::vec3(0.0, cam_config.offset, cam_config.height),
             speed: cam_config.speed,
             look_ahead: cam_config.look_ahead,
         };
+        if let Some(ref a) = agent {
+            let b = &a.phys_data.bbox;
+            let body_h = (b.max[2] - b.min[2]).abs() * a.car.scale;
+            let extra = if body_h > 1.0 {
+                body_h.clamp(6.0, 28.0)
+            } else {
+                12.0
+            };
+            follow.offset.z += extra;
+            log::info!("chase camera raised by {extra:.0} (one body height)");
+        }
 
         let moving_t = Instant::now();
         let moving = level::moving::MovingWorld::load(&level_config, vfs);
@@ -844,6 +865,27 @@ impl WebApp {
                 front_face: cam.front_face(),
             },
             cave: None,
+            cave_pads: {
+                let mut pads = Vec::new();
+                if let Some(v) = vfs {
+                    for key in ["escaves.prm", "spots.prm"] {
+                        if let Some(bytes) = v.read(key) {
+                            pads.extend(escave::cave::pads_from_prm(&String::from_utf8_lossy(
+                                &bytes,
+                            )));
+                        }
+                    }
+                }
+                if pads.is_empty() {
+                    log::info!("No escaves.prm/spots.prm; VLC names like Escave1 will not map");
+                } else {
+                    log::info!("Loaded {} escave/spot pads for iscreen", pads.len());
+                }
+                pads
+            },
+            stick: (0.0, 0.0),
+            use_held: false,
+            touch_stick: uses_touch_stick(),
         }
     }
 
@@ -882,7 +924,17 @@ impl WebApp {
             escave::draw_shutters(ctx, shutter);
         }
 
+        if self.touch_stick {
+            self.use_held = draw_use_button(ctx);
+        }
+
         if !self.screen.is_world() {
+            self.stick = (0.0, 0.0);
+            return;
+        }
+
+        if self.touch_stick {
+            self.stick = draw_drive_stick(ctx);
             return;
         }
 
@@ -1053,8 +1105,9 @@ impl WebApp {
         if self.cave.as_ref().is_some_and(|c| c.name == name) {
             return;
         }
+        let situation = escave::cave::Situation::Shop;
         let Some((config, level)) =
-            escave::cave::load_from_vfs(&self.iscreen, name, &self.cave_boot.geometry)
+            escave::cave::load_from_vfs(&self.iscreen, name, &self.cave_boot.geometry, situation)
         else {
             self.cave = None;
             return;
@@ -1075,9 +1128,18 @@ impl WebApp {
             &self.cave_boot.geometry,
             self.cave_boot.front_face,
         );
-        let (mut cam, target, distance) = escave::cave::camera(&level, self.cam.proj);
+        let (mut cam, target, distance) = escave::cave::camera(&level, self.cam.proj, situation);
         cam.proj.update(extent.width as u16, extent.height as u16);
-        log::info!("escave iscreen {name} {}x{}", level.size.0, level.size.1);
+        let tile = situation.region();
+        log::info!(
+            "escave iscreen {name} {}x{} from {}x{}+{},{}",
+            level.size.0,
+            level.size.1,
+            tile.w,
+            tile.h,
+            tile.x,
+            tile.y
+        );
         self.cave = Some(CaveView {
             name: name.to_string(),
             level,
@@ -1126,8 +1188,13 @@ impl WebApp {
         ) else {
             return;
         };
+        let name = escave::cave::resolve_name(
+            &arrival.name,
+            (arrival.pos.0, arrival.pos.1),
+            &self.cave_pads,
+        );
         self.start_enter(
-            arrival.name,
+            name,
             glam::Vec3::new(arrival.pos.0 as f32, arrival.pos.1 as f32, pos.z),
         );
     }
@@ -1440,6 +1507,115 @@ fn key_from_code(code: &str) -> Option<KeyCode> {
     })
 }
 
+/// Phone / tablet: a coarse pointer, or a narrow screen that also has touch.
+fn uses_touch_stick() -> bool {
+    let Some(window) = web_sys::window() else {
+        return false;
+    };
+    if window
+        .match_media("(pointer: coarse)")
+        .ok()
+        .flatten()
+        .is_some_and(|m| m.matches())
+    {
+        return true;
+    }
+    let touch = window.navigator().max_touch_points() > 0;
+    let narrow = window
+        .inner_width()
+        .ok()
+        .and_then(|v| v.as_f64())
+        .unwrap_or(1024.0)
+        < 900.0;
+    touch && narrow
+}
+
+const STICK_RADIUS: f32 = 56.0;
+const USE_RADIUS: f32 = 36.0;
+const TOUCH_MARGIN: f32 = 20.0;
+const TOUCH_GAP: f32 = 16.0;
+
+/// Bottom-right analog stick. Returns (motor, rudder) in [-1, 1], matching WASD.
+fn draw_drive_stick(ctx: &egui::Context) -> (f32, f32) {
+    const RADIUS: f32 = STICK_RADIUS;
+    const MARGIN: f32 = TOUCH_MARGIN;
+    let mut drive = (0.0f32, 0.0f32);
+    egui::Area::new(egui::Id::new("drive-stick"))
+        .order(egui::Order::Foreground)
+        .anchor(egui::Align2::RIGHT_BOTTOM, egui::vec2(-MARGIN, -MARGIN))
+        .show(ctx, |ui| {
+            let size = egui::vec2(RADIUS * 2.0, RADIUS * 2.0);
+            let (resp, painter) = ui.allocate_painter(size, egui::Sense::drag());
+            let center = resp.rect.center();
+            let mut knob = egui::Vec2::ZERO;
+            if resp.dragged()
+                && let Some(pos) = resp.interact_pointer_pos()
+            {
+                let v = pos - center;
+                let max = RADIUS - 6.0;
+                let len = v.length();
+                knob = if len > max { v * (max / len) } else { v };
+            }
+            painter.circle_filled(center, RADIUS, egui::Color32::from_black_alpha(90));
+            painter.circle_stroke(
+                center,
+                RADIUS,
+                egui::Stroke::new(2.0_f32, egui::Color32::from_white_alpha(70)),
+            );
+            painter.circle_filled(
+                center + knob,
+                RADIUS * 0.38,
+                egui::Color32::from_white_alpha(150),
+            );
+            let reach = RADIUS - 6.0;
+            let nx = (knob.x / reach).clamp(-1.0, 1.0);
+            let ny = (knob.y / reach).clamp(-1.0, 1.0);
+            const DEAD: f32 = 0.12;
+            if nx.abs() > DEAD || ny.abs() > DEAD {
+                // egui +Y is down; W is motor +, A is rudder +.
+                drive = (-ny, -nx);
+            }
+        });
+    drive
+}
+
+/// Use / Space, to the left of the stick so a thumb can hit it without
+/// fighting the knob. Held like the key: press edge opens a pad, or
+/// leaves the shop.
+fn draw_use_button(ctx: &egui::Context) -> bool {
+    const RADIUS: f32 = USE_RADIUS;
+    let x = -(TOUCH_MARGIN + STICK_RADIUS * 2.0 + TOUCH_GAP);
+    let mut held = false;
+    egui::Area::new(egui::Id::new("use-button"))
+        .order(egui::Order::Foreground)
+        .anchor(egui::Align2::RIGHT_BOTTOM, egui::vec2(x, -TOUCH_MARGIN))
+        .show(ctx, |ui| {
+            let size = egui::vec2(RADIUS * 2.0, RADIUS * 2.0);
+            let (resp, painter) = ui.allocate_painter(size, egui::Sense::click_and_drag());
+            held = resp.is_pointer_button_down_on();
+            let fill = if held {
+                egui::Color32::from_white_alpha(50)
+            } else {
+                egui::Color32::from_black_alpha(90)
+            };
+            let center = resp.rect.center();
+            painter.circle_filled(center, RADIUS, fill);
+            painter.circle_stroke(
+                center,
+                RADIUS,
+                egui::Stroke::new(2.0_f32, egui::Color32::from_white_alpha(70)),
+            );
+            painter.text(
+                center,
+                egui::Align2::CENTER_CENTER,
+                "USE",
+                egui::FontId::proportional(16.0),
+                egui::Color32::from_white_alpha(200),
+            );
+        });
+    held
+}
+
 fn pointer_pos(canvas: &web_sys::HtmlCanvasElement, event: &web_sys::PointerEvent) -> [f32; 2] {
     let rect = canvas.get_bounding_client_rect();
     [
@@ -1599,6 +1775,9 @@ impl WebHandler {
         let on_pointerdown = Closure::wrap(Box::new(move |event: web_sys::PointerEvent| {
             let _ = canvas_focus.focus();
             if event.button() == 0 {
+                if !in_level_picker(&event) {
+                    event.prevent_default();
+                }
                 down(event, Some(true));
             }
         }) as Box<dyn FnMut(web_sys::PointerEvent)>);
@@ -2246,8 +2425,17 @@ impl WebHandler {
         if keys.contains(&KeyCode::KeyD) {
             rudder = -1.0;
         }
+        {
+            let (sm, sr) = gpu.app.stick;
+            if sm.abs() > 0.01 {
+                motor = sm;
+            }
+            if sr.abs() > 0.01 {
+                rudder = sr;
+            }
+        }
         let brake = keys.contains(&KeyCode::ControlLeft);
-        let space = keys.contains(&KeyCode::Space);
+        let space = keys.contains(&KeyCode::Space) || gpu.app.use_held;
         let turbo = keys.contains(&KeyCode::ShiftLeft);
         // Roll direction matches native: Q/E are scaled by cam.scale.y
         // (which is -1) so Q → +1, E → -1.

--- a/docs/embed.css
+++ b/docs/embed.css
@@ -8,6 +8,7 @@ html, body {
     color: #c9d1d9;
     font-family: 'Segoe UI', system-ui, sans-serif;
     overflow: hidden;
+    overscroll-behavior: none;
 }
 
 #canvas {
@@ -15,6 +16,9 @@ html, body {
     height: 100vh;
     display: block;
     background: #1a1a2e;
+    touch-action: none;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 #loading {

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
     <title>Vangers – Rust WebGPU</title>
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
-        body { font-family: 'Segoe UI', system-ui, sans-serif; background: #0d1117; color: #c9d1d9; }
+        body { font-family: 'Segoe UI', system-ui, sans-serif; background: #0d1117; color: #c9d1d9; overscroll-behavior: none; }
 
         /* Tab bar */
         nav { display: flex; background: #161b22; border-bottom: 1px solid #30363d; }
@@ -26,6 +26,7 @@
         #game-panel { position: relative; }
         #game-panel canvas {
             width: 100vw; height: calc(100vh - 47px); display: block; background: #1a1a2e;
+            touch-action: none; user-select: none; -webkit-user-select: none;
         }
         #loading {
             position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);

--- a/res/shader/globals.inc.wgsl
+++ b/res/shader/globals.inc.wgsl
@@ -15,8 +15,8 @@ struct Globals {
 
 @group(0) @binding(0) var<uniform> u_Globals: Globals;
 
-/// 0 = this sample sits in the cone from the camera through the vehicle
-/// (terrain here would hide the car), 1 = leave the surface alone.
+/// Opacity of terrain that sits between the camera and the vehicle.
+/// 1 = fully solid, ~0.2 on the view axis (see the car through a veil).
 fn focus_visibility(pos: vec3<f32>) -> f32 {
     let f = u_Globals.focus_pos;
     if (f.w <= 0.001) {
@@ -31,7 +31,7 @@ fn focus_visibility(pos: vec3<f32>) -> f32 {
     }
     let to_pos = pos - cam;
     let dist_pos = length(to_pos);
-    if (dist_pos >= dist_car - f.w) {
+    if (dist_pos >= dist_car - f.w * 0.4) {
         return 1.0;
     }
     let axis = to_car / dist_car;
@@ -40,8 +40,9 @@ fn focus_visibility(pos: vec3<f32>) -> f32 {
         return 1.0;
     }
     let perp = length(to_pos - axis * along);
-    let cone_r = f.w * (along / dist_car) * 1.45;
-    return smoothstep(cone_r * 0.35, cone_r, perp);
+    let cone_r = f.w * (along / dist_car) * 2.6;
+    let edge = smoothstep(0.0, cone_r, perp);
+    return mix(0.18, 1.0, edge * edge);
 }
 
 fn closest_local_light(pos: vec3<f32>, normal: vec3<f32>) -> f32 {

--- a/res/shader/terrain/mesh.wgsl
+++ b/res/shader/terrain/mesh.wgsl
@@ -61,7 +61,7 @@ fn vertex(
 
 @fragment
 fn fragment(in: Varyings) -> @location(0) vec4<f32> {
-    if (in.world_pos.z <= 0.0 || focus_visibility(in.world_pos) < 0.45) {
+    if (in.world_pos.z <= 0.0) {
         discard;
     }
     let suf = get_surface(in.world_pos.xy);
@@ -93,6 +93,8 @@ fn fragment(in: Varyings) -> @location(0) vec4<f32> {
     // `u_Locals.lighting_flags[1]`: 1 = smooth normals on, 0 = flat.
     let normal = normalize(mix(geo, mix(grad_normal, geo, smoothstep(0.55, 0.8, slant)), f32(u_Locals.lighting_flags[1u])));
 
-    let terrain_color = evaluate_color_normal(ty, in.world_pos, visibility, normal);
-    return apply_fog(terrain_color, in.world_pos.xy);
+    var terrain_color = evaluate_color_normal(ty, in.world_pos, visibility, normal);
+    terrain_color = apply_fog(terrain_color, in.world_pos.xy);
+    terrain_color.a = focus_visibility(in.world_pos);
+    return terrain_color;
 }

--- a/res/shader/terrain/ray.wgsl
+++ b/res/shader/terrain/ray.wgsl
@@ -148,23 +148,11 @@ fn ray_color(in: RayInput) -> FragOutput {
         return FragOutput(u_Locals.fog_color, 1.0);
     }
 
-    var visibility = fetch_shadow_visibility(pt.pos);
+    let visibility = fetch_shadow_visibility(pt.pos);
     var frag_color = apply_fog(color_point(pt, visibility), pt.pos.xy);
-    var depth_pos = pt.pos;
-    let cover = focus_visibility(pt.pos);
-    if (cover < 0.999) {
-        let dir = normalize(sp_far_world - sp_near_world);
-        let behind = cast_ray_to_map(pt.pos + dir * 0.75, sp_far_world);
-        var back_color = u_Locals.fog_color;
-        if (behind.hit) {
-            let back_vis = fetch_shadow_visibility(behind.pos);
-            back_color = apply_fog(color_point(behind, back_vis), behind.pos.xy);
-            depth_pos = behind.pos;
-        }
-        frag_color = mix(back_color, frag_color, cover * 0.4);
-    }
+    frag_color.a = focus_visibility(pt.pos);
 
-    let target_ndc = u_Globals.view_proj * vec4<f32>(depth_pos, 1.0);
+    let target_ndc = u_Globals.view_proj * vec4<f32>(pt.pos, 1.0);
     let depth = target_ndc.z / target_ndc.w;
     return FragOutput(frag_color, depth);
 }

--- a/res/shader/terrain/voxel-draw.wgsl
+++ b/res/shader/terrain/voxel-draw.wgsl
@@ -63,9 +63,6 @@ fn cast_miss() -> CastPoint {
 }
 
 fn check_hit(pos: vec3<f32>) -> u32 {
-    if (focus_visibility(pos) < 0.45) {
-        return TYPE_MISS;
-    }
     let suf = get_surface(pos.xy);
     if (suf.high_alt <= 0.0) {
         return TYPE_MISS;
@@ -258,7 +255,8 @@ fn draw_color(@builtin(position) frag_coord: vec4<f32>) -> FragOutput {
     }
 
     let visibility = fetch_shadow_visibility(pt.pos);
-    let frag_color = apply_fog(evaluate_color(pt.ty, pt.pos, visibility), pt.pos.xy);
+    var frag_color = apply_fog(evaluate_color(pt.ty, pt.pos, visibility), pt.pos.xy);
+    frag_color.a = focus_visibility(pt.pos);
     let actual_color = mix(frag_color, debug_color, debug_color.a);
 
     let target_ndc = u_Globals.view_proj * vec4<f32>(pt.pos, 1.0);

--- a/src/escave/cave.rs
+++ b/src/escave/cave.rs
@@ -1,29 +1,133 @@
 //! Underground iscreen maps: the living thing's voxel interior.
 //!
 //! Original `location_data` points at `resource/iscreen/ldata/lN/escave.ini`.
-//! The road renderer already knows how to voxelize a height map, so a visit
-//! loads that INI as a second [`Level`] and draws it behind the shop.
+//! The VMC is a 2048×1024 atlas of 800×600 screens (`I_RES_X`/`I_RES_Y` in
+//! `iscreen.h`). `put_map(iScreenOffs, 0, I_RES_X, I_RES_Y)` copies one tile:
+//! talk at `screen_offs 0` (`escave00.inc`), shop at `800` (`escave02.inc`).
+//! We clip to that rectangle and orbit the camera around it.
 
 use crate::config::settings;
-use crate::level::{self, Level, LevelConfig, Texel};
+use crate::level::{self, Level, LevelConfig, Power, Region, Texel};
 use crate::space::Camera;
 use crate::vfs::Vfs;
 use glam::{Quat, Vec3};
 use std::path::{Path, PathBuf};
 
+/// Original `I_RES_X` / `I_RES_Y`.
+pub const VIEW: (i32, i32) = (800, 600);
+
+/// Which 800×600 tile of the iscreen atlas to show.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Situation {
+    /// Counselor / location screen. `screen_offs 0`.
+    Talk,
+    /// Shop. `screen_offs 800`.
+    Shop,
+}
+
+impl Situation {
+    /// Original `iScreen::ScreenOffs`.
+    pub fn screen_offs(self) -> i32 {
+        match self {
+            Situation::Talk => 0,
+            Situation::Shop => 800,
+        }
+    }
+
+    /// Atlas rectangle `put_map` copies onto the 800×600 framebuffer.
+    pub fn region(self) -> Region {
+        Region {
+            x: self.screen_offs(),
+            y: 0,
+            w: VIEW.0,
+            h: VIEW.1,
+        }
+    }
+}
+
+fn name_key(name: &str) -> String {
+    name.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .flat_map(|c| c.to_lowercase())
+        .collect()
+}
+
 /// Folder under the data path for this escave's iscreen map.
 pub fn ldata_dir(name: &str) -> Option<&'static str> {
-    Some(match name {
-        "Podish" => "resource/iscreen/ldata/l0",
-        "Incubator" => "resource/iscreen/ldata/l1",
-        "VigBoo" => "resource/iscreen/ldata/l2",
-        "Lampasso" => "resource/iscreen/ldata/l3",
-        "Ogorod" => "resource/iscreen/ldata/l4",
-        "ZeePa" => "resource/iscreen/ldata/l5",
-        "B-Zone" | "BZone" => "resource/iscreen/ldata/l6",
-        "Spobs" => "resource/iscreen/ldata/l7",
+    Some(match name_key(name).as_str() {
+        "podish" => "resource/iscreen/ldata/l0",
+        "incubator" => "resource/iscreen/ldata/l1",
+        "vigboo" => "resource/iscreen/ldata/l2",
+        "lampasso" => "resource/iscreen/ldata/l3",
+        "ogorod" => "resource/iscreen/ldata/l4",
+        "zeepa" => "resource/iscreen/ldata/l5",
+        "bzone" => "resource/iscreen/ldata/l6",
+        "spobs" => "resource/iscreen/ldata/l7",
         _ => return None,
     })
+}
+
+/// A named pad from `escaves.prm` / `spots.prm`.
+#[derive(Clone, Debug)]
+pub struct Pad {
+    pub name: String,
+    pub pos: (i32, i32),
+}
+
+/// Scan original prm text for name + world-XY. Item lines and `none` are skipped.
+pub fn pads_from_prm(text: &str) -> Vec<Pad> {
+    let mut pads = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty()
+            || line.starts_with("/*")
+            || line.starts_with('*')
+            || line.starts_with("uniVang")
+        {
+            continue;
+        }
+        let mut bits = line.split_whitespace();
+        let Some(name) = bits.next() else {
+            continue;
+        };
+        let Some(_world) = bits.next() else {
+            continue;
+        };
+        let Some(x) = bits.next().and_then(|s| s.parse().ok()) else {
+            continue;
+        };
+        let Some(y) = bits.next().and_then(|s| s.parse().ok()) else {
+            continue;
+        };
+        if ldata_dir(name).is_some() {
+            pads.push(Pad {
+                name: name.to_string(),
+                pos: (x, y),
+            });
+        }
+    }
+    pads
+}
+
+/// VLC sensors are `Escave1` / `Spot2`. Map them to Podish / VigBoo / … by XY.
+pub fn resolve_name(sensor: &str, pos: (i32, i32), pads: &[Pad]) -> String {
+    if ldata_dir(sensor).is_some() {
+        return sensor.to_string();
+    }
+    const REACH2: i32 = 256 * 256;
+    pads.iter()
+        .filter(|p| {
+            let dx = p.pos.0 - pos.0;
+            let dy = p.pos.1 - pos.1;
+            dx * dx + dy * dy <= REACH2
+        })
+        .min_by_key(|p| {
+            let dx = p.pos.0 - pos.0;
+            let dy = p.pos.1 - pos.1;
+            dx * dx + dy * dy
+        })
+        .map(|p| p.name.clone())
+        .unwrap_or_else(|| sensor.to_string())
 }
 
 pub fn ini_path(data_path: &Path, name: &str) -> Option<PathBuf> {
@@ -40,14 +144,16 @@ pub fn load(
     data_path: &Path,
     name: &str,
     geometry: &settings::Geometry,
+    situation: Situation,
 ) -> Option<(LevelConfig, Level)> {
     let ini = ini_path(data_path, name)?;
     if !ini.is_file() {
         log::info!("escave iscreen missing at {}", ini.display());
         return None;
     }
-    let config = LevelConfig::load(&ini);
-    let level = level::load(&config, geometry);
+    let mut config = LevelConfig::load(&ini);
+    let mut level = level::load(&config, geometry);
+    clip(&mut config, &mut level, situation);
     Some((config, level))
 }
 
@@ -56,29 +162,85 @@ pub fn load_from_vfs(
     vfs: &Vfs,
     name: &str,
     geometry: &settings::Geometry,
+    situation: Situation,
 ) -> Option<(LevelConfig, Level)> {
     let ini = ini_key(name)?;
     if !vfs.contains(&ini) {
         log::info!("escave iscreen missing at {ini}");
         return None;
     }
-    let config = LevelConfig::load_from_vfs(vfs, &ini);
-    let level = level::load_from_vfs(vfs, &config, geometry);
+    let mut config = LevelConfig::load_from_vfs(vfs, &ini);
+    let mut level = level::load_from_vfs(vfs, &config, geometry);
+    clip(&mut config, &mut level, situation);
     Some((config, level))
 }
 
-pub fn look_target(level: &Level) -> Vec3 {
-    let cx = level.size.0 as f32 * 0.5;
-    let cy = level.size.1 as f32 * 0.5;
-    let ground = match level.get((cx as i32, cy as i32)) {
-        Texel::Single(p) => p.0,
-        Texel::Dual { high, .. } => high.0,
-    };
-    Vec3::new(cx, cy, ground + 8.0)
+/// Keep only `situation`'s 800×600 tile, at the origin. Terrain textures are
+/// a power of two, so the field is padded with void (height 0).
+pub fn clip(config: &mut LevelConfig, level: &mut Level, situation: Situation) {
+    let region = situation.region();
+    let (src_w, src_h) = level.size;
+    let dst_w = (region.w.max(1) as u32).next_power_of_two() as i32;
+    let dst_h = (region.h.max(1) as u32).next_power_of_two() as i32;
+    let mut height = vec![0u8; (dst_w * dst_h) as usize];
+    let mut meta = vec![0u8; (dst_w * dst_h) as usize];
+    let x0 = region.x.max(0);
+    let y0 = region.y.max(0);
+    let copy_w = (region.x + region.w).min(src_w) - x0;
+    let copy_h = (region.y + region.h).min(src_h) - y0;
+    if copy_w > 0 && copy_h > 0 {
+        let cw = copy_w as usize;
+        for y in 0..copy_h {
+            let src = ((y0 + y) * src_w + x0) as usize;
+            let dst = (y * dst_w) as usize;
+            height[dst..dst + cw].copy_from_slice(&level.height[src..src + cw]);
+            meta[dst..dst + cw].copy_from_slice(&level.meta[src..src + cw]);
+        }
+    }
+    level.height = height.into_boxed_slice();
+    level.meta = meta.into_boxed_slice();
+    level.size = (dst_w, dst_h);
+    config.size = (Power::from_value(dst_w), Power::from_value(dst_h));
 }
 
-pub fn look_distance(level: &Level) -> f32 {
-    (level.size.0.min(level.size.1) as f32 * 0.82).max(64.0)
+fn sample_height(level: &Level, x: i32, y: i32) -> f32 {
+    match level.get((x, y)) {
+        Texel::Single(p) => p.0,
+        Texel::Dual { high, .. } => high.0,
+    }
+}
+
+/// Height-weighted centroid of non-void texels. After [`clip`] that is the
+/// situation tile; the atlas centre is often a hole (height 0).
+pub fn look_target(level: &Level) -> Vec3 {
+    let (w, h) = level.size;
+    let mut sx = 0.0;
+    let mut sy = 0.0;
+    let mut sz = 0.0;
+    let mut wt = 0.0;
+    for y in (0..h).step_by(4) {
+        for x in (0..w).step_by(4) {
+            let z = sample_height(level, x, y);
+            if z > 0.0 {
+                sx += x as f32 * z;
+                sy += y as f32 * z;
+                sz += z * z;
+                wt += z;
+            }
+        }
+    }
+    if wt < 1.0 {
+        let cx = w as f32 * 0.5;
+        let cy = h as f32 * 0.5;
+        return Vec3::new(cx, cy, sample_height(level, cx as i32, cy as i32) + 8.0);
+    }
+    Vec3::new(sx / wt, sy / wt, sz / wt + 8.0)
+}
+
+/// Stand back from the original 800×600 window, not the padded power-of-two.
+pub fn look_distance(situation: Situation) -> f32 {
+    let r = situation.region();
+    (r.w.min(r.h) as f32 * 0.82).max(64.0)
 }
 
 /// Radians above the XY plane. 90° is straight down; this is 30° off vertical
@@ -93,9 +255,13 @@ pub fn orbit(cam: &mut Camera, target: Vec3, distance: f32, yaw: f32, elevation:
     cam.rot = Camera::look_rotation(-offset);
 }
 
-pub fn camera(level: &Level, proj: crate::space::Projection) -> (Camera, Vec3, f32) {
+pub fn camera(
+    level: &Level,
+    proj: crate::space::Projection,
+    situation: Situation,
+) -> (Camera, Vec3, f32) {
     let target = look_target(level);
-    let distance = look_distance(level);
+    let distance = look_distance(situation);
     let mut cam = Camera {
         loc: target,
         rot: Quat::IDENTITY,
@@ -123,7 +289,10 @@ mod tests {
     fn fostral_escaves_have_iscreen_folders() {
         assert_eq!(ldata_dir("Podish"), Some("resource/iscreen/ldata/l0"));
         assert_eq!(ldata_dir("Incubator"), Some("resource/iscreen/ldata/l1"));
+        assert_eq!(ldata_dir("VigBoo"), Some("resource/iscreen/ldata/l2"));
+        assert_eq!(ldata_dir("vig boo\0"), Some("resource/iscreen/ldata/l2"));
         assert!(ldata_dir("MysteryHole").is_none());
+        assert!(ldata_dir("Escave1").is_none());
         let path = ini_path(Path::new("/data"), "Podish").unwrap();
         assert!(path.ends_with("resource/iscreen/ldata/l0/escave.ini"));
         assert_eq!(
@@ -137,27 +306,104 @@ mod tests {
         );
     }
 
-    #[test]
-    fn look_distance_is_backed_off_the_map() {
-        let level = Level {
-            size: (2048, 1024),
+    fn dummy_level(w: i32, h: i32, fill: u8) -> Level {
+        let n = (w * h) as usize;
+        Level {
+            size: (w, h),
             flood_map: vec![0; 4].into_boxed_slice(),
-            height: vec![0; 4].into_boxed_slice(),
-            meta: vec![0; 4].into_boxed_slice(),
+            height: vec![fill; n].into_boxed_slice(),
+            meta: vec![0; n].into_boxed_slice(),
             palette: [[0; 4]; 0x100],
-            terrains: Box::new([]),
+            terrains: vec![level::TerrainConfig::default(); 8].into_boxed_slice(),
             geometry: settings::Geometry::default(),
-        };
+        }
+    }
+
+    fn dummy_config(w: i32, h: i32) -> LevelConfig {
+        LevelConfig {
+            path_palette: PathBuf::new(),
+            path_data: PathBuf::new(),
+            is_compressed: false,
+            size: (Power::from_value(w), Power::from_value(h)),
+            geo: Power(0),
+            section: Power(8),
+            min_square: Power(0),
+            terrains: vec![level::TerrainConfig::default(); 8].into_boxed_slice(),
+            dynamic_palette: level::DynamicPalette::default(),
+        }
+    }
+
+    #[test]
+    fn original_windows_are_800x600_talk_then_shop() {
+        let talk = Situation::Talk.region();
+        assert_eq!((talk.x, talk.y, talk.w, talk.h), (0, 0, 800, 600));
+        let shop = Situation::Shop.region();
+        assert_eq!((shop.x, shop.y, shop.w, shop.h), (800, 0, 800, 600));
+        assert_eq!(shop.x, talk.x + talk.w);
+    }
+
+    #[test]
+    fn clip_extracts_the_shop_tile_to_origin() {
+        let mut level = dummy_level(2048, 1024, 0);
+        let mut config = dummy_config(2048, 1024);
+        // Shop pixel (900, 100) and talk pixel (100, 100).
+        level.height[(100 * 2048 + 900) as usize] = 80;
+        level.height[(100 * 2048 + 100) as usize] = 80;
+        clip(&mut config, &mut level, Situation::Shop);
+        assert_eq!(level.size, (1024, 1024));
+        assert_eq!(config.size.0.as_value(), 1024);
+        assert_eq!(config.size.1.as_value(), 1024);
+        // Shop (900, 100) lands at (100, 100); talk did not come along.
+        assert_eq!(level.height[(100 * 1024 + 100) as usize], 80);
+        assert_eq!(level.height[(100 * 1024) as usize], 0);
+        let at = look_target(&level);
         assert!(
-            look_distance(&level) > 800.0,
-            "camera should sit back from a 1024-wide iscreen, got {}",
-            look_distance(&level)
+            (at.x - 100.0).abs() < 1.0 && (at.y - 100.0).abs() < 1.0,
+            "camera should sit on the extracted shop pixel, got {at:?}"
         );
+    }
+
+    #[test]
+    fn look_distance_frames_the_800x600_window() {
+        let d = look_distance(Situation::Shop);
+        assert!(
+            d > 400.0 && d < 600.0,
+            "camera should frame the 600-tall tile, got {d}"
+        );
+        assert!((d - look_distance(Situation::Talk)).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn vlc_escave1_on_glorx_is_vigboo() {
+        let text = "\
+uniVang-ParametersFile_Ver_1
+Podish Fostral 1500 15879 LEEPURINGA
+none
+VigBoo Glorx 3 8797 BOORAWCHICK
+none
+Lampasso Glorx 1903 809 NOBOOL
+none
+Ogorod Glorx 1102 15109 PIPKA
+none
+";
+        let pads = pads_from_prm(text);
+        assert_eq!(resolve_name("Escave1", (21, 8790), &pads), "VigBoo");
+        assert_eq!(resolve_name("Spot4", (1898, 799), &pads), "Lampasso");
+        assert_eq!(resolve_name("Spot2", (1107, 15100), &pads), "Ogorod");
+        assert_eq!(resolve_name("Podish", (0, 0), &pads), "Podish");
     }
 
     #[test]
     fn missing_iscreen_in_vfs_is_none() {
         let vfs = Vfs::new();
-        assert!(load_from_vfs(&vfs, "Podish", &settings::Geometry::default()).is_none());
+        assert!(
+            load_from_vfs(
+                &vfs,
+                "Podish",
+                &settings::Geometry::default(),
+                Situation::Shop
+            )
+            .is_none()
+        );
     }
 }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -771,15 +771,15 @@ impl Render {
             }
 
             pass.set_bind_group(0, &self.global.bind_group, &[]);
-            pass.push_debug_group("terrain");
-            self.terrain.draw(&mut pass);
-            pass.pop_debug_group();
-
             pass.push_debug_group("vehicles");
             pass.set_pipeline(&self.object.pipelines.main);
             pass.set_bind_group(1, &self.object.surface_bind_group, &[]);
             pass.set_bind_group(2, &self.object.bind_group, &[]);
             batcher.draw(&mut pass);
+            pass.pop_debug_group();
+
+            pass.push_debug_group("terrain");
+            self.terrain.draw(&mut pass);
             pass.pop_debug_group();
 
             pass.push_debug_group("water");

--- a/src/render/terrain/mod.rs
+++ b/src/render/terrain/mod.rs
@@ -1048,7 +1048,7 @@ impl Context {
                     compilation_options: Default::default(),
                     targets: &[Some(wgpu::ColorTargetState {
                         format: color_format,
-                        blend: None,
+                        blend: Some(wgpu::BlendState::ALPHA_BLENDING),
                         write_mask,
                     })],
                 }),

--- a/src/render/terrain/pipeline.rs
+++ b/src/render/terrain/pipeline.rs
@@ -16,7 +16,7 @@ pub(super) fn create_ray_pipeline(
 ) -> wgpu::RenderPipeline {
     let color_descs = [Some(wgpu::ColorTargetState {
         format: color_format,
-        blend: None,
+        blend: Some(wgpu::BlendState::ALPHA_BLENDING),
         write_mask: wgpu::ColorWrites::all(),
     })];
     let (targets, depth_format) = match kind {
@@ -55,7 +55,10 @@ pub(super) fn create_ray_pipeline(
         depth_stencil: Some(wgpu::DepthStencilState {
             format: depth_format,
             depth_write_enabled: Some(true),
-            depth_compare: Some(wgpu::CompareFunction::Always),
+            depth_compare: Some(match kind {
+                PipelineKind::Main => wgpu::CompareFunction::Less,
+                PipelineKind::Shadow => wgpu::CompareFunction::Always,
+            }),
             stencil: Default::default(),
             bias: Default::default(),
         }),
@@ -100,7 +103,7 @@ pub(super) fn create_voxel_pipelines(
         super::super::load_shader("terrain/voxel-draw", &substitutions, device).unwrap();
     let color_descs = [Some(wgpu::ColorTargetState {
         format: color_format,
-        blend: None,
+        blend: Some(wgpu::BlendState::ALPHA_BLENDING),
         write_mask: wgpu::ColorWrites::all(),
     })];
 
@@ -126,7 +129,7 @@ pub(super) fn create_voxel_pipelines(
         depth_stencil: Some(wgpu::DepthStencilState {
             format: DEPTH_FORMAT,
             depth_write_enabled: Some(true),
-            depth_compare: Some(wgpu::CompareFunction::Always),
+            depth_compare: Some(wgpu::CompareFunction::Less),
             stencil: Default::default(),
             bias: Default::default(),
         }),

--- a/src/space.rs
+++ b/src/space.rs
@@ -798,7 +798,8 @@ mod ground_tests {
     }
 
     /// Wide-FOV chase used by the web build: one body-length back so the
-    /// car does not shrink into the distance.
+    /// car does not shrink into the distance. Live play then adds one
+    /// body-height on top of `offset.z`.
     #[test]
     fn a_close_chase_keeps_the_car_nearby() {
         let target = Transform {


### PR DESCRIPTION
The 2048x1024 iscreen is an atlas: put_map copies an 800x600 window (talk at screen_offs 0, shop at 800). Load that tile, pad to a power of two, and orbit it. VLC names like Escave1 map to VigBoo by pad XY.

Web chase sits one body-height higher so the lower half is not dirt under the hull. Phones get a bottom-right stick and a Use button (Space). Terrain between camera and car is a soft veil; vehicles draw first so the hill can fade over them.