### PR TITLE
Keep world height 0 solid and share the camera panel

### DIFF
--- a/bin/road/game.rs
+++ b/bin/road/game.rs
@@ -1036,7 +1036,7 @@ impl Game {
             screen_size: extent,
         };
         let pal = level.palette;
-        let render = Render::new(
+        let mut render = Render::new(
             &gfx,
             &config,
             &pal,
@@ -1044,6 +1044,7 @@ impl Game {
             &self.cave_boot.geometry,
             self.cave_boot.front_face,
         );
+        render.terrain.set_void_at_zero(true);
         let (mut cam, target, distance) = escave::cave::camera(&level, self.cam.proj, situation);
         cam.proj.update(extent.width as u16, extent.height as u16);
         let tile = situation.region();
@@ -1965,34 +1966,15 @@ impl Application for Game {
                 egui::CollapsingHeader::new("Camera")
                     .default_open(false)
                     .show(ui, |ui| {
-                        self.cam.draw_ui(ui);
                         if let CameraStyle::Follow {
                             ref mut follow,
                             ref mut ground_anchor,
                         } = self.cam_style
                         {
-                            let mut angle_deg = follow.angle_x.to_degrees();
-                            ui.add(egui::Slider::new(&mut angle_deg, -105.0..=0.0).text("Angle"));
-                            follow.angle_x = angle_deg.to_radians();
-                            ui.horizontal(|ui| {
-                                ui.add(
-                                    egui::DragValue::new(&mut follow.offset.x)
-                                        .speed(1.0)
-                                        .prefix("x:"),
-                                );
-                                ui.add(
-                                    egui::DragValue::new(&mut follow.offset.y)
-                                        .speed(1.0)
-                                        .prefix("y:"),
-                                );
-                                ui.add(
-                                    egui::DragValue::new(&mut follow.offset.z)
-                                        .speed(1.0)
-                                        .prefix("z:"),
-                                );
-                            });
-                            ui.add(egui::Slider::new(&mut follow.speed, 0.1..=10.0).text("Speed"));
-                            ui.checkbox(ground_anchor, "Ground anchor");
+                            self.cam
+                                .draw_controls(ui, Some(follow), Some(ground_anchor));
+                        } else {
+                            self.cam.draw_controls(ui, None, None);
                         }
                     });
                 egui::CollapsingHeader::new("Level")

--- a/bin/web/main.rs
+++ b/bin/web/main.rs
@@ -935,6 +935,7 @@ impl WebApp {
 
         if self.touch_stick {
             self.stick = draw_drive_stick(ctx);
+            self.draw_camera_window(ctx, true);
             return;
         }
 
@@ -975,11 +976,27 @@ impl WebApp {
             }
             ui.separator();
             ui.label("Camera");
-            ui.label(format!(
-                "Pos: ({:.0}, {:.0}, {:.0})",
-                self.cam.loc.x, self.cam.loc.y, self.cam.loc.z
-            ));
+            self.draw_camera_controls(ui);
         });
+    }
+
+    fn draw_camera_window(&mut self, ctx: &egui::Context, compact: bool) {
+        egui::Window::new("Camera")
+            .collapsible(true)
+            .default_open(!compact)
+            .resizable(false)
+            .show(ctx, |ui| {
+                self.draw_camera_controls(ui);
+            });
+    }
+
+    fn draw_camera_controls(&mut self, ui: &mut egui::Ui) {
+        let follow = if self.agent.is_some() {
+            Some(&mut self.follow)
+        } else {
+            None
+        };
+        self.cam.draw_controls(ui, follow, None);
     }
 
     fn resize(&mut self, extent: wgpu::Extent3d, device: &wgpu::Device) {
@@ -1120,7 +1137,7 @@ impl WebApp {
             screen_size: extent,
         };
         let pal = level.palette;
-        let render = Render::new(
+        let mut render = Render::new(
             &gfx,
             &config,
             &pal,
@@ -1128,6 +1145,7 @@ impl WebApp {
             &self.cave_boot.geometry,
             self.cave_boot.front_face,
         );
+        render.terrain.set_void_at_zero(true);
         let (mut cam, target, distance) = escave::cave::camera(&level, self.cam.proj, situation);
         cam.proj.update(extent.width as u16, extent.height as u16);
         let tile = situation.region();

--- a/res/shader/surface.inc.wgsl
+++ b/res/shader/surface.inc.wgsl
@@ -4,6 +4,9 @@ struct SurfaceConstants {
     texture_scale: vec4<f32>,    // XY = size, Z = height scale, w = number of layers
     terrain_bits: u32, // low 4 bits = shift, high 4 bits = mask
     delta_mode: u32, // low 8 bits = power, higher 16 bits = mask
+    /// 1 = height 0 is empty (iscreen padding / holes). World maps keep 0 solid.
+    void_zero: u32,
+    _pad: u32,
 };
 
 @group(1) @binding(0) var<uniform> u_Surface: SurfaceConstants;
@@ -93,10 +96,10 @@ struct SurfaceAlt {
     mid: f32,
 };
 
-/// Height 0 is empty (the iscreen void, unused map). A `z <= low` test
-/// would treat that plane as solid and light it from noisy meta bytes.
+/// Height 0 is empty only on iscreen maps (`void_zero`). World ground at
+/// altitude 0 is real terrain and must stay solid.
 fn surface_is_void(alt: SurfaceAlt) -> bool {
-    return alt.high <= 0.0;
+    return u_Surface.void_zero != 0u && alt.high <= 0.0;
 }
 
 fn get_surface_alt(pos: vec2<f32>) -> SurfaceAlt {

--- a/res/shader/terrain/mesh.wgsl
+++ b/res/shader/terrain/mesh.wgsl
@@ -61,7 +61,7 @@ fn vertex(
 
 @fragment
 fn fragment(in: Varyings) -> @location(0) vec4<f32> {
-    if (in.world_pos.z <= 0.0) {
+    if (u_Surface.void_zero != 0u && in.world_pos.z <= 0.0) {
         discard;
     }
     let suf = get_surface(in.world_pos.xy);

--- a/res/shader/terrain/voxel-draw.wgsl
+++ b/res/shader/terrain/voxel-draw.wgsl
@@ -64,7 +64,7 @@ fn cast_miss() -> CastPoint {
 
 fn check_hit(pos: vec3<f32>) -> u32 {
     let suf = get_surface(pos.xy);
-    if (suf.high_alt <= 0.0) {
+    if (u_Surface.void_zero != 0u && suf.high_alt <= 0.0) {
         return TYPE_MISS;
     }
     if (pos.z < suf.low_alt) {

--- a/src/render/object.rs
+++ b/src/render/object.rs
@@ -157,7 +157,7 @@ pub fn create_stub_surface(device: &wgpu::Device) -> StubSurface {
     use wgpu::util::DeviceExt as _;
 
     // SurfaceConstants layout: vec4 texture_scale, u32 terrain_bits,
-    // u32 delta_mode, u32 pad0, u32 pad1. We need texture_scale.x and
+    // u32 delta_mode, u32 void_zero, u32 pad1. We need texture_scale.x and
     // .y to be non-zero so the shader's wrap math doesn't divide by 0,
     // and texture_scale.z = 0 so the flood-fed water Z stays at 0
     // (keeps the underwater check inert for vehicles above ground).

--- a/src/render/terrain/mod.rs
+++ b/src/render/terrain/mod.rs
@@ -116,7 +116,8 @@ struct SurfaceConstants {
     texture_scale: [f32; 4],
     terrain_bits: u32,
     delta_mode: u32,
-    pad0: u32,
+    /// 1 = treat height 0 as empty (iscreen). World maps leave this 0.
+    void_zero: u32,
     pad1: u32,
 }
 unsafe impl Pod for SurfaceConstants {}
@@ -694,10 +695,18 @@ pub struct Context {
     /// gradient so low-poly faces shade continuously; `false` → the flat
     /// per-triangle geometric normal.
     pub smooth_normals: bool,
+    /// Height 0 is empty (iscreen padding and holes). Off for world maps.
+    void_at_zero: bool,
     ray_steps: u32,
 }
 
 impl Context {
+    /// Height 0 is empty on iscreen maps (padding and the creature's hole).
+    /// World ground at altitude 0 stays solid.
+    pub fn set_void_at_zero(&mut self, yes: bool) {
+        self.void_at_zero = yes;
+    }
+
     pub fn memory_stats(&self) -> MemoryStats {
         match self.kind {
             Kind::Ray { .. } | Kind::Slice { .. } => MemoryStats::default(),
@@ -1986,9 +1995,10 @@ impl Context {
                 texture_scale: [0.0; 4],
                 terrain_bits: 0,
                 delta_mode: 0,
-                pad0: 0,
+                void_zero: 0,
                 pad1: 0,
             },
+            void_at_zero: false,
             // Default to unbaked diffuse + shadow — matches the look
             // we tuned in the cosine-lighting commit. Toggle in the UI
             // to A/B against the original baked-palette path.
@@ -2132,7 +2142,7 @@ impl Context {
                 ],
                 terrain_bits: bits.shift as u32 | ((bits.mask as u32) << 4),
                 delta_mode,
-                pad0: 0,
+                void_zero: u32::from(self.void_at_zero),
                 pad1: 0,
             }
         };

--- a/src/space.rs
+++ b/src/space.rs
@@ -196,6 +196,33 @@ pub struct Follow {
     pub look_ahead: f32,
 }
 
+impl Follow {
+    pub fn draw_ui(&mut self, ui: &mut egui::Ui) {
+        let mut angle_deg = self.angle_x.to_degrees();
+        ui.add(egui::Slider::new(&mut angle_deg, -105.0..=0.0).text("Angle"));
+        self.angle_x = angle_deg.to_radians();
+        ui.horizontal(|ui| {
+            ui.add(
+                egui::DragValue::new(&mut self.offset.x)
+                    .speed(1.0)
+                    .prefix("x:"),
+            );
+            ui.add(
+                egui::DragValue::new(&mut self.offset.y)
+                    .speed(1.0)
+                    .prefix("y:"),
+            );
+            ui.add(
+                egui::DragValue::new(&mut self.offset.z)
+                    .speed(1.0)
+                    .prefix("z:"),
+            );
+        });
+        ui.add(egui::Slider::new(&mut self.speed, 0.1..=16.0).text("Speed"));
+        ui.add(egui::Slider::new(&mut self.look_ahead, 0.0..=80.0).text("Look-ahead"));
+    }
+}
+
 #[derive(Copy, Clone)]
 pub struct Direction {
     pub view: Vec3,
@@ -551,6 +578,27 @@ impl Camera {
                 ui.add(egui::Slider::new(&mut p.far, 50.0..=10000.0).text("Depth far"));
             }
         }
+    }
+
+    /// Tweaks + web Settings. Free-cam knobs always; chase sliders when
+    /// `follow` is `Some`. `ground_anchor` is native-only.
+    pub fn draw_controls(
+        &mut self,
+        ui: &mut egui::Ui,
+        follow: Option<&mut Follow>,
+        ground_anchor: Option<&mut bool>,
+    ) {
+        self.draw_ui(ui);
+        if let Some(follow) = follow {
+            follow.draw_ui(ui);
+        }
+        if let Some(anchor) = ground_anchor {
+            ui.checkbox(anchor, "Ground anchor");
+        }
+        ui.label(format!(
+            "Pos: ({:.0}, {:.0}, {:.0})",
+            self.loc.x, self.loc.y, self.loc.z
+        ));
     }
 }
 


### PR DESCRIPTION
Altitude 0 is real ground on a world map; treating it as empty was only for iscreen holes and padding. Gate that skip on the cave renderer.

Tweaks and the web Settings/Camera window both call Camera::draw_controls for yaw, clip, chase offset, and look-ahead.